### PR TITLE
95-etl-pipeline-fetch-census-acs-demographics-data-into-postgres

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -28,6 +28,9 @@ class Settings(BaseSettings):
     # Comma-separated origins, e.g. "http://localhost:5173,https://calsight.example.com"
     cors_origins: str = "http://localhost:5173"
 
+    # -- Census --
+    census_api_key: str = ""
+
     # -- App --
     debug: bool = True
 

--- a/backend/etl/census_api.py
+++ b/backend/etl/census_api.py
@@ -1,0 +1,155 @@
+"""Census Bureau ACS API client.
+
+Fetches demographic data for all California counties for a given year.
+Uses ACS 5-year estimates (2009+) or 1-year estimates (2005-2008).
+
+The Census API returns JSON like:
+    [
+        ["B01003_001E", "B01002_001E", ..., "state", "county"],
+        ["1000000",     "35.2",        ..., "06",    "001"],
+        ...
+    ]
+
+First row = headers (variable codes), remaining rows = one per county.
+Values are strings (or null for missing data).
+"""
+
+import time
+import logging
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Census variable codes mapped to readable names.
+# "E" suffix = Estimate (as opposed to "M" = Margin of Error).
+VARIABLES = {
+    "B01003_001E": "population",       # Total population
+    "B01002_001E": "median_age",       # Median age
+    "B19013_001E": "median_income",    # Median household income ($)
+    "B08006_003E": "commute_drive_alone",  # Workers who drove alone
+    "B08006_004E": "commute_carpool",      # Workers who carpooled
+    "B08006_008E": "commute_transit",      # Public transit riders
+    "B08006_005E": "commute_walk",         # Walked to work
+    "B08006_014E": "commute_bike",         # Bicycle commuters
+    "B08006_017E": "commute_wfh",          # Worked from home
+    "B08006_001E": "commute_total",        # Total workers (denominator)
+}
+
+VARIABLE_CODES = ",".join(VARIABLES.keys())
+
+MAX_RETRIES = 3
+BACKOFF_BASE = 2  # seconds
+
+
+def _safe_int(value):
+    """Convert a Census string value to int. Returns None for nulls.
+
+    The Census API returns numbers as strings ("1000000") or null.
+    """
+    if value is None or value == "":
+        return None
+    return int(value)
+
+
+def _safe_float(value):
+    """Convert a Census string value to float. Returns None for nulls."""
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def _commute_pct(count, total):
+    """Calculate commute mode percentage from raw count and total.
+
+    Example: 500,000 drove alone out of 800,000 total workers = 62.5%
+    """
+    if count is None or total is None or total == 0:
+        return None
+    return round(count / total * 100, 2)
+
+
+def fetch_county_demographics(year: int, api_key: str) -> list[dict]:
+    """Fetch demographic data for all CA counties for a given year.
+
+    Picks the right ACS dataset:
+    - 2010+: ACS 5-year (covers all counties, most reliable)
+    - 2005-2009: ACS 1-year (only covers counties with 65k+ population)
+
+    Returns a list of dicts with keys matching the Demographic model,
+    plus 'county_fips' (3-digit FIPS code like "001" for Alameda).
+    """
+    dataset = "acs5" if year >= 2010 else "acs1"
+    url = (
+        f"https://api.census.gov/data/{year}/acs/{dataset}"
+        f"?get={VARIABLE_CODES}"
+        f"&for=county:*&in=state:06"
+        f"&key={api_key}"
+    )
+
+    logger.info("Fetching ACS %s data for %d", dataset, year)
+
+    # Retry with exponential backoff.
+    # Government APIs can be flaky — this handles transient failures.
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = httpx.get(url, timeout=30.0)
+            resp.raise_for_status()
+            break
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            last_error = exc
+            if attempt < MAX_RETRIES - 1:
+                wait = BACKOFF_BASE ** (attempt + 1)
+                logger.warning(
+                    "Attempt %d failed for year %d: %s. Retrying in %ds...",
+                    attempt + 1, year, exc, wait,
+                )
+                time.sleep(wait)
+    else:
+        # This runs if the for-loop finished without "break" —
+        # meaning all retries failed.
+        logger.error("All %d attempts failed for year %d", MAX_RETRIES, year)
+        raise last_error
+
+    # Parse the JSON response.
+    # Row 0 = headers, rows 1+ = county data.
+    data = resp.json()
+    header = data[0]
+    rows = data[1:]
+
+    results = []
+    for row in rows:
+        # zip(header, row) pairs each header with its value:
+        # {"B01003_001E": "1000000", "county": "001", ...}
+        record = dict(zip(header, row))
+
+        # Convert string values to proper Python types
+        population = _safe_int(record.get("B01003_001E"))
+        median_age = _safe_float(record.get("B01002_001E"))
+        median_income = _safe_int(record.get("B19013_001E"))
+
+        # Commute: Census gives raw counts, we convert to percentages
+        commute_total = _safe_int(record.get("B08006_001E"))
+        drive_alone = _safe_int(record.get("B08006_003E"))
+        carpool = _safe_int(record.get("B08006_004E"))
+        transit = _safe_int(record.get("B08006_008E"))
+        walk = _safe_int(record.get("B08006_005E"))
+        bike = _safe_int(record.get("B08006_014E"))
+        wfh = _safe_int(record.get("B08006_017E"))
+
+        results.append({
+            "county_fips": record["county"],
+            "population": population,
+            "median_age": median_age,
+            "median_income": median_income,
+            "commute_drive_alone_pct": _commute_pct(drive_alone, commute_total),
+            "commute_carpool_pct": _commute_pct(carpool, commute_total),
+            "commute_transit_pct": _commute_pct(transit, commute_total),
+            "commute_walk_pct": _commute_pct(walk, commute_total),
+            "commute_bike_pct": _commute_pct(bike, commute_total),
+            "commute_wfh_pct": _commute_pct(wfh, commute_total),
+        })
+
+    logger.info("Fetched %d county rows for %d", len(results), year)
+    return results

