### PR TITLE
91-mobile-map-page-requires-scrolling-to-see-full-california

### DIFF
--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -15,7 +15,7 @@ export default function BottomTabBar() {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-surface-container-lowest bottom-tab-shadow" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
-      <div className="flex items-center justify-around h-20">
+      <div className="flex items-center justify-around h-14">
         {tabs.map((tab) => (
           <NavLink
             key={tab.to}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -24,11 +24,11 @@ export default function Layout() {
     <>
       <NavBar />
       {isMapPage ? (
-        <main className="pt-16 flex h-screen overflow-hidden">
+        <main className="pt-12 pb-14 md:pt-16 md:pb-0 flex h-dvh overflow-hidden">
           <Outlet />
         </main>
       ) : (
-        <div key={location.pathname} className="page-enter pt-16 min-h-screen flex flex-col pb-28 md:pb-0">
+        <div key={location.pathname} className="page-enter pt-12 md:pt-16 min-h-screen flex flex-col pb-20 md:pb-0">
           <main className="flex-1">
             <Outlet />
           </main>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -20,7 +20,7 @@ export default function NavBar() {
 
 
   return (
-    <header className="bg-surface fixed top-0 z-50 flex w-full items-center justify-between px-6 py-3 h-16">
+    <header className="bg-surface fixed top-0 z-50 flex w-full items-center justify-between px-4 py-2 h-12 md:px-6 md:py-3 md:h-16">
       <div className="flex items-center gap-8">
         <NavLink to="/" className="flex items-center gap-2">
           <img src={logo} alt="CalSight" className="h-7 w-auto" />

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -8,8 +8,8 @@ const CA_CENTER: [number, number] = [37.2, -119.5];
 const CA_ZOOM = 6;
 
 const CA_BOUNDS: LatLngBoundsExpression = [
-  [32.0, -125.0],
-  [42.5, -114.0],
+  [28.0, -127.0],
+  [46.0, -112.0],
 ];
 
 interface MapCanvasProps {

--- a/frontend/src/components/map/SearchPill.test.tsx
+++ b/frontend/src/components/map/SearchPill.test.tsx
@@ -9,6 +9,8 @@ function createMockMap() {
     setView: vi.fn(),
     zoomIn: vi.fn(),
     zoomOut: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
   } as unknown as LeafletMap;
 }
 

--- a/frontend/src/components/map/SearchPill.tsx
+++ b/frontend/src/components/map/SearchPill.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef } from "react";
 import type { Map as LeafletMap } from "leaflet";
 
 interface SearchPillProps {
@@ -5,48 +6,128 @@ interface SearchPillProps {
 }
 
 export default function SearchPill({ map }: SearchPillProps) {
+  const [isMoving, setIsMoving] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!map) return;
+
+    const onMoveStart = () => setIsMoving(true);
+    const onMoveEnd = () => setIsMoving(false);
+
+    map.on("movestart", onMoveStart);
+    map.on("moveend", onMoveEnd);
+
+    return () => {
+      map.off("movestart", onMoveStart);
+      map.off("moveend", onMoveEnd);
+    };
+  }, [map]);
+
+  // Auto-focus the input when expanded
+  useEffect(() => {
+    if (isExpanded && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isExpanded]);
+
+  // Collapse when map starts moving
+  useEffect(() => {
+    if (isMoving) setIsExpanded(false);
+  }, [isMoving]);
+
+  function handleClose() {
+    setIsExpanded(false);
+    setQuery("");
+  }
+
   return (
-    <div className="absolute bottom-28 md:bottom-8 left-4 right-4 md:left-1/2 md:right-auto md:-translate-x-1/2 z-10 flex items-center gap-1 p-1 bg-white dark:bg-neutral-800 rounded-full shadow-lg">
-      {/* Search button */}
-      <button className="flex items-center gap-2 flex-1 md:flex-none px-6 py-3 bg-primary text-on-primary rounded-full transition-all hover:opacity-90">
-        <span className="material-symbols-outlined text-lg">search</span>
-        <span className="text-sm font-semibold tracking-tight">
-          Search California
-        </span>
-      </button>
-
-      {/* Divider — hidden on mobile */}
-      <div className="hidden md:block w-[1px] h-6 bg-outline-variant/30 mx-2" />
-
-      {/* Location — hidden on mobile */}
-      <button
-        onClick={() => {
-          if (map) map.setView([37.2, -119.5], 6, { animate: true, duration: 0.5 });
-        }}
-        className="hidden md:block p-3 text-on-surface-variant hover:text-on-surface transition-colors"
+    <>
+      {/* Mobile: compact pill / expanded search bar */}
+      <div
+        className={`absolute z-10 md:hidden transition-all duration-300 ${
+          isExpanded
+            ? "bottom-4 left-4 right-4"
+            : "bottom-4 left-4"
+        } ${
+          isMoving && !isExpanded ? "opacity-60 scale-90" : "opacity-100 scale-100"
+        }`}
       >
-        <span className="material-symbols-outlined">my_location</span>
-      </button>
+        {isExpanded ? (
+          <div className="flex items-center gap-2 px-4 py-2 bg-surface-container-lowest rounded-full shadow-lg ghost-border">
+            <span className="material-symbols-outlined text-lg text-on-surface-variant">search</span>
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search counties..."
+              className="flex-1 bg-transparent text-sm text-on-surface placeholder:text-on-surface-variant/60 outline-none ring-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 border-none"
+            />
+            <button
+              onClick={handleClose}
+              className="p-1 hover:bg-surface-container rounded-full transition-colors"
+            >
+              <span className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setIsExpanded(true)}
+            className="flex items-center gap-2 px-4 py-3 bg-primary text-on-primary rounded-full shadow-lg transition-all duration-300 hover:opacity-90"
+          >
+            <span className="material-symbols-outlined text-lg">search</span>
+            <span
+              className={`text-sm font-semibold tracking-tight overflow-hidden whitespace-nowrap transition-all duration-300 ${
+                isMoving ? "max-w-0 opacity-0" : "max-w-[100px] opacity-100"
+              }`}
+            >
+              Search
+            </span>
+          </button>
+        )}
+      </div>
 
-      {/* Zoom in — hidden on mobile */}
-      <button
-        onClick={() => {
-          if (map) map.zoomIn(1, { animate: true });
-        }}
-        className="hidden md:block p-3 text-on-surface-variant hover:text-on-surface transition-colors"
-      >
-        <span className="material-symbols-outlined">zoom_in</span>
-      </button>
+      {/* Desktop: full pill, centered bottom */}
+      <div className="hidden md:flex absolute bottom-8 left-1/2 -translate-x-1/2 z-10 items-center gap-1 p-1 bg-white dark:bg-neutral-800 rounded-full shadow-lg">
+        <button className="flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-full transition-all hover:opacity-90">
+          <span className="material-symbols-outlined text-lg">search</span>
+          <span className="text-sm font-semibold tracking-tight">
+            Search California
+          </span>
+        </button>
 
-      {/* Zoom out — hidden on mobile */}
-      <button
-        onClick={() => {
-          if (map) map.zoomOut(1, { animate: true });
-        }}
-        className="hidden md:block p-3 text-on-surface-variant hover:text-on-surface transition-colors"
-      >
-        <span className="material-symbols-outlined">zoom_out</span>
-      </button>
-    </div>
+        <div className="w-[1px] h-6 bg-outline-variant/30 mx-2" />
+
+        <button
+          onClick={() => {
+            if (map) map.setView([37.2, -119.5], 6, { animate: true, duration: 0.5 });
+          }}
+          className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          <span className="material-symbols-outlined">my_location</span>
+        </button>
+
+        <button
+          onClick={() => {
+            if (map) map.zoomIn(1, { animate: true });
+          }}
+          className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          <span className="material-symbols-outlined">zoom_in</span>
+        </button>
+
+        <button
+          onClick={() => {
+            if (map) map.zoomOut(1, { animate: true });
+          }}
+          className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          <span className="material-symbols-outlined">zoom_out</span>
+        </button>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
 1. Layout — h-dvh + pb-14 md:pb-0 so the map fits the viewport above the tab bar
  2. Compact chrome — navbar h-12 on mobile, tab bar h-14 on mobile
  3. Looser map bounds — extra padding around California so you can scroll past it
  4. Search pill — compact on mobile, collapses while panning, expands to text input on tap

 ## What does this PR do?

  - Fixes mobile viewport so the map fits between the header and bottom nav without scrolling
  - Shrinks navbar (48px) and tab bar (56px) on mobile to maximize map area
  - Expands map pan bounds so users can scroll past California's edges to reach border counties
  - Redesigns search pill for mobile: compact bottom-left pill that collapses to an icon while panning and expands to a
  full-width text input on tap
  - Uses dvh (dynamic viewport height) for correct sizing on mobile browsers with URL bars

##  How to test

  - Open in Chrome DevTools → toggle device toolbar → select ~360x800 viewport
  - Verify California fits within the map area without page scrolling
  - Verify you can pan the map past California's top and bottom edges
  - Verify bottom tab bar and navbar don't overlap the map's interactive area
  - Tap the search pill → should expand to a text input
  - Pan the map → search pill should collapse to just the icon
  - Check on desktop → layout and search pill should be unchanged
  - Navigate to Stats/About pages → navbar and spacing should look normal

 ## Checklist

  - Code builds without errors
  - Tested locally
  - No console errors/warnings