### PR TITLE
83-docker-verify-frontend-and-backend-run-together-in-docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,23 @@ Takes millions of crash records from California's [Crash Reporting System (CCRS)
 ```bash
 git clone https://github.com/JeffreySardella/CalSight.git
 cd CalSight
-docker-compose up
+docker-compose up --build
 ```
 
 - Frontend: http://localhost:5173
 - Backend API: http://localhost:8000
 - API docs: http://localhost:8000/docs
+
+```bash
+# Stop all services
+docker-compose down
+
+# Stop and reset database
+docker-compose down -v
+
+# Rebuild after dependency changes
+docker-compose up --build
+```
 
 ### Run Without Docker
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - "5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U calsight"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   backend:
     build: ./backend
@@ -17,7 +22,8 @@ services:
     environment:
       DATABASE_URL: postgresql://calsight:calsight_dev@db:5432/calsight
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - ./backend:/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
@@ -28,6 +34,8 @@ services:
       - "5173:5173"
     depends_on:
       - backend
+    environment:
+      VITE_API_TARGET: http://backend:8000
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       usePolling: true,
     },
     proxy: {
-      '/api': 'http://localhost:8000',
+      '/api': process.env.VITE_API_TARGET || 'http://localhost:8000',
     },
   },
 })


### PR DESCRIPTION
 Closes #83
 - Fix Vite proxy to use service names for Docker networking
 - Add postgres healthcheck so backend waits for DB to be ready
 - Add docker-compose commands to README

## What does this PR do?
-Fixes docker-compose so all 3 services (postgres, backend, frontend) work together with the current Vite/Tailwind setup.

## How to test
- Run docker-compose up --build
- Visit http://localhost:5173 — frontend loads
- Visit http://localhost:5173/api/health — returns {"status":"ok"}
- Run docker-compose down

## Checklist
- Code builds without errors
- Tested locally
- No console errors/warnings