--- a/backend/etl/load_demographics.py
+++ b/backend/etl/load_demographics.py
@@ -1,0 +1,205 @@
+"""ETL orchestrator: load Census ACS demographics into Postgres.
+
+This is the main script you run to populate the demographics table.
+It coordinates everything:
+  1. Reads the county FIPS lookup from Postgres
+  2. Loops through each year (2005-2022)
+  3. Calls the Census API client for each year
+  4. Transforms the data to match our Demographic model
+  5. Upserts (insert-or-update) into the database
+
+"Upsert" means: if a row for (county, year) already exists, update it.
+If not, insert a new one. This makes the script safe to re-run — you
+won't get duplicate rows.
+
+Usage:
+    python -m etl.load_demographics
+    python -m etl.load_demographics --start 2020 --end 2022
+"""
+
+import argparse
+import logging
+import sys
+
+from sqlalchemy import select
+
+from app.database import SessionLocal
+from app.models import County, Demographic
+from app.settings import settings
+from etl.census_api import fetch_county_demographics
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_START_YEAR = 2005
+DEFAULT_END_YEAR = 2022
+
+
+def build_fips_lookup(county_rows: list[tuple]) -> dict[str, int]:
+    """Build a mapping from 3-digit FIPS suffix to county_code.
+
+    Why this is needed:
+    - Census API returns county as 3 digits: "001" (Alameda)
+    - Our counties table stores 5-digit FIPS: "06001"
+    - Our Demographic table uses county_code: 1
+
+    So we need: "001" -> 1
+
+    Args:
+        county_rows: List of (code, fips) tuples from counties table.
+    """
+    lookup = {}
+    for code, fips in county_rows:
+        if fips is None:
+            continue
+        # "06001" -> last 3 chars -> "001"
+        suffix = fips[-3:]
+        lookup[suffix] = code
+    return lookup
+
+
+def transform_to_demographic_kwargs(
+    api_row: dict, fips_lookup: dict[str, int], year: int
+) -> dict | None:
+    """Transform one Census API row into kwargs for the Demographic model.
+
+    This is the "T" in ETL — taking data shaped one way (Census format)
+    and reshaping it for our database.
+
+    Returns None if the county FIPS isn't in our lookup (skip it).
+    """
+    county_fips = api_row["county_fips"]
+    county_code = fips_lookup.get(county_fips)
+    if county_code is None:
+        return None
+
+    return {
+        "county_code": county_code,
+        "year": year,
+        "population": api_row.get("population"),
+        "median_age": api_row.get("median_age"),
+        "median_income": api_row.get("median_income"),
+        "commute_drive_alone_pct": api_row.get("commute_drive_alone_pct"),
+        "commute_carpool_pct": api_row.get("commute_carpool_pct"),
+        "commute_transit_pct": api_row.get("commute_transit_pct"),
+        "commute_walk_pct": api_row.get("commute_walk_pct"),
+        "commute_bike_pct": api_row.get("commute_bike_pct"),
+        "commute_wfh_pct": api_row.get("commute_wfh_pct"),
+    }
+
+
+def upsert_demographics(session, rows: list[dict]) -> tuple[int, int]:
+    """Insert new rows or update existing ones.
+
+    "Upsert" = "insert or update". We check if a row with this
+    (county_code, year) already exists:
+    - Yes: update its values (in case Census revised the data)
+    - No: insert a new row
+
+    This makes the script idempotent — run it 10 times, same result.
+    """
+    inserted = 0
+    updated = 0
+    for kwargs in rows:
+        existing = session.query(Demographic).filter_by(
+            county_code=kwargs["county_code"],
+            year=kwargs["year"],
+        ).first()
+
+        if existing:
+            for key, value in kwargs.items():
+                setattr(existing, key, value)
+            updated += 1
+        else:
+            session.add(Demographic(**kwargs))
+            inserted += 1
+
+    session.commit()
+    return inserted, updated
+
+
+def run(start_year: int = DEFAULT_START_YEAR, end_year: int = DEFAULT_END_YEAR):
+    """Main ETL entry point."""
+    api_key = settings.census_api_key
+    if not api_key:
+        logger.error("CENSUS_API_KEY is not set. Add it to backend/.env")
+        sys.exit(1)
+
+    db = SessionLocal()
+    try:
+        # Step 1: Build the FIPS -> county_code lookup from the DB
+        county_rows = db.execute(
+            select(County.code, County.fips)
+        ).all()
+        fips_lookup = build_fips_lookup(county_rows)
+        logger.info("Loaded %d counties from database", len(fips_lookup))
+
+        if len(fips_lookup) == 0:
+            logger.error(
+                "No counties in database. Run: python -m app.seed_counties"
+            )
+            sys.exit(1)
+
+        total_inserted = 0
+        total_updated = 0
+        failed_years = []
+
+        # Step 2: Loop through each year
+        for year in range(start_year, end_year + 1):
+            try:
+                # Step 3: Fetch from Census API
+                api_rows = fetch_county_demographics(year, api_key)
+
+                # Step 4: Transform each row
+                kwargs_list = []
+                for row in api_rows:
+                    kwargs = transform_to_demographic_kwargs(
+                        row, fips_lookup, year
+                    )
+                    if kwargs is not None:
+                        kwargs_list.append(kwargs)
+
+                # Step 5: Upsert into Postgres
+                inserted, updated = upsert_demographics(db, kwargs_list)
+                total_inserted += inserted
+                total_updated += updated
+                logger.info(
+                    "Year %d: %d inserted, %d updated",
+                    year, inserted, updated,
+                )
+            except Exception as exc:
+                failed_years.append(year)
+                logger.error("Year %d failed: %s", year, exc)
+                # Rollback this year's partial writes, then continue
+                db.rollback()
+
+        # Summary
+        logger.info(
+            "Done. %d inserted, %d updated, %d years failed %s",
+            total_inserted,
+            total_updated,
+            len(failed_years),
+            failed_years if failed_years else "",
+        )
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Load Census ACS demographics into Postgres"
+    )
+    parser.add_argument(
+        "--start", type=int, default=DEFAULT_START_YEAR,
+        help=f"Start year (default: {DEFAULT_START_YEAR})",
+    )
+    parser.add_argument(
+        "--end", type=int, default=DEFAULT_END_YEAR,
+        help=f"End year (default: {DEFAULT_END_YEAR})",
+    )
+    args = parser.parse_args()
+    run(start_year=args.start, end_year=args.end)

