### PR TITLE
70-backend-cors-environment-variables-and-config-management

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,8 @@
+# Database connection string
 DATABASE_URL=postgresql://calsight:calsight_dev@localhost:5433/calsight
+
+# Comma-separated list of allowed CORS origins
+CORS_ORIGINS=http://localhost:5173
+
+# Set to false in production to disable debug mode and auto-docs
+DEBUG=true

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,14 +1,9 @@
-import os
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://calsight:calsight_dev@localhost:5433/calsight",
-)
+from app.settings import settings
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(settings.database_url)
 SessionLocal = sessionmaker(bind=engine)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,13 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-app = FastAPI(title="CalSight API", version="0.1.0")
+from app.settings import settings
+
+app = FastAPI(title="CalSight API", version="0.1.0", debug=settings.debug)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=settings.cors_origin_list,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -1,0 +1,41 @@
+"""Application settings powered by pydantic-settings.
+
+How it works:
+  1. BaseSettings reads values from environment variables automatically.
+     A field named `database_url` maps to the env var `DATABASE_URL`.
+  2. If a .env file exists, values are loaded from it (via python-dotenv).
+  3. Real environment variables always override .env file values — so
+     Docker/Azure env vars win over local .env defaults.
+  4. If a required variable is missing AND has no default, the app crashes
+     at startup with a clear validation error instead of failing later.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        # Look for .env file in the backend/ directory (one level up from app/)
+        env_file=".env",
+        # If a real env var exists, it beats the .env file value
+        env_file_encoding="utf-8",
+    )
+
+    # -- Database --
+    database_url: str = "postgresql://calsight:calsight_dev@localhost:5433/calsight"
+
+    # -- CORS --
+    # Comma-separated origins, e.g. "http://localhost:5173,https://calsight.example.com"
+    cors_origins: str = "http://localhost:5173"
+
+    # -- App --
+    debug: bool = True
+
+    @property
+    def cors_origin_list(self) -> list[str]:
+        """Parse the comma-separated CORS_ORIGINS string into a list."""
+        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+
+
+# Single instance — import this everywhere instead of creating new Settings()
+settings = Settings()

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -13,7 +13,8 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from app.database import DATABASE_URL, Base
+from app.database import Base
+from app.settings import settings
 
 # Import all models so Base.metadata knows about them.
 # Without this, autogenerate would see an empty metadata and
@@ -21,7 +22,7 @@ from app.database import DATABASE_URL, Base
 import app.models  # noqa: F401
 
 config = context.config
-config.set_main_option("sqlalchemy.url", DATABASE_URL)
+config.set_main_option("sqlalchemy.url", settings.database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ alembic==1.15.2
 psycopg2-binary==2.9.11
 httpx==0.28.1
 python-dotenv==1.2.2
+pydantic-settings==2.8.1
 ruff==0.15.8
 pytest==9.0.2
 pytest-asyncio==1.3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - "8000:8000"
     environment:
       DATABASE_URL: postgresql://calsight:calsight_dev@db:5432/calsight
+      CORS_ORIGINS: http://localhost:5173
+      DEBUG: "true"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Replace hardcoded CORS origins and scattered os.getenv() calls with a centralized Settings class using pydantic-settings. CORS origins, database URL, and debug mode are now configurable via environment variables, making the backend deployable across dev/staging/production without code changes.

## What does this PR do?

  - Adds backend/app/settings.py with a pydantic BaseSettings class as the single source of truth for config
  - Moves CORS origins from hardcoded ["http://localhost:5173"] to CORS_ORIGINS env var
  - Moves database URL from raw os.getenv() to settings.database_url
  - Adds DEBUG env var to toggle FastAPI debug mode
  - Updates .env.example with all required variables
  - Adds CORS_ORIGINS and DEBUG to docker-compose.yml
  - Adds pydantic-settings dependency

## How to test

  - Run pip install -r requirements.txt to install pydantic-settings
  - Run pytest tests/ -v — all 27 tests should pass
  - Verify default config works: python -c "from app.settings import settings; print(settings.cors_origin_list)"
  - Verify env var override works: CORS_ORIGINS="https://example.com" python -c "from app.settings import settings;
  print(settings.cors_origin_list)"
  - Run docker compose up and confirm backend starts with CORS configured

## Checklist

  - Code builds without errors
  - Tested locally
  - No console errors/warnings