--- a/backend/tests/test_census_api.py
+++ b/backend/tests/test_census_api.py
@@ -1,0 +1,114 @@
+"""Tests for the Census API client.
+
+These use mocking — we fake the HTTP responses so tests don't hit
+the real Census API. This makes tests fast, reliable, and free.
+"""
+
+import httpx
+import pytest
+from unittest.mock import patch, MagicMock
+
+from etl.census_api import fetch_county_demographics
+
+
+# This is what the Census API actually returns — a list of lists
+# where the first row is headers and the rest are data.
+MOCK_RESPONSE_JSON = [
+    ["B01003_001E", "B01002_001E", "B19013_001E",
+     "B08006_003E", "B08006_004E", "B08006_008E",
+     "B08006_005E", "B08006_014E", "B08006_017E",
+     "B08006_001E", "state", "county"],
+    ["1000000", "35.2", "65000",
+     "500000", "80000", "50000",
+     "30000", "10000", "70000",
+     "800000", "06", "001"],
+]
+
+
+def _mock_success(json_data=None):
+    """Helper: create a mock httpx response that returns given JSON."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = json_data or MOCK_RESPONSE_JSON
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+class TestFetchCountyDemographics:
+    @patch("etl.census_api.httpx.get")
+    def test_returns_parsed_rows(self, mock_get):
+        """One data row in -> one parsed dict out."""
+        mock_get.return_value = _mock_success()
+
+        rows = fetch_county_demographics(year=2022, api_key="fake-key")
+
+        assert len(rows) == 1
+        assert rows[0]["county_fips"] == "001"
+        assert rows[0]["population"] == 1000000
+        assert rows[0]["median_age"] == 35.2
+        assert rows[0]["median_income"] == 65000
+
+    @patch("etl.census_api.httpx.get")
+    def test_uses_acs5_for_2010_and_later(self, mock_get):
+        """ACS 5-year has full county coverage, used for 2010+."""
+        mock_get.return_value = _mock_success()
+
+        fetch_county_demographics(year=2015, api_key="fake-key")
+
+        url = mock_get.call_args[0][0]
+        assert "/acs/acs5" in url
+
+    @patch("etl.census_api.httpx.get")
+    def test_uses_acs1_for_2009_and_earlier(self, mock_get):
+        """ACS 1-year is all that's available pre-2010."""
+        mock_get.return_value = _mock_success()
+
+        fetch_county_demographics(year=2009, api_key="fake-key")
+
+        url = mock_get.call_args[0][0]
+        assert "/acs/acs1" in url
+
+    @patch("etl.census_api.httpx.get")
+    def test_computes_commute_percentages(self, mock_get):
+        """Raw counts get divided by total workers to make percentages."""
+        mock_get.return_value = _mock_success()
+
+        rows = fetch_county_demographics(year=2022, api_key="fake-key")
+
+        row = rows[0]
+        # 500000 / 800000 * 100 = 62.5
+        assert row["commute_drive_alone_pct"] == pytest.approx(62.5)
+        # 80000 / 800000 * 100 = 10.0
+        assert row["commute_carpool_pct"] == pytest.approx(10.0)
+        # 70000 / 800000 * 100 = 8.75
+        assert row["commute_wfh_pct"] == pytest.approx(8.75)
+
+    @patch("etl.census_api.httpx.get")
+    def test_handles_null_values(self, mock_get):
+        """ACS 1-year returns null for small counties — we store None."""
+        response_with_nulls = [
+            MOCK_RESPONSE_JSON[0],  # header row stays the same
+            [None, None, None,
+             None, None, None,
+             None, None, None,
+             None, "06", "003"],
+        ]
+        mock_get.return_value = _mock_success(response_with_nulls)
+
+        rows = fetch_county_demographics(year=2006, api_key="fake-key")
+
+        assert len(rows) == 1
+        assert rows[0]["population"] is None
+        assert rows[0]["commute_drive_alone_pct"] is None
+
+    @patch("etl.census_api.httpx.get")
+    def test_retries_on_server_error(self, mock_get):
+        """Should retry up to 3 times on 500 errors, then raise."""
+        mock_get.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            fetch_county_demographics(year=2022, api_key="fake-key")
+
+        assert mock_get.call_count == 3

--- a/backend/tests/test_load_demographics.py
+++ b/backend/tests/test_load_demographics.py
@@ -1,0 +1,67 @@
+"""Tests for the ETL orchestrator.
+
+These test the pure logic (FIPS mapping, data transformation) without
+needing a database connection. The actual DB upsert is tested in Task 4
+when we run the real pipeline.
+"""
+
+from etl.load_demographics import build_fips_lookup, transform_to_demographic_kwargs
+
+
+# Simulates rows you'd get from: SELECT code, fips FROM counties
+MOCK_COUNTIES = [
+    (1, "06001"),   # Alameda
+    (10, "06019"),  # Fresno
+    (19, "06037"),  # Los Angeles
+]
+
+
+class TestBuildFipsLookup:
+    def test_maps_three_digit_fips_to_county_code(self):
+        """Census API returns "001", our DB stores "06001".
+        This lookup bridges between them."""
+        lookup = build_fips_lookup(MOCK_COUNTIES)
+        assert lookup["001"] == 1
+        assert lookup["019"] == 10
+        assert lookup["037"] == 19
+
+    def test_ignores_counties_with_no_fips(self):
+        """Some counties might not have FIPS — skip them safely."""
+        counties_with_none = [(99, None)]
+        lookup = build_fips_lookup(counties_with_none)
+        assert len(lookup) == 0
+
+
+class TestTransformToDemographicKwargs:
+    def test_transforms_api_row_to_model_kwargs(self):
+        """Census API dict -> Demographic model kwargs."""
+        fips_lookup = {"001": 1}
+        api_row = {
+            "county_fips": "001",
+            "population": 1000000,
+            "median_age": 35.2,
+            "median_income": 65000,
+            "commute_drive_alone_pct": 62.5,
+            "commute_carpool_pct": 10.0,
+            "commute_transit_pct": 6.25,
+            "commute_walk_pct": 3.75,
+            "commute_bike_pct": 1.25,
+            "commute_wfh_pct": 8.75,
+        }
+
+        result = transform_to_demographic_kwargs(api_row, fips_lookup, year=2022)
+
+        assert result["county_code"] == 1
+        assert result["year"] == 2022
+        assert result["population"] == 1000000
+        assert result["median_age"] == 35.2
+        assert result["commute_wfh_pct"] == 8.75
+
+    def test_returns_none_for_unknown_fips(self):
+        """If Census returns a county we don't know about, skip it."""
+        fips_lookup = {"001": 1}
+        api_row = {"county_fips": "999"}
+
+        result = transform_to_demographic_kwargs(api_row, fips_lookup, year=2022)
+
+        assert result is None

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,14 @@
+from app.settings import Settings
+
+
+def test_settings_has_census_api_key_field():
+    """Settings class should accept a CENSUS_API_KEY env var."""
+    s = Settings(census_api_key="test-key-123")
+    assert s.census_api_key == "test-key-123"
+
+
+def test_census_api_key_defaults_to_empty_without_env(monkeypatch):
+    """Key is optional so the app doesn't crash without it."""
+    monkeypatch.delenv("CENSUS_API_KEY", raising=False)
+    s = Settings(_env_file=None)
+    assert s.census_api_key == ""


### PR DESCRIPTION
Fetches population, income, and commute data from the Census Bureau API (2005-2022) and upserts into the demographics table with retry logic.

## What does this PR do?

Adds a Census Bureau ETL pipeline that fetches ACS demographic data (population, median age, median income, and
commute mode percentages) for all 58 California counties across 2005-2022 and upserts it into the demographics
Postgres table.

New files:
- backend/etl/census_api.py — API client that calls the Census ACS endpoint with retry/backoff, parses the JSON
response, and converts raw commute counts to percentages
- backend/etl/load_demographics.py — Orchestrator that reads the county FIPS lookup from Postgres, loops through
years, transforms API rows, and upserts (insert-or-update) so the script is safe to re-run
- Tests for both modules plus a settings test for the new CENSUS_API_KEY field

Key design decisions:
- Uses ACS 5-year estimates for 2010+ (full county coverage) and ACS 1-year for 2005-2009
- Upsert logic makes the pipeline idempotent — re-running updates existing rows instead of creating duplicates
- Exponential backoff (3 retries) handles flaky government API responses
- Supports --start / --end CLI args for partial runs

## How to test
- Set CENSUS_API_KEY in backend/.env (free key from https://api.census.gov/data/key_signup.html)
- Run python -m etl.load_demographics --start 2020 --end 2022 to test a small year range
- Verify rows in Postgres: SELECT count(*) FROM demographics WHERE year = 2022; (should be ~58 rows)
- Run pytest backend/tests/test_census_api.py backend/tests/test_load_demographics.py backend/tests/test_settings.py

## Checklist
- Code builds without errors
- Tested locally
- No console errors/warnings
