### PR TITLE
40-fastapi-endpoints-apicrashes-apistats-apidemographics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,20 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: calsight
+          POSTGRES_PASSWORD: calsight_dev
+          POSTGRES_DB: calsight
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,7 +33,13 @@ jobs:
           python-version: "3.12"
       - run: pip install -r requirements.txt
       - run: ruff check .
-      - run: pytest
+      - name: Run unit tests
+        run: pytest -m "not integration"
+      - name: Run integration tests
+        env:
+          TEST_DATABASE_URL: postgresql://calsight:calsight_dev@localhost:5433/calsight_test
+          TEST_DATABASE_ADMIN_URL: postgresql://calsight:calsight_dev@localhost:5433/postgres
+        run: pytest -m integration
 
   frontend:
     runs-on: ubuntu-latest

--- a/backend/app/county_slug_map.py
+++ b/backend/app/county_slug_map.py
@@ -1,0 +1,47 @@
+"""Slug <-> county_code lookup built from the counties table.
+
+The slug convention matches `frontend/src/hooks/useFilterParams.ts`:
+lowercase, spaces replaced with hyphens. Examples: Los Angeles -> los-angeles.
+
+Usage inside a handler:
+    slug_map = get_slug_map(db)  # lazy-built + cached per process
+    code = get_code("los-angeles", slug_map)
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models import County
+
+
+def slugify_name(name: str) -> str:
+    """CA county name -> URL slug. Matches frontend slugify()."""
+    return name.lower().replace(" ", "-")
+
+
+def build_map(rows: list[tuple[int, str]]) -> dict[str, int]:
+    """Build {slug: code} from (code, name) tuples."""
+    return {slugify_name(name): code for code, name in rows}
+
+
+def get_code(slug: str, slug_map: dict[str, int]) -> int | None:
+    return slug_map.get(slug)
+
+
+_cached_map: dict[str, int] | None = None
+
+
+def get_slug_map(db: Session) -> dict[str, int]:
+    """Return {slug: code} for all 58 counties, built once per process."""
+    global _cached_map
+    if _cached_map is None:
+        rows = [(c.code, c.name) for c in db.query(County.code, County.name).all()]
+        _cached_map = build_map(rows)
+    return _cached_map
+
+
+def _reset_cache_for_tests() -> None:
+    """Test helper — let each session start with a fresh cache."""
+    global _cached_map
+    _cached_map = None

--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -1,0 +1,175 @@
+"""URL-param <-> SQL predicate translation, shared by /api/crashes and /api/stats.
+
+Conventions:
+  - parse_* returns None for "no filter on this dimension" (omitted or empty param)
+  - parse_* returns a set[int] or set[str] of DB-truthful values otherwise
+  - parse_* raises FilterError with a helpful message on bad input
+
+Router handlers let FilterError propagate; a global exception handler in
+`app.main` converts it to 422 with `{detail, filter}`, matching the
+error envelope documented in the spec.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from sqlalchemy import ColumnElement
+
+from app.models import Crash
+
+
+class FilterError(ValueError):
+    def __init__(self, filter: str, detail: str):
+        super().__init__(detail)
+        self.filter = filter
+        self.detail = detail
+
+
+_FIRST_YEAR = 2001
+
+
+def _split_csv(raw: str) -> list[str]:
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def parse_year(raw: str | None) -> set[int] | None:
+    """Parse ?year=2020,2023 into {2020, 2023}. None/"" -> no filter."""
+    if raw is None or raw == "":
+        return None
+    current_year = date.today().year
+    out: set[int] = set()
+    for part in _split_csv(raw):
+        try:
+            y = int(part)
+        except ValueError:
+            raise FilterError(
+                "year",
+                f"Year values must be integers; got '{part}'.",
+            ) from None
+        if y < _FIRST_YEAR or y > current_year:
+            raise FilterError(
+                "year",
+                f"Year {y} is outside the supported range "
+                f"({_FIRST_YEAR}-{current_year}).",
+            )
+        out.add(y)
+    return out or None
+
+
+def parse_county_codes(
+    raw: str | None,
+    slug_map: dict[str, int],
+) -> set[int] | None:
+    """Parse ?county=los-angeles,orange into {19, 30} (codes)."""
+    if raw is None or raw == "":
+        return None
+    out: set[int] = set()
+    for part in _split_csv(raw):
+        code = slug_map.get(part)
+        if code is None:
+            examples = ", ".join(sorted(slug_map.keys())[:5])
+            raise FilterError(
+                "county",
+                f"Unknown county '{part}'. Examples: {examples}, ...",
+            )
+        out.add(code)
+    return out or None
+
+
+# Canonical DB values, mapped from URL slugs.
+_SEVERITY_SLUG_TO_DB = {
+    "fatal": "Fatal",
+    "injury": "Injury",
+    "property-damage-only": "Property Damage Only",
+}
+
+# Canonical DB canonical_cause values.
+_CAUSE_SLUG_TO_DB = {
+    "dui": "dui",
+    "speeding": "speeding",
+    "lane-change": "lane_change",  # cosmetic hyphen -> underscore
+    "other": "other",
+}
+
+
+def parse_severity(raw: str | None) -> set[str] | None:
+    if raw is None or raw == "":
+        return None
+    out: set[str] = set()
+    for part in _split_csv(raw):
+        db_value = _SEVERITY_SLUG_TO_DB.get(part)
+        if db_value is None:
+            allowed = ", ".join(_SEVERITY_SLUG_TO_DB.keys())
+            raise FilterError(
+                "severity",
+                f"Unknown severity '{part}'. Allowed: {allowed}.",
+            )
+        out.add(db_value)
+    return out or None
+
+
+def parse_cause(raw: str | None) -> set[str] | None:
+    if raw is None or raw == "":
+        return None
+    out: set[str] = set()
+    for part in _split_csv(raw):
+        if part == "distracted":
+            raise FilterError(
+                "cause",
+                "'distracted' is not a cause category. Use ?distracted=true.",
+            )
+        if part == "weather":
+            raise FilterError(
+                "cause",
+                "'weather' is not a cause category. Weather conditions are "
+                "available on individual crash records via crashes.weather.",
+            )
+        db_value = _CAUSE_SLUG_TO_DB.get(part)
+        if db_value is None:
+            allowed = ", ".join(_CAUSE_SLUG_TO_DB.keys())
+            raise FilterError(
+                "cause",
+                f"Unknown cause '{part}'. Allowed: {allowed}.",
+            )
+        out.add(db_value)
+    return out or None
+
+
+def parse_bool_flag(raw: str | None, name: str) -> bool | None:
+    if raw is None or raw == "":
+        return None
+    if raw == "true":
+        return True
+    if raw == "false":
+        return False
+    raise FilterError(
+        name,
+        f"{name} must be 'true' or 'false'; got '{raw}'.",
+    )
+
+
+def build_crash_predicates(
+    *,
+    years: set[int] | None = None,
+    county_codes: set[int] | None = None,
+    severities: set[str] | None = None,
+    causes: set[str] | None = None,
+    alcohol: bool | None = None,
+    distracted: bool | None = None,
+) -> list[ColumnElement]:
+    """Build SQLAlchemy WHERE predicates for the crashes table."""
+    preds: list[ColumnElement] = []
+    if years:
+        preds.append(Crash.crash_year.in_(years))
+    if county_codes:
+        preds.append(Crash.county_code.in_(county_codes))
+    if severities:
+        preds.append(Crash.severity.in_(severities))
+    if causes:
+        preds.append(Crash.canonical_cause.in_(causes))
+    if alcohol is not None:
+        preds.append(Crash.is_alcohol_involved.is_(alcohol))
+    if distracted is not None:
+        preds.append(Crash.is_distraction_involved.is_(distracted))
+    return preds

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,13 @@
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
+import logging
 
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from app.filters import FilterError
 from app.settings import settings
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="CalSight API", version="0.1.0", debug=settings.debug)
 
@@ -11,6 +17,40 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(FilterError)
+async def filter_error_handler(request: Request, exc: FilterError):
+    return JSONResponse(
+        status_code=422,
+        content={"detail": exc.detail, "filter": exc.filter},
+    )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    logger.exception("Unhandled exception on %s", request.url.path)
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal server error"},
+    )
+
+
+from app.routers.context import router as context_router  # noqa: E402
+from app.routers.crash_people import router as crash_people_router  # noqa: E402
+from app.routers.crashes import router as crashes_router  # noqa: E402
+from app.routers.demographics import router as demographics_router  # noqa: E402
+from app.routers.meta import router as meta_router  # noqa: E402
+from app.routers.reference import router as reference_router  # noqa: E402
+from app.routers.stats import router as stats_router  # noqa: E402
+
+app.include_router(reference_router, prefix="/api")
+app.include_router(demographics_router, prefix="/api")
+app.include_router(context_router, prefix="/api")
+app.include_router(crashes_router, prefix="/api")
+app.include_router(crash_people_router, prefix="/api")
+app.include_router(stats_router, prefix="/api")
+app.include_router(meta_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -254,6 +254,41 @@ class Demographic(Base):
     pct_45_64 = Column(Float)              # middle age
     pct_65_plus = Column(Float)            # elderly — most vulnerable as pedestrians
 
+    # Sex distribution — also derived from B01001 (sums of male and female
+    # age cells respectively, divided by total population). Useful for
+    # cross-referencing with crash_parties.gender / crash_victims.gender.
+    pct_male = Column(Float)
+    pct_female = Column(Float)
+
+    # Economic — per-capita alternative to median_income (household).
+    # From Census table B19301.
+    per_capita_income = Column(Integer)
+
+    # Exposure proxy — longer commutes = more time on roads = more crash
+    # chances, independent of skill. From B08013 (aggregate minutes) / B08301
+    # (workers 16+).
+    mean_travel_time_to_work = Column(Float)  # minutes
+
+    # Equity lens — language/cultural barriers hypothesis. From B05002.
+    pct_foreign_born = Column(Float)
+
+    # Stress proxy — renters paying 30%+ of income (HUD's "rent-burdened"
+    # threshold). Sum of B25070 cells 007-010 / total renters.
+    pct_rent_burdened = Column(Float)
+
+    # Kids-on-roads signal — enrolled in school (nursery through graduate).
+    # From B14001 (pop 3+).
+    pct_enrolled_in_school = Column(Float)
+
+    # Niche risk correlate — veterans have higher motorcycle crash rates in
+    # national studies. From B21001 (civilian pop 18+).
+    pct_veteran = Column(Float)
+
+    # Pedestrian vulnerability angle — people with disabilities are
+    # over-represented in pedestrian fatalities. From B18101 (sex by age by
+    # disability status), summed across all "with a disability" cells.
+    pct_with_disability = Column(Float)
+
     # Socioeconomic — poverty is from B17001, education from B15003.
     # Education is null for some years because the Census didn't publish
     # B15003 until 2012 in the ACS 5-year data.

--- a/backend/app/routers/context.py
+++ b/backend/app/routers/context.py
@@ -1,0 +1,163 @@
+"""Context endpoints: unemployment, vehicles, licensed-drivers, data-quality,
+insights."""
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import parse_county_codes, parse_year
+from app.models import (
+    CountyInsight,
+    DataQualityStat,
+    LicensedDriver,
+    UnemploymentRate,
+    VehicleRegistration,
+)
+from app.schemas.context import (
+    CountyInsightOut,
+    DataQualityStatOut,
+    LicensedDriverOut,
+    UnemploymentOut,
+    VehicleRegistrationOut,
+)
+
+router = APIRouter(tags=["context"])
+
+_FIVE_MIN = "public, max-age=300"
+
+
+@router.get("/unemployment", response_model=list[UnemploymentOut])
+def list_unemployment(
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """BLS monthly unemployment rates per county."""
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(UnemploymentRate)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(UnemploymentRate.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(UnemploymentRate.year.in_(years))
+    rows = q.order_by(
+        UnemploymentRate.county_code,
+        UnemploymentRate.year,
+        UnemploymentRate.month,
+    ).all()
+    return [UnemploymentOut.model_validate(r) for r in rows]
+
+
+@router.get("/vehicles", response_model=list[VehicleRegistrationOut])
+def list_vehicles(
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """DMV vehicle registrations per county × year, including EV counts."""
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(VehicleRegistration)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(VehicleRegistration.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(VehicleRegistration.year.in_(years))
+    rows = q.order_by(
+        VehicleRegistration.county_code, VehicleRegistration.year
+    ).all()
+    return [VehicleRegistrationOut.model_validate(r) for r in rows]
+
+
+@router.get("/licensed-drivers", response_model=list[LicensedDriverOut])
+def list_licensed_drivers(
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """DMV licensed driver counts per county × year."""
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(LicensedDriver)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(LicensedDriver.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(LicensedDriver.year.in_(years))
+    rows = q.order_by(LicensedDriver.county_code, LicensedDriver.year).all()
+    return [LicensedDriverOut.model_validate(r) for r in rows]
+
+
+@router.get("/data-quality", response_model=list[DataQualityStatOut])
+def list_data_quality(
+    response: Response,
+    county: str | None = Query(None),
+    year: int | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Pre-computed fill rates. NULL in returned rows marks scope:
+
+    - `?county=X&year=Y`  -> specific (county_code=X AND year=Y)
+    - `?county=X`         -> per-county all-time (county_code=X AND year IS NULL)
+    - `?year=Y`           -> statewide per-year (county_code IS NULL AND year=Y)
+    - (no filter)         -> all rows
+    """
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(DataQualityStat)
+
+    if county and year is not None:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(
+                DataQualityStat.county_code.in_(codes),
+                DataQualityStat.year == year,
+            )
+    elif county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(
+                DataQualityStat.county_code.in_(codes),
+                DataQualityStat.year.is_(None),
+            )
+    elif year is not None:
+        q = q.filter(
+            DataQualityStat.county_code.is_(None),
+            DataQualityStat.year == year,
+        )
+
+    return [DataQualityStatOut.model_validate(r) for r in q.all()]
+
+
+@router.get("/insights", response_model=list[CountyInsightOut])
+def list_insights(
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """County insight cards with pre-generated narrative.
+
+    Returns `[]` until issue #68 populates `county_insights`.
+    """
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(CountyInsight)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(CountyInsight.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(CountyInsight.year.in_(years))
+    return [CountyInsightOut.model_validate(r) for r in q.all()]

--- a/backend/app/routers/crash_people.py
+++ b/backend/app/routers/crash_people.py
@@ -1,0 +1,270 @@
+"""Crash-people endpoints: parties (drivers/peds/cyclists involved) and
+victims (injured/killed people in a crash).
+
+Two scopes:
+  - Drill-down: /api/crashes/{collision_id}/parties|victims for one crash
+  - Cross-crash list: /api/parties|victims with optional filters
+
+Join key: rows in `crash_parties` and `crash_victims` carry
+`(collision_id, data_source)`. SWITRS and CCRS use overlapping numeric
+collision_ids, so any join to `crashes` MUST use both columns. See
+`docs/db-schema.md` for the 3.85M-collision-id-overlap detail.
+"""
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import (
+    FilterError,
+    parse_county_codes,
+    parse_year,
+)
+from app.models import Crash, CrashParty, CrashVictim
+from app.schemas.common import PaginatedResponse
+from app.schemas.crash_people import CrashPartyOut, CrashVictimOut
+
+router = APIRouter(tags=["crash-people"])
+
+
+# ── Drill-down endpoints (B1) ──────────────────────────────────────────
+
+
+@router.get(
+    "/crashes/{collision_id}/parties",
+    response_model=list[CrashPartyOut],
+)
+def list_parties_for_crash(
+    response: Response,
+    collision_id: int,
+    data_source: str = Query(..., pattern="^(ccrs|switrs)$"),
+    db: Session = Depends(get_db),
+):
+    """All parties (drivers, pedestrians, cyclists) for one crash.
+
+    `data_source` is required because (collision_id, data_source) is the
+    real join key — SWITRS and CCRS share the same numeric collision_id
+    space (3.85M overlapping IDs).
+
+    Example: `/api/crashes/2573749/parties?data_source=ccrs`
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+    rows = (
+        db.query(CrashParty)
+        .filter(
+            CrashParty.collision_id == collision_id,
+            CrashParty.data_source == data_source,
+        )
+        .order_by(CrashParty.party_number)
+        .all()
+    )
+    return [CrashPartyOut.model_validate(r) for r in rows]
+
+
+@router.get(
+    "/crashes/{collision_id}/victims",
+    response_model=list[CrashVictimOut],
+)
+def list_victims_for_crash(
+    response: Response,
+    collision_id: int,
+    data_source: str = Query(..., pattern="^(ccrs|switrs)$"),
+    db: Session = Depends(get_db),
+):
+    """All victims (injured, killed, witnesses, passengers) for one crash.
+
+    `data_source` is required (see /api/crashes/{collision_id}/parties).
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+    rows = (
+        db.query(CrashVictim)
+        .filter(
+            CrashVictim.collision_id == collision_id,
+            CrashVictim.data_source == data_source,
+        )
+        .order_by(CrashVictim.party_number)
+        .all()
+    )
+    return [CrashVictimOut.model_validate(r) for r in rows]
+
+
+# ── Cross-crash list endpoints (B2) ────────────────────────────────────
+
+
+def _parse_age_range(age_min: int | None, age_max: int | None) -> tuple[int | None, int | None]:
+    if age_min is not None and age_min < 0:
+        raise FilterError("age_min", "age_min must be >= 0.")
+    if age_max is not None and age_max < 0:
+        raise FilterError("age_max", "age_max must be >= 0.")
+    if age_min is not None and age_max is not None and age_min > age_max:
+        raise FilterError("age_min", "age_min must be <= age_max.")
+    return age_min, age_max
+
+
+def _parse_gender(raw: str | None) -> set[str] | None:
+    """Gender filter: accepts m/f/u (case-insensitive). DB stores M/F/U."""
+    if raw is None or raw == "":
+        return None
+    out: set[str] = set()
+    for part in raw.split(","):
+        token = part.strip().upper()
+        if not token:
+            continue
+        if token not in {"M", "F", "U"}:
+            raise FilterError(
+                "gender",
+                f"Unknown gender '{token}'. Allowed: m, f, u.",
+            )
+        out.add(token)
+    return out or None
+
+
+@router.get("/parties", response_model=PaginatedResponse[CrashPartyOut])
+def list_parties(
+    response: Response,
+    collision_id: int | None = Query(None),
+    data_source: str | None = Query(None, pattern="^(ccrs|switrs)$"),
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    gender: str | None = Query(None),
+    age_min: int | None = Query(None, ge=0, le=130),
+    age_max: int | None = Query(None, ge=0, le=130),
+    party_type: str | None = Query(None),
+    at_fault: bool | None = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    """Paginated cross-crash party query.
+
+    Filters:
+      - `collision_id` + `data_source`: drill into one crash (same as
+        /api/crashes/{collision_id}/parties but with paging)
+      - `county` (slug, multi), `year` (multi): JOINs to `crashes` on
+        (collision_id, data_source); slow without #106's covering index
+      - `gender=m,f,u`, `age_min`, `age_max`, `party_type`, `at_fault=true|false`:
+        direct column filters
+
+    `total` is always null here — counting party rows across millions
+    is too slow without indexes. Use `/api/stats?group_by=...` for totals.
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+    age_min_v, age_max_v = _parse_age_range(age_min, age_max)
+    gender_set = _parse_gender(gender)
+
+    q = db.query(CrashParty)
+
+    if collision_id is not None:
+        q = q.filter(CrashParty.collision_id == collision_id)
+    if data_source is not None:
+        q = q.filter(CrashParty.data_source == data_source)
+
+    needs_join = bool(county) or bool(year)
+    if needs_join:
+        q = q.join(
+            Crash,
+            (Crash.collision_id == CrashParty.collision_id)
+            & (Crash.data_source == CrashParty.data_source),
+        )
+        if county:
+            codes = parse_county_codes(county, get_slug_map(db))
+            if codes:
+                q = q.filter(Crash.county_code.in_(codes))
+        if year:
+            years = parse_year(year)
+            if years:
+                q = q.filter(Crash.crash_year.in_(years))
+
+    if gender_set:
+        q = q.filter(CrashParty.gender.in_(gender_set))
+    if age_min_v is not None:
+        q = q.filter(CrashParty.age >= age_min_v)
+    if age_max_v is not None:
+        q = q.filter(CrashParty.age <= age_max_v)
+    if party_type is not None:
+        q = q.filter(CrashParty.party_type == party_type)
+    if at_fault is not None:
+        q = q.filter(CrashParty.at_fault.is_(at_fault))
+
+    rows = q.order_by(CrashParty.id.desc()).offset(offset).limit(limit).all()
+    return PaginatedResponse[CrashPartyOut](
+        limit=limit,
+        offset=offset,
+        items=[CrashPartyOut.model_validate(r) for r in rows],
+        total=None,
+    )
+
+
+@router.get("/victims", response_model=PaginatedResponse[CrashVictimOut])
+def list_victims(
+    response: Response,
+    collision_id: int | None = Query(None),
+    data_source: str | None = Query(None, pattern="^(ccrs|switrs)$"),
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    gender: str | None = Query(None),
+    age_min: int | None = Query(None, ge=0, le=130),
+    age_max: int | None = Query(None, ge=0, le=130),
+    person_type: str | None = Query(None),
+    injury_severity: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    """Paginated cross-crash victim query (injured + killed + witnesses).
+
+    Filters: same shape as /api/parties, plus `person_type` (Driver,
+    Pedestrian, Bicyclist, Passenger) and `injury_severity` (Fatal,
+    Severe, Possible, etc. — raw CCRS values; not the same vocabulary
+    as crashes.severity).
+
+    `total` is always null — see /api/parties for rationale.
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+    age_min_v, age_max_v = _parse_age_range(age_min, age_max)
+    gender_set = _parse_gender(gender)
+
+    q = db.query(CrashVictim)
+
+    if collision_id is not None:
+        q = q.filter(CrashVictim.collision_id == collision_id)
+    if data_source is not None:
+        q = q.filter(CrashVictim.data_source == data_source)
+
+    needs_join = bool(county) or bool(year)
+    if needs_join:
+        q = q.join(
+            Crash,
+            (Crash.collision_id == CrashVictim.collision_id)
+            & (Crash.data_source == CrashVictim.data_source),
+        )
+        if county:
+            codes = parse_county_codes(county, get_slug_map(db))
+            if codes:
+                q = q.filter(Crash.county_code.in_(codes))
+        if year:
+            years = parse_year(year)
+            if years:
+                q = q.filter(Crash.crash_year.in_(years))
+
+    if gender_set:
+        q = q.filter(CrashVictim.gender.in_(gender_set))
+    if age_min_v is not None:
+        q = q.filter(CrashVictim.age >= age_min_v)
+    if age_max_v is not None:
+        q = q.filter(CrashVictim.age <= age_max_v)
+    if person_type is not None:
+        q = q.filter(CrashVictim.person_type == person_type)
+    if injury_severity is not None:
+        q = q.filter(CrashVictim.injury_severity == injury_severity)
+
+    rows = q.order_by(CrashVictim.id.desc()).offset(offset).limit(limit).all()
+    return PaginatedResponse[CrashVictimOut](
+        limit=limit,
+        offset=offset,
+        items=[CrashVictimOut.model_validate(r) for r in rows],
+        total=None,
+    )

--- a/backend/app/routers/crashes.py
+++ b/backend/app/routers/crashes.py
@@ -1,0 +1,134 @@
+"""Paginated crash detail endpoint."""
+
+import logging
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import (
+    FilterError,
+    build_crash_predicates,
+    parse_bool_flag,
+    parse_cause,
+    parse_county_codes,
+    parse_severity,
+    parse_year,
+)
+from app.models import Crash
+from app.schemas.common import PaginatedResponse
+from app.schemas.crashes import CrashOut
+
+router = APIRouter(tags=["crashes"])
+logger = logging.getLogger(__name__)
+
+# Bounded cost for `?include_total=true` on the 11M-row crashes table.
+# Two layers of defense, because neither is enough alone on B1ms Azure:
+#   1. Filter requirement — unfiltered COUNT(*) takes minutes; we reject
+#      `include_total=true` unless at least one filter is set.
+#   2. statement_timeout — even with filters, broad combinations (e.g.
+#      year + severity only) can take >60s without a covering index
+#      (#106). The timeout caps the worst case and returns total=null.
+# The real fix is covering-index work on the `crashes` table — see #106.
+# Future bulk/export endpoints (see #57) should use their own longer budget.
+COUNT_STATEMENT_TIMEOUT_MS = 5000
+
+
+@router.get("/crashes", response_model=PaginatedResponse[CrashOut])
+def list_crashes(
+    response: Response,
+    year: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    include_total: bool = Query(False),
+    db: Session = Depends(get_db),
+):
+    """Paginated crash detail records.
+
+    Filters (all multi-value, comma-separated):
+      - `year=2020,2023`
+      - `county=los-angeles,orange` (slugified county names)
+      - `severity=fatal,injury,property-damage-only`
+      - `cause=dui,speeding,lane-change,other`
+      - `alcohol=true|false`  (CCRS 2016+ only; excludes SWITRS)
+      - `distracted=true|false`  (CCRS 2016+ only)
+
+    Sorted by `crash_datetime DESC, id DESC`. `total` is `null` by default;
+    set `?include_total=true` to get a count — this requires at least one
+    filter (year, county, severity, cause, alcohol, distracted) to keep the
+    query bounded. For aggregate totals across all crashes, use `/api/stats`.
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+    years = parse_year(year)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+    alcohol_v = parse_bool_flag(alcohol, "alcohol")
+    distracted_v = parse_bool_flag(distracted, "distracted")
+
+    if include_total and not any([
+        years, county_codes, severities, causes,
+        alcohol_v is not None, distracted_v is not None,
+    ]):
+        raise FilterError(
+            "include_total",
+            "include_total=true requires at least one filter (year, county, "
+            "severity, cause, alcohol, distracted). Unbounded COUNT(*) over "
+            "11M crashes is too slow. For aggregate totals, use /api/stats.",
+        )
+
+    preds = build_crash_predicates(
+        years=years,
+        county_codes=county_codes,
+        severities=severities,
+        causes=causes,
+        alcohol=alcohol_v,
+        distracted=distracted_v,
+    )
+
+    q = db.query(Crash).filter(*preds).order_by(
+        Crash.crash_datetime.desc(), Crash.id.desc()
+    )
+
+    total: int | None = None
+    if include_total:
+        # Bounded COUNT — falls back to null on timeout so slow queries
+        # don't stall the client. (The filter requirement above handles
+        # the unfiltered case; this catches broad filter combos.)
+        #
+        # We use `SET` (session-scoped) rather than `SET LOCAL` (tx-scoped)
+        # because SQLAlchemy's transaction lifecycle around Session.execute
+        # is inconsistent enough that SET LOCAL sometimes doesn't apply to
+        # the subsequent Query.count(). The finally block resets the timeout
+        # before the connection goes back to the pool so the next request
+        # starts clean.
+        try:
+            db.execute(text(f"SET statement_timeout = {COUNT_STATEMENT_TIMEOUT_MS}"))
+            total = q.count()
+        except OperationalError as exc:
+            logger.warning(
+                "include_total COUNT exceeded %dms; returning total=null (%s)",
+                COUNT_STATEMENT_TIMEOUT_MS,
+                exc.__class__.__name__,
+            )
+            db.rollback()
+            total = None
+        finally:
+            db.execute(text("SET statement_timeout = 0"))
+
+    rows = q.offset(offset).limit(limit).all()
+    return PaginatedResponse[CrashOut](
+        limit=limit,
+        offset=offset,
+        items=[CrashOut.model_validate(r) for r in rows],
+        total=total,
+    )

--- a/backend/app/routers/demographics.py
+++ b/backend/app/routers/demographics.py
@@ -1,0 +1,34 @@
+"""Census ACS demographics per county × year."""
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import parse_county_codes, parse_year
+from app.models import Demographic
+from app.schemas.demographics import DemographicOut
+
+router = APIRouter(tags=["demographics"])
+
+
+@router.get("/demographics", response_model=list[DemographicOut])
+def list_demographics(
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """ACS demographics per county × year. All ~27 columns per row."""
+    response.headers["Cache-Control"] = "public, max-age=300"
+    q = db.query(Demographic)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(Demographic.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(Demographic.year.in_(years))
+    rows = q.order_by(Demographic.county_code, Demographic.year).all()
+    return [DemographicOut.model_validate(r) for r in rows]

--- a/backend/app/routers/meta.py
+++ b/backend/app/routers/meta.py
@@ -1,0 +1,42 @@
+"""Meta endpoints: data freshness, API metadata."""
+
+from fastapi import APIRouter, Depends, Response
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import EtlRun
+from app.schemas.meta import SourceFreshness
+
+router = APIRouter(tags=["meta"])
+
+
+@router.get("/meta/data-freshness", response_model=dict[str, SourceFreshness])
+def data_freshness(response: Response, db: Session = Depends(get_db)):
+    """Latest successful ETL run per source (for the 'data as of' pill).
+
+    Backed by `etl_runs`. Returns a dict keyed by source name.
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+    subq = (
+        db.query(
+            EtlRun.source,
+            func.max(EtlRun.finished_at).label("last_loaded_at"),
+        )
+        .filter(EtlRun.status == "success")
+        .group_by(EtlRun.source)
+        .subquery()
+    )
+    rows = (
+        db.query(EtlRun.source, EtlRun.finished_at, EtlRun.rows_loaded)
+        .join(
+            subq,
+            (EtlRun.source == subq.c.source)
+            & (EtlRun.finished_at == subq.c.last_loaded_at),
+        )
+        .all()
+    )
+    return {
+        source: SourceFreshness(last_loaded_at=finished_at, rows_loaded=rows_loaded)
+        for source, finished_at, rows_loaded in rows
+    }

--- a/backend/app/routers/reference.py
+++ b/backend/app/routers/reference.py
@@ -1,0 +1,168 @@
+"""Reference data endpoints: counties, hospitals, schools, road-miles,
+calenviroscreen, traffic-volumes, speed-limits."""
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import parse_county_codes
+from app.models import (
+    CalenviroScreen,
+    County,
+    Hospital,
+    RoadMile,
+    SchoolLocation,
+    SpeedLimit,
+    TrafficVolume,
+)
+from app.schemas.common import PaginatedResponse
+from app.schemas.reference import (
+    CalenviroScreenOut,
+    CountyOut,
+    HospitalOut,
+    RoadMileOut,
+    SchoolOut,
+    SpeedLimitOut,
+    TrafficVolumeOut,
+)
+
+router = APIRouter(tags=["reference"])
+
+_ONE_HOUR = "public, max-age=3600"
+
+
+@router.get("/counties", response_model=list[CountyOut])
+def list_counties(
+    response: Response,
+    include_geojson: bool = Query(True, description="Include decoded GeoJSON in each row."),
+    db: Session = Depends(get_db),
+):
+    """List all 58 CA counties with lookup and optional GeoJSON boundaries.
+
+    Example: `/api/counties?include_geojson=false`
+    """
+    response.headers["Cache-Control"] = _ONE_HOUR
+    rows = db.query(County).order_by(County.name).all()
+    out = [CountyOut.model_validate(row) for row in rows]
+    if not include_geojson:
+        for row in out:
+            row.geojson = None
+    return out
+
+
+@router.get("/hospitals", response_model=list[HospitalOut])
+def list_hospitals(
+    response: Response,
+    county: str | None = Query(None),
+    trauma_only: bool = Query(False),
+    db: Session = Depends(get_db),
+):
+    """List hospitals with optional county filter and trauma-center-only flag."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+    q = db.query(Hospital)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(Hospital.county_code.in_(codes))
+    if trauma_only:
+        q = q.filter(Hospital.trauma_center.isnot(None))
+    return [HospitalOut.model_validate(r) for r in q.all()]
+
+
+@router.get("/schools", response_model=PaginatedResponse[SchoolOut])
+def list_schools(
+    response: Response,
+    county: str | None = Query(None),
+    school_type: str | None = Query(None),
+    limit: int = Query(1000, ge=1, le=5000),
+    offset: int = Query(0, ge=0),
+    include_total: bool = Query(False),
+    db: Session = Depends(get_db),
+):
+    """Paginated K-12 schools. ~10K total CA schools, so pagination required."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+    q = db.query(SchoolLocation)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(SchoolLocation.county_code.in_(codes))
+    if school_type:
+        q = q.filter(SchoolLocation.school_type == school_type)
+    total: int | None = None
+    if include_total:
+        total = q.count()
+    rows = q.order_by(SchoolLocation.school_name).offset(offset).limit(limit).all()
+    return PaginatedResponse[SchoolOut](
+        limit=limit,
+        offset=offset,
+        items=[SchoolOut.model_validate(r) for r in rows],
+        total=total,
+    )
+
+
+@router.get("/calenviroscreen", response_model=list[CalenviroScreenOut])
+def list_calenviroscreen(
+    response: Response,
+    county: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """County-level CalEnviroScreen 4.0 scores (population-weighted averages)."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+    q = db.query(CalenviroScreen)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(CalenviroScreen.county_code.in_(codes))
+    return [CalenviroScreenOut.model_validate(r) for r in q.all()]
+
+
+@router.get("/road-miles", response_model=list[RoadMileOut])
+def list_road_miles(
+    response: Response,
+    county: str | None = Query(None),
+    f_system: int | None = Query(None, ge=1, le=7),
+    db: Session = Depends(get_db),
+):
+    """Caltrans road mileage by county and FHWA functional-system class (1-7)."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+    q = db.query(RoadMile)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(RoadMile.county_code.in_(codes))
+    if f_system is not None:
+        q = q.filter(RoadMile.f_system == f_system)
+    return [RoadMileOut.model_validate(r) for r in q.all()]
+
+
+@router.get("/traffic-volumes", response_model=list[TrafficVolumeOut])
+def list_traffic_volumes(
+    response: Response,
+    county: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Caltrans AADT summary, one row per county."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+    q = db.query(TrafficVolume)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(TrafficVolume.county_code.in_(codes))
+    return [TrafficVolumeOut.model_validate(r) for r in q.all()]
+
+
+@router.get("/speed-limits", response_model=list[SpeedLimitOut])
+def list_speed_limits(
+    response: Response,
+    county: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Caltrans posted-speed-limit segment summary, one row per (county, speed)."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+    q = db.query(SpeedLimit)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(SpeedLimit.county_code.in_(codes))
+    return [SpeedLimitOut.model_validate(r) for r in q.all()]

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1,0 +1,344 @@
+"""Aggregate crash stats, dispatched to the right materialized view."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy import Column, Integer, MetaData, SmallInteger, String, Table, func, select
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import (
+    FilterError,
+    parse_cause,
+    parse_county_codes,
+    parse_severity,
+    parse_year,
+)
+from app.models import County
+from app.schemas.stats import (
+    AgeBracketRow,
+    CauseRow,
+    CountyRow,
+    GenderRow,
+    GrandTotal,
+    HourRow,
+    SeverityRow,
+    YearRow,
+)
+
+router = APIRouter(tags=["stats"])
+
+# Materialized views declared explicitly — we do NOT use `autoload_with=engine`
+# because that would open a DB connection at module import time, which breaks
+# pure-unit tests and CI jobs without DB access. The columns here must mirror
+# `backend/migrations/versions/f3d4e5f6a7b8_add_stats_materialized_views.py`;
+# if that migration changes, update this block too.
+_metadata = MetaData()
+
+mv_year = Table(
+    "mv_crashes_by_year", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("crash_count", Integer),
+    Column("total_killed", Integer),
+    Column("total_injured", Integer),
+)
+
+mv_cause = Table(
+    "mv_crashes_by_cause", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("canonical_cause", String),
+    Column("crash_count", Integer),
+    Column("total_killed", Integer),
+    Column("total_injured", Integer),
+)
+
+mv_hour = Table(
+    "mv_crashes_by_hour", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("canonical_cause", String),
+    Column("crash_hour", SmallInteger),
+    Column("crash_count", Integer),
+)
+
+# Per-victim demographic aggregates. Backs ?group_by=gender / age_bracket.
+# Source: crash_victims JOINed to crashes on (collision_id, data_source).
+# Columns must mirror migration b5e9d3f1c8a4_add_mv_crash_victims_by_demographics.
+mv_victims = Table(
+    "mv_crash_victims_by_demographics", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("gender", String),
+    Column("age_bracket", String),
+    Column("victim_count", Integer),
+    Column("fatal_victim_count", Integer),
+)
+
+
+def _pick_view(group_by: str | None, has_cause_filter: bool):
+    if group_by == "hour":
+        return mv_hour
+    if group_by == "cause" or has_cause_filter:
+        return mv_cause
+    return mv_year
+
+
+def _apply_filters(stmt, view, years, county_codes, severities, causes):
+    if years:
+        stmt = stmt.where(view.c.crash_year.in_(years))
+    if county_codes:
+        stmt = stmt.where(view.c.county_code.in_(county_codes))
+    if severities:
+        stmt = stmt.where(view.c.severity.in_(severities))
+    if causes:
+        stmt = stmt.where(view.c.canonical_cause.in_(causes))
+    return stmt
+
+
+@router.get("/stats")
+def stats(
+    response: Response,
+    year: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    group_by: str | None = Query(
+        None,
+        pattern="^(county|year|cause|hour|severity|gender|age_bracket)$",
+    ),
+    db: Session = Depends(get_db),
+):
+    """Aggregated stats from materialized views.
+
+    `group_by` dispatches to one of four views (see `docs/db-schema.md`):
+      - `hour` -> mv_crashes_by_hour (counts only, no killed/injured)
+      - `cause` OR any cause filter -> mv_crashes_by_cause
+      - `gender` / `age_bracket` -> mv_crash_victims_by_demographics
+        (counts VICTIMS, not crashes — see GenderRow docstring)
+      - everything else -> mv_crashes_by_year
+
+    `alcohol` / `distracted` are not supported here (crash views don't carry
+    those columns). Use `/api/crashes` with those filters for drill-down.
+    `cause` filter is incompatible with `group_by=gender|age_bracket`
+    because the victim-demographics view doesn't carry canonical_cause.
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+    if alcohol is not None and alcohol != "":
+        raise FilterError(
+            "alcohol",
+            "Alcohol filter is not supported on /api/stats. Use /api/crashes?alcohol=true.",
+        )
+    if distracted is not None and distracted != "":
+        raise FilterError(
+            "distracted",
+            "Distracted filter is not supported on /api/stats. Use /api/crashes?distracted=true.",
+        )
+
+    years = parse_year(year)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+
+    if group_by in ("gender", "age_bracket") and causes:
+        raise FilterError(
+            "cause",
+            "cause filter is not supported with group_by=gender or age_bracket "
+            "(victim-demographics view doesn't carry canonical_cause).",
+        )
+
+    view = _pick_view(group_by, has_cause_filter=bool(causes))
+
+    # --- grand total (no group_by) ---
+    if group_by is None:
+        stmt = select(
+            func.coalesce(func.sum(view.c.crash_count), 0).label("total_crashes"),
+            func.coalesce(func.sum(view.c.total_killed), 0).label("total_killed"),
+            func.coalesce(func.sum(view.c.total_injured), 0).label("total_injured"),
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        row = db.execute(stmt).one()
+        return GrandTotal(
+            total_crashes=row.total_crashes,
+            total_killed=row.total_killed,
+            total_injured=row.total_injured,
+        ).model_dump()
+
+    # --- group_by=county ---
+    if group_by == "county":
+        stmt = (
+            select(
+                view.c.county_code,
+                County.name.label("county_name"),
+                func.sum(view.c.crash_count).label("crash_count"),
+                func.sum(view.c.total_killed).label("total_killed"),
+                func.sum(view.c.total_injured).label("total_injured"),
+            )
+            .select_from(view.join(County, County.code == view.c.county_code))
+            .group_by(view.c.county_code, County.name)
+            .order_by(func.sum(view.c.crash_count).desc())
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [
+            CountyRow(
+                county_code=r.county_code,
+                county_name=r.county_name,
+                crash_count=r.crash_count,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=year ---
+    if group_by == "year":
+        stmt = (
+            select(
+                view.c.crash_year.label("year"),
+                func.sum(view.c.crash_count).label("crash_count"),
+                func.sum(view.c.total_killed).label("total_killed"),
+                func.sum(view.c.total_injured).label("total_injured"),
+            )
+            .group_by(view.c.crash_year)
+            .order_by(view.c.crash_year)
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [
+            YearRow(
+                year=r.year,
+                crash_count=r.crash_count,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=cause ---
+    if group_by == "cause":
+        stmt = (
+            select(
+                view.c.canonical_cause,
+                func.sum(view.c.crash_count).label("crash_count"),
+                func.sum(view.c.total_killed).label("total_killed"),
+                func.sum(view.c.total_injured).label("total_injured"),
+            )
+            .group_by(view.c.canonical_cause)
+            .order_by(func.sum(view.c.crash_count).desc())
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [
+            CauseRow(
+                canonical_cause=r.canonical_cause,
+                crash_count=r.crash_count,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=hour (no killed/injured columns on this view) ---
+    if group_by == "hour":
+        stmt = (
+            select(
+                view.c.crash_hour.label("hour"),
+                func.sum(view.c.crash_count).label("crash_count"),
+            )
+            .group_by(view.c.crash_hour)
+            .order_by(view.c.crash_hour)
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [HourRow(hour=r.hour, crash_count=r.crash_count).model_dump() for r in rows]
+
+    # --- group_by=severity ---
+    if group_by == "severity":
+        stmt = (
+            select(
+                view.c.severity,
+                func.sum(view.c.crash_count).label("crash_count"),
+                func.sum(view.c.total_killed).label("total_killed"),
+                func.sum(view.c.total_injured).label("total_injured"),
+            )
+            .group_by(view.c.severity)
+            .order_by(func.sum(view.c.crash_count).desc())
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [
+            SeverityRow(
+                severity=r.severity,
+                crash_count=r.crash_count,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=gender (victim-demographics MV) ---
+    if group_by == "gender":
+        v = mv_victims
+        stmt = (
+            select(
+                v.c.gender,
+                func.sum(v.c.victim_count).label("victim_count"),
+                func.sum(v.c.fatal_victim_count).label("fatal_victim_count"),
+            )
+            .group_by(v.c.gender)
+            .order_by(func.sum(v.c.victim_count).desc())
+        )
+        if years:
+            stmt = stmt.where(v.c.crash_year.in_(years))
+        if county_codes:
+            stmt = stmt.where(v.c.county_code.in_(county_codes))
+        if severities:
+            stmt = stmt.where(v.c.severity.in_(severities))
+        rows = db.execute(stmt).all()
+        return [
+            GenderRow(
+                gender=r.gender,
+                victim_count=r.victim_count,
+                fatal_victim_count=r.fatal_victim_count,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=age_bracket (victim-demographics MV) ---
+    if group_by == "age_bracket":
+        v = mv_victims
+        stmt = (
+            select(
+                v.c.age_bracket,
+                func.sum(v.c.victim_count).label("victim_count"),
+                func.sum(v.c.fatal_victim_count).label("fatal_victim_count"),
+            )
+            .group_by(v.c.age_bracket)
+            .order_by(func.sum(v.c.victim_count).desc())
+        )
+        if years:
+            stmt = stmt.where(v.c.crash_year.in_(years))
+        if county_codes:
+            stmt = stmt.where(v.c.county_code.in_(county_codes))
+        if severities:
+            stmt = stmt.where(v.c.severity.in_(severities))
+        rows = db.execute(stmt).all()
+        return [
+            AgeBracketRow(
+                age_bracket=r.age_bracket,
+                victim_count=r.victim_count,
+                fatal_victim_count=r.fatal_victim_count,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # Unreachable — pattern validator catches bad values.
+    raise HTTPException(status_code=500, detail="Unreachable group_by branch")

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -1,0 +1,23 @@
+"""Shared Pydantic models: error envelope, pagination wrapper."""
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    detail: str
+    filter: str | None = Field(
+        default=None,
+        description="Which filter param was invalid, if any.",
+    )
+
+
+T = TypeVar("T")
+
+
+class PaginatedResponse(BaseModel, Generic[T]):
+    limit: int
+    offset: int
+    items: list[T]
+    total: int | None = None

--- a/backend/app/schemas/context.py
+++ b/backend/app/schemas/context.py
@@ -1,0 +1,83 @@
+"""Response models for context endpoints: unemployment, vehicles, drivers,
+data-quality, insights."""
+
+from pydantic import BaseModel
+
+
+class UnemploymentOut(BaseModel):
+    county_code: int
+    year: int
+    month: int
+    unemployment_rate: float | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class VehicleRegistrationOut(BaseModel):
+    county_code: int
+    year: int
+    total_vehicles: int | None = None
+    ev_vehicles: int | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class LicensedDriverOut(BaseModel):
+    county_code: int
+    year: int
+    driver_count: int | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class DataQualityStatOut(BaseModel):
+    county_code: int | None = None
+    year: int | None = None
+    total_crashes: int | None = None
+    crashes_with_coords: int | None = None
+    coords_pct: float | None = None
+    crashes_with_primary_factor: int | None = None
+    primary_factor_pct: float | None = None
+    crashes_with_weather: int | None = None
+    weather_pct: float | None = None
+    crashes_with_road_cond: int | None = None
+    road_cond_pct: float | None = None
+    crashes_with_lighting: int | None = None
+    lighting_pct: float | None = None
+    crashes_with_alcohol_flag: int | None = None
+    alcohol_flag_pct: float | None = None
+    crashes_alcohol_true: int | None = None
+    alcohol_true_pct: float | None = None
+    crashes_with_distraction_flag: int | None = None
+    distraction_flag_pct: float | None = None
+    crashes_distraction_true: int | None = None
+    distraction_true_pct: float | None = None
+    total_parties: int | None = None
+    parties_with_age: int | None = None
+    age_pct: float | None = None
+    parties_with_gender: int | None = None
+    gender_pct: float | None = None
+    parties_with_sobriety: int | None = None
+    sobriety_pct: float | None = None
+    total_victims: int | None = None
+    victims_with_injury_severity: int | None = None
+    injury_severity_pct: float | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class CountyInsightOut(BaseModel):
+    county_code: int
+    year: int
+    total_crashes: int | None = None
+    total_killed: int | None = None
+    total_injured: int | None = None
+    crash_rate_per_capita: float | None = None
+    top_cause: str | None = None
+    top_cause_pct: float | None = None
+    yoy_change_pct: float | None = None
+    peak_hour: int | None = None
+    dui_pct: float | None = None
+    narrative: str | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/crash_people.py
+++ b/backend/app/schemas/crash_people.py
@@ -1,0 +1,43 @@
+"""Response models for /api/crashes/{collision_id}/parties|victims and
+/api/parties|victims endpoints."""
+
+from pydantic import BaseModel
+
+
+class CrashPartyOut(BaseModel):
+    id: int
+    party_id: int
+    collision_id: int
+    data_source: str | None = None
+    party_number: int | None = None
+    party_type: str | None = None
+    at_fault: bool | None = None
+    gender: str | None = None
+    age: int | None = None
+    sobriety: str | None = None
+    vehicle_type: str | None = None
+    vehicle_year: int | None = None
+    vehicle_make: str | None = None
+    speed_limit: int | None = None
+    movement: str | None = None
+    safety_equipment: str | None = None
+    cell_phone_use: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class CrashVictimOut(BaseModel):
+    id: int
+    victim_id: int
+    collision_id: int
+    data_source: str | None = None
+    party_number: int | None = None
+    age: int | None = None
+    gender: str | None = None
+    injury_severity: str | None = None
+    person_type: str | None = None
+    seat_position: str | None = None
+    safety_equipment: str | None = None
+    ejected: str | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/crashes.py
+++ b/backend/app/schemas/crashes.py
@@ -1,0 +1,30 @@
+"""Response model for /api/crashes."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class CrashOut(BaseModel):
+    id: int
+    collision_id: int
+    data_source: str | None = None
+    crash_datetime: datetime
+    county_code: int
+    county_name: str | None = None
+    city_name: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    severity: str | None = None
+    canonical_cause: str | None = None
+    primary_factor: str | None = None
+    number_killed: int | None = None
+    number_injured: int | None = None
+    weather: str | None = None
+    road_condition: str | None = None
+    lighting: str | None = None
+    is_alcohol_involved: bool | None = None
+    is_distraction_involved: bool | None = None
+    pedestrian_involved: bool | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/demographics.py
+++ b/backend/app/schemas/demographics.py
@@ -1,0 +1,68 @@
+"""Response model for /api/demographics."""
+
+from pydantic import BaseModel
+
+
+class DemographicOut(BaseModel):
+    county_code: int
+    year: int
+    population: int | None = None
+    median_age: float | None = None
+    median_income: int | None = None
+    population_density: float | None = None
+
+    # Race
+    pct_white: float | None = None
+    pct_black: float | None = None
+    pct_asian: float | None = None
+    pct_hispanic: float | None = None
+    pct_other_race: float | None = None
+
+    # Age brackets
+    pct_under_18: float | None = None
+    pct_18_24: float | None = None
+    pct_25_44: float | None = None
+    pct_45_64: float | None = None
+    pct_65_plus: float | None = None
+
+    # Sex
+    pct_male: float | None = None
+    pct_female: float | None = None
+
+    # Economic
+    per_capita_income: int | None = None
+
+    # Exposure + equity
+    mean_travel_time_to_work: float | None = None  # minutes
+    pct_foreign_born: float | None = None
+
+    # Stress / household
+    pct_rent_burdened: float | None = None  # paying 30%+ of income in rent
+    pct_enrolled_in_school: float | None = None
+
+    # Niche risk correlates
+    pct_veteran: float | None = None
+    pct_with_disability: float | None = None
+
+    # Socioeconomic
+    poverty_rate: float | None = None
+    pct_bachelors_or_higher: float | None = None
+    pct_high_school_or_higher: float | None = None
+
+    # Housing / transportation
+    pct_no_vehicle: float | None = None
+    pct_owner_occupied_housing: float | None = None
+
+    # Commute
+    commute_drive_alone_pct: float | None = None
+    commute_carpool_pct: float | None = None
+    commute_transit_pct: float | None = None
+    commute_walk_pct: float | None = None
+    commute_bike_pct: float | None = None
+    commute_wfh_pct: float | None = None
+
+    # Language
+    pct_english_only: float | None = None
+    pct_spanish_speaking: float | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/meta.py
+++ b/backend/app/schemas/meta.py
@@ -1,0 +1,10 @@
+"""Response model for /api/meta/data-freshness."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class SourceFreshness(BaseModel):
+    last_loaded_at: datetime | None
+    rows_loaded: int | None

--- a/backend/app/schemas/reference.py
+++ b/backend/app/schemas/reference.py
@@ -1,0 +1,111 @@
+"""Response models for reference endpoints."""
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, field_validator
+
+
+class CountyOut(BaseModel):
+    code: int
+    name: str
+    fips: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    population: int | None = None
+    land_area_sq_miles: float | None = None
+    geojson: dict[str, Any] | None = None
+
+    @field_validator("geojson", mode="before")
+    @classmethod
+    def decode_geojson(cls, v: Any) -> Any:
+        """DB stores GeoJSON as TEXT; decode to JSON for the response."""
+        if v is None or isinstance(v, dict):
+            return v
+        if isinstance(v, str):
+            return json.loads(v) if v else None
+        return v
+
+    model_config = {"from_attributes": True}
+
+
+class HospitalOut(BaseModel):
+    facility_id: str
+    facility_name: str
+    facility_type: str | None = None
+    county_code: int
+    city: str | None = None
+    address: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    bed_capacity: int | None = None
+    trauma_center: str | None = None
+    trauma_pediatric: str | None = None
+    status: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class SchoolOut(BaseModel):
+    cds_code: str
+    school_name: str
+    county_code: int
+    city: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    school_type: str | None = None
+    status: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class CalenviroScreenOut(BaseModel):
+    county_code: int
+    ces_score: float | None = None
+    ces_percentile: float | None = None
+    pollution_burden: float | None = None
+    pop_characteristics: float | None = None
+    pm25_score: float | None = None
+    ozone_score: float | None = None
+    diesel_pm_score: float | None = None
+    pesticide_score: float | None = None
+    traffic_score: float | None = None
+    # Population-characteristics sub-scores
+    poverty_pct: float | None = None
+    unemployment_pct: float | None = None
+    education_pct: float | None = None
+    linguistic_isolation_pct: float | None = None
+    housing_burden_pct: float | None = None
+    # Provenance
+    tract_count: int | None = None
+    total_population: int | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class RoadMileOut(BaseModel):
+    county_code: int
+    f_system: int
+    segment_count: int | None = None
+    total_miles: float | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class TrafficVolumeOut(BaseModel):
+    county_code: int
+    total_aadt: int | None = None
+    segment_count: int | None = None
+    avg_aadt_per_segment: int | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class SpeedLimitOut(BaseModel):
+    county_code: int
+    speed_limit: int
+    segment_count: int | None = None
+    avg_lanes: float | None = None
+    total_aadt: int | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -1,0 +1,61 @@
+"""Response models for /api/stats — shape varies by group_by."""
+
+from pydantic import BaseModel
+
+
+class GrandTotal(BaseModel):
+    total_crashes: int
+    total_killed: int
+    total_injured: int
+
+
+class CountyRow(BaseModel):
+    county_code: int
+    county_name: str | None = None
+    crash_count: int
+    total_killed: int
+    total_injured: int
+
+
+class YearRow(BaseModel):
+    year: int
+    crash_count: int
+    total_killed: int
+    total_injured: int
+
+
+class CauseRow(BaseModel):
+    canonical_cause: str
+    crash_count: int
+    total_killed: int
+    total_injured: int
+
+
+class HourRow(BaseModel):
+    hour: int
+    crash_count: int
+
+
+class SeverityRow(BaseModel):
+    severity: str
+    crash_count: int
+    total_killed: int
+    total_injured: int
+
+
+class GenderRow(BaseModel):
+    """Row from /api/stats?group_by=gender. Counts VICTIMS, not crashes —
+    sourced from mv_crash_victims_by_demographics, so a single fatal crash
+    with 1 driver and 2 injured passengers contributes 3 to victim_count."""
+    gender: str
+    victim_count: int
+    fatal_victim_count: int
+
+
+class AgeBracketRow(BaseModel):
+    """Row from /api/stats?group_by=age_bracket. Same victim-count caveat
+    as GenderRow. Buckets: under_18, 18_24, 25_44, 45_64, over_65, unknown
+    (matches the demographics table conventions)."""
+    age_bracket: str
+    victim_count: int
+    fatal_victim_count: int

--- a/backend/etl/census_api.py
+++ b/backend/etl/census_api.py
@@ -1,17 +1,21 @@
 """Pull demographic data from the Census Bureau ACS API.
 
-Gets 28 fields per county per year — population, income, race/ethnicity,
-age brackets, poverty, education, vehicle ownership, housing, and language.
-Uses the ACS 5-year estimates for 2010+ (all 58 counties) and 1-year
-estimates for 2005-2009 (only covers counties over 65K population).
+Gets ~36 fields per county per year — population, income, race/ethnicity,
+age brackets, poverty, education, vehicle ownership, housing, language,
+sex distribution, travel time, foreign-born share, rent burden, school
+enrollment, veteran status, and disability rate. Uses the ACS 5-year
+estimates for 2010+ (all 58 counties) and 1-year estimates for 2005-2009
+(only covers counties over 65K population).
 
-We make up to 3 API requests per year because the Census caps you at
+We make up to 4 API requests per year because the Census caps you at
 50 variables per request:
-  1. Core stuff — population, income, commute, race, poverty, vehicles,
-     housing, language (24 variables)
-  2. Age distribution — 47 cells from B01001 that we sum into 5 brackets
+  1. Profile — core + per-capita income, travel time, foreign-born,
+     rent burden, school enrollment, veteran status (~38 variables)
+  2. Age distribution — 47 cells from B01001 summed into 5 brackets +
+     sex totals
   3. Education — B15003, but this table doesn't exist before 2012 in the
      5-year data so we just skip it gracefully for older years
+  4. Disability — B18101 sex-by-age-by-disability (13 variables)
 """
 
 import time
@@ -54,7 +58,48 @@ PROFILE_VARIABLES = {
     "B16001_001E": "lang_total",        # Population 5 years and over
     "B16001_002E": "lang_english_only",
     "B16001_003E": "lang_spanish",
+    # Per-capita income (B19301 — single value, no division needed)
+    "B19301_001E": "per_capita_income",
+    # Travel time to work: aggregate minutes / total workers 16+ who commuted.
+    # Reuses B08006_001E (commute_total above) as the denominator — same
+    # universe as B08301_001E but B08301 isn't published for ACS1 2005.
+    "B08013_001E": "travel_time_agg",
+    # Place of Birth (B05002 — foreign-born share)
+    "B05002_001E": "birth_total",
+    "B05002_013E": "birth_foreign",     # Foreign born
+    # Gross Rent as % of Household Income (B25070 — rent-burdened %)
+    "B25070_001E": "rent_total",        # Total renter households
+    "B25070_007E": "rent_30_34",        # 30-34.9% of income in rent
+    "B25070_008E": "rent_35_39",        # 35-39.9%
+    "B25070_009E": "rent_40_49",        # 40-49.9%
+    "B25070_010E": "rent_50_plus",      # 50%+ — severely cost-burdened
+    # School Enrollment (B14001 — pop 3+)
+    "B14001_001E": "school_total",
+    "B14001_002E": "school_enrolled",
+    # Veteran Status (B21001 — civilian pop 18+)
+    "B21001_001E": "vet_total",
+    "B21001_002E": "vet_veteran",
 }
+
+# ── Request 4: disability (13 variables) ──────────────────────────────
+# B18101 — Sex by Age by Disability Status. We pull the total and the
+# twelve "With a disability" cells (6 age brackets × 2 sexes), sum them,
+# divide by total to get the overall disability rate.
+DISABILITY_VARIABLES = [
+    "B18101_001E",                       # total universe
+    # Male "with a disability" cells (6 age brackets)
+    "B18101_004E", "B18101_007E", "B18101_010E",
+    "B18101_013E", "B18101_016E", "B18101_019E",
+    # Female "with a disability" cells (6 age brackets)
+    "B18101_023E", "B18101_026E", "B18101_029E",
+    "B18101_032E", "B18101_035E", "B18101_038E",
+]
+_DISABILITY_WITH_CELLS = [
+    "B18101_004E", "B18101_007E", "B18101_010E",
+    "B18101_013E", "B18101_016E", "B18101_019E",
+    "B18101_023E", "B18101_026E", "B18101_029E",
+    "B18101_032E", "B18101_035E", "B18101_038E",
+]
 
 # ── Request 3 (optional): education (10 variables) ────────────────────
 # B15003 — Educational Attainment for 25+
@@ -242,6 +287,37 @@ def _process_profile(record: dict) -> dict:
     lang_english = _safe_int(record.get("B16001_002E"))
     lang_spanish = _safe_int(record.get("B16001_003E"))
 
+    # Per-capita income — direct from B19301
+    per_capita_income = _safe_int(record.get("B19301_001E"))
+
+    # Mean travel time to work (minutes) = aggregate minutes / workers 16+
+    # who commute. Uses commute_total above (same universe as B08301).
+    travel_agg = _safe_int(record.get("B08013_001E"))
+    mean_travel_time = None
+    if travel_agg is not None and commute_total is not None and commute_total > 0:
+        mean_travel_time = round(travel_agg / commute_total, 2)
+
+    # Foreign-born share
+    birth_total = _safe_int(record.get("B05002_001E"))
+    birth_foreign = _safe_int(record.get("B05002_013E"))
+
+    # Rent burden — renters paying 30%+ of income (HUD definition)
+    rent_total = _safe_int(record.get("B25070_001E"))
+    rent_burdened_cells = [
+        _safe_int(record.get(f"B25070_{i:03d}E")) for i in (7, 8, 9, 10)
+    ]
+    rent_burdened = None
+    if any(v is not None for v in rent_burdened_cells):
+        rent_burdened = sum(v for v in rent_burdened_cells if v is not None)
+
+    # School enrollment (pop 3+)
+    school_total = _safe_int(record.get("B14001_001E"))
+    school_enrolled = _safe_int(record.get("B14001_002E"))
+
+    # Veteran status (civilian pop 18+)
+    vet_total = _safe_int(record.get("B21001_001E"))
+    vet_veteran = _safe_int(record.get("B21001_002E"))
+
     return {
         "county_fips": record["county"],
         "population": population,
@@ -265,6 +341,12 @@ def _process_profile(record: dict) -> dict:
         "pct_owner_occupied_housing": _pct(housing_owner, housing_total),
         "pct_english_only": _pct(lang_english, lang_total),
         "pct_spanish_speaking": _pct(lang_spanish, lang_total),
+        "per_capita_income": per_capita_income,
+        "mean_travel_time_to_work": mean_travel_time,
+        "pct_foreign_born": _pct(birth_foreign, birth_total),
+        "pct_rent_burdened": _pct(rent_burdened, rent_total),
+        "pct_enrolled_in_school": _pct(school_enrolled, school_total),
+        "pct_veteran": _pct(vet_veteran, vet_total),
     }
 
 
@@ -272,6 +354,7 @@ def _process_age(record: dict) -> dict:
     """Process a single county row from the age distribution request.
 
     Sums male + female cells into 5 age brackets, then converts to percentages.
+    Also computes total male / female percentages (sums across all age cells).
     """
     total_pop = _safe_int(record.get("B01001_001E"))
 
@@ -288,6 +371,13 @@ def _process_age(record: dict) -> dict:
         else:
             brackets[bracket_name] = None
 
+    # Sex totals — sum across all male age cells (3-25) and female age cells
+    # (27-49). Used independently of the age brackets for sex distribution.
+    all_male_cells = list(range(3, 26))
+    all_female_cells = list(range(27, 50))
+    male_total = _sum_cells(record, all_male_cells)
+    female_total = _sum_cells(record, all_female_cells)
+
     return {
         "county_fips": record["county"],
         "pct_under_18": _pct(brackets["under_18"], total_pop),
@@ -295,6 +385,28 @@ def _process_age(record: dict) -> dict:
         "pct_25_44": _pct(brackets["25_44"], total_pop),
         "pct_45_64": _pct(brackets["45_64"], total_pop),
         "pct_65_plus": _pct(brackets["65_plus"], total_pop),
+        "pct_male": _pct(male_total, total_pop),
+        "pct_female": _pct(female_total, total_pop),
+    }
+
+
+def _process_disability(record: dict) -> dict:
+    """Process a single county row from the B18101 disability request.
+
+    Sums the twelve "With a disability" cells (6 age brackets × 2 sexes)
+    and divides by the total universe to get the overall disability rate.
+    """
+    total = _safe_int(record.get("B18101_001E"))
+    with_disability_cells = [
+        _safe_int(record.get(cell)) for cell in _DISABILITY_WITH_CELLS
+    ]
+    with_disability = None
+    if any(v is not None for v in with_disability_cells):
+        with_disability = sum(v for v in with_disability_cells if v is not None)
+
+    return {
+        "county_fips": record["county"],
+        "pct_with_disability": _pct(with_disability, total),
     }
 
 
@@ -366,6 +478,19 @@ def fetch_county_demographics(year: int, api_key: str) -> list[dict]:
     except (httpx.HTTPStatusError, httpx.RequestError):
         logger.info("Education data (B15003) not available for %d — skipping", year)
 
+    # Request 4 (optional): disability — B18101. Skip gracefully if absent.
+    disability_by_fips = {}
+    try:
+        disability_codes = ",".join(DISABILITY_VARIABLES)
+        disability_url = _build_url(year, api_key, disability_codes)
+        disability_data = _fetch_with_retry(disability_url)
+        disability_rows = _parse_response(disability_data)
+        for row in disability_rows:
+            disability_result = _process_disability(row)
+            disability_by_fips[disability_result["county_fips"]] = disability_result
+    except (httpx.HTTPStatusError, httpx.RequestError):
+        logger.info("Disability data (B18101) not available for %d — skipping", year)
+
     # Build lookup for age data by county FIPS
     age_by_fips = {}
     for row in age_rows:
@@ -386,6 +511,8 @@ def fetch_county_demographics(year: int, api_key: str) -> list[dict]:
             "pct_25_44": age_result.get("pct_25_44"),
             "pct_45_64": age_result.get("pct_45_64"),
             "pct_65_plus": age_result.get("pct_65_plus"),
+            "pct_male": age_result.get("pct_male"),
+            "pct_female": age_result.get("pct_female"),
         })
 
         # Merge in education data if available
@@ -393,6 +520,11 @@ def fetch_county_demographics(year: int, api_key: str) -> list[dict]:
         if edu_result:
             profile_result["pct_high_school_or_higher"] = edu_result.get("pct_high_school_or_higher")
             profile_result["pct_bachelors_or_higher"] = edu_result.get("pct_bachelors_or_higher")
+
+        # Merge in disability data if available
+        disability_result = disability_by_fips.get(fips, {})
+        if disability_result:
+            profile_result["pct_with_disability"] = disability_result.get("pct_with_disability")
 
         results.append(profile_result)
 

--- a/backend/etl/load_demographics.py
+++ b/backend/etl/load_demographics.py
@@ -104,6 +104,17 @@ def transform_to_demographic_kwargs(
         "pct_25_44": api_row.get("pct_25_44"),
         "pct_45_64": api_row.get("pct_45_64"),
         "pct_65_plus": api_row.get("pct_65_plus"),
+        # Sex
+        "pct_male": api_row.get("pct_male"),
+        "pct_female": api_row.get("pct_female"),
+        # Economic / exposure / equity / niche
+        "per_capita_income": api_row.get("per_capita_income"),
+        "mean_travel_time_to_work": api_row.get("mean_travel_time_to_work"),
+        "pct_foreign_born": api_row.get("pct_foreign_born"),
+        "pct_rent_burdened": api_row.get("pct_rent_burdened"),
+        "pct_enrolled_in_school": api_row.get("pct_enrolled_in_school"),
+        "pct_veteran": api_row.get("pct_veteran"),
+        "pct_with_disability": api_row.get("pct_with_disability"),
         # Socioeconomic
         "poverty_rate": api_row.get("poverty_rate"),
         "pct_bachelors_or_higher": api_row.get("pct_bachelors_or_higher"),

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -1,9 +1,10 @@
-"""Refresh the three StatsPage materialized views.
+"""Refresh the StatsPage materialized views.
 
-The views are defined in migration f3d4e5f6a7b8:
-  - mv_crashes_by_hour
-  - mv_crashes_by_cause
-  - mv_crashes_by_year
+Views and the migrations that defined them:
+  - mv_crashes_by_hour                     (f3d4e5f6a7b8)
+  - mv_crashes_by_cause                    (f3d4e5f6a7b8)
+  - mv_crashes_by_year                     (f3d4e5f6a7b8)
+  - mv_crash_victims_by_demographics       (b5e9d3f1c8a4) — gender / age
 
 They were created WITH NO DATA — the first run of this module populates
 them. Subsequent runs do a CONCURRENTLY refresh (doesn't block reads)
@@ -33,9 +34,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 _VIEWS = [
-    "mv_crashes_by_year",    # smallest first, quick sanity check
+    "mv_crashes_by_year",                  # smallest first, quick sanity check
     "mv_crashes_by_cause",
-    "mv_crashes_by_hour",    # largest
+    "mv_crashes_by_hour",                  # largest of the crash MVs
+    "mv_crash_victims_by_demographics",    # JOIN-based, ~140K rows
 ]
 
 

--- a/backend/migrations/versions/a4f8c2d9e1b3_add_pct_male_pct_female_to_demographics.py
+++ b/backend/migrations/versions/a4f8c2d9e1b3_add_pct_male_pct_female_to_demographics.py
@@ -1,0 +1,32 @@
+"""add pct_male and pct_female to demographics
+
+Adds two nullable Float columns derived from Census table B01001
+(Sex by Age). The ETL already pulls all 47 male+female age cells —
+we just compute the totals as percentages of population.
+
+Existing rows stay NULL until the demographics ETL re-runs.
+
+Revision ID: a4f8c2d9e1b3
+Revises: f3d4e5f6a7b8
+Create Date: 2026-04-18 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a4f8c2d9e1b3'
+down_revision: Union[str, None] = 'f3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('demographics', sa.Column('pct_male', sa.Float(), nullable=True))
+    op.add_column('demographics', sa.Column('pct_female', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('demographics', 'pct_female')
+    op.drop_column('demographics', 'pct_male')

--- a/backend/migrations/versions/b5e9d3f1c8a4_add_mv_crash_victims_by_demographics.py
+++ b/backend/migrations/versions/b5e9d3f1c8a4_add_mv_crash_victims_by_demographics.py
@@ -1,0 +1,88 @@
+"""create materialized view mv_crash_victims_by_demographics
+
+Powers /api/stats?group_by=gender|age_bracket. Joins crash_victims to
+crashes on (collision_id, data_source) — see docs/db-schema.md for why
+that's the only correct join key — and aggregates victim counts by
+(county, year, severity, gender, age_bracket).
+
+Age brackets mirror the demographics convention (under_18, 18_24, 25_44,
+45_64, 65_plus) so victim distributions can be compared against county
+population distributions without re-bucketing.
+
+Estimated size: 58 counties × ~25 years × 4 severities × 4 genders ×
+6 age buckets = ~140K rows.
+
+Refresh is concurrent (UNIQUE index below); the ETL orchestrator
+(issue #101) should refresh this alongside the existing 3 MVs.
+
+Revision ID: b5e9d3f1c8a4
+Revises: a4f8c2d9e1b3
+Create Date: 2026-04-18 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'b5e9d3f1c8a4'
+down_revision: Union[str, None] = 'a4f8c2d9e1b3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # GROUP BY must use the same COALESCE/CASE expressions as SELECT so that
+    # rows where (e.g.) cv.gender is NULL don't form a separate group from
+    # rows where cv.gender = 'U' — both collapse to 'U' in the SELECT and
+    # would otherwise violate the UNIQUE index below on first refresh.
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_crash_victims_by_demographics AS
+        SELECT
+            c.county_code,
+            c.crash_year,
+            COALESCE(c.severity, 'Unknown') AS severity,
+            COALESCE(cv.gender, 'U') AS gender,
+            CASE
+                WHEN cv.age IS NULL THEN 'unknown'
+                WHEN cv.age < 18  THEN 'under_18'
+                WHEN cv.age <= 24 THEN '18_24'
+                WHEN cv.age <= 44 THEN '25_44'
+                WHEN cv.age <= 64 THEN '45_64'
+                ELSE 'over_65'
+            END AS age_bracket,
+            COUNT(*)::integer AS victim_count,
+            SUM(CASE WHEN cv.injury_severity = 'Fatal' THEN 1 ELSE 0 END)::integer AS fatal_victim_count
+        FROM crash_victims cv
+        JOIN crashes c
+          ON c.collision_id = cv.collision_id
+         AND c.data_source = cv.data_source
+        WHERE c.crash_year IS NOT NULL
+        GROUP BY
+            c.county_code,
+            c.crash_year,
+            COALESCE(c.severity, 'Unknown'),
+            COALESCE(cv.gender, 'U'),
+            CASE
+                WHEN cv.age IS NULL THEN 'unknown'
+                WHEN cv.age < 18  THEN 'under_18'
+                WHEN cv.age <= 24 THEN '18_24'
+                WHEN cv.age <= 44 THEN '25_44'
+                WHEN cv.age <= 64 THEN '45_64'
+                ELSE 'over_65'
+            END
+        WITH NO DATA
+    """)
+    # UNIQUE index required for REFRESH CONCURRENTLY.
+    op.execute("""
+        CREATE UNIQUE INDEX ix_mv_crash_victims_by_demographics_pk
+        ON mv_crash_victims_by_demographics
+        (county_code, crash_year, severity, gender, age_bracket)
+    """)
+    op.execute("""
+        CREATE INDEX ix_mv_crash_victims_by_demographics_county_year
+        ON mv_crash_victims_by_demographics (county_code, crash_year)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_crash_victims_by_demographics")

--- a/backend/migrations/versions/c6f3a2e7b9d1_add_seven_demographic_fields.py
+++ b/backend/migrations/versions/c6f3a2e7b9d1_add_seven_demographic_fields.py
@@ -1,0 +1,51 @@
+"""add 7 more demographic fields
+
+Adds per_capita_income, mean_travel_time_to_work, pct_foreign_born,
+pct_rent_burdened, pct_enrolled_in_school, pct_veteran, pct_with_disability
+to the demographics table. All nullable; existing rows stay NULL until the
+ETL re-runs.
+
+Sources:
+  B19301 — per capita income (direct value)
+  B08013 / B08301 — aggregate travel time / workers 16+
+  B05002 — place of birth (foreign-born share)
+  B25070 — gross rent as % of household income
+  B14001 — school enrollment
+  B21001 — veteran status
+  B18101 — sex by age by disability status
+
+Revision ID: c6f3a2e7b9d1
+Revises: b5e9d3f1c8a4
+Create Date: 2026-04-18 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c6f3a2e7b9d1'
+down_revision: Union[str, None] = 'b5e9d3f1c8a4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_NEW_COLUMNS = [
+    ('per_capita_income', sa.Integer()),
+    ('mean_travel_time_to_work', sa.Float()),
+    ('pct_foreign_born', sa.Float()),
+    ('pct_rent_burdened', sa.Float()),
+    ('pct_enrolled_in_school', sa.Float()),
+    ('pct_veteran', sa.Float()),
+    ('pct_with_disability', sa.Float()),
+]
+
+
+def upgrade() -> None:
+    for name, type_ in _NEW_COLUMNS:
+        op.add_column('demographics', sa.Column(name, type_, nullable=True))
+
+
+def downgrade() -> None:
+    for name, _ in reversed(_NEW_COLUMNS):
+        op.drop_column('demographics', name)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+markers =
+    unit: fast unit tests with no external deps (default)
+    integration: API tests that need a real Postgres
+addopts = -ra --strict-markers

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -1,0 +1,261 @@
+"""Integration-test fixtures: dedicated Postgres DB, seed data, FastAPI client."""
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+# CRITICAL: override DATABASE_URL BEFORE importing anything from `app`.
+# app.settings reads it at import time (pydantic-settings), and
+# app.database.engine is constructed from that value — so if we import
+# app before setting this, the tests would run against the default URL
+# (Azure) instead of the local test DB.
+TEST_DB_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql://calsight:calsight_dev@localhost:5433/calsight_test",
+)
+ADMIN_URL = os.environ.get(
+    "TEST_DATABASE_ADMIN_URL",
+    "postgresql://calsight:calsight_dev@localhost:5433/postgres",
+)
+os.environ["DATABASE_URL"] = TEST_DB_URL
+
+import pytest  # noqa: E402
+from alembic import command as alembic_command  # noqa: E402
+from alembic.config import Config as AlembicConfig  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy.orm import Session, sessionmaker  # noqa: E402
+
+from app.database import get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models import (  # noqa: E402
+    CalenviroScreen,
+    County,
+    Crash,
+    CrashParty,
+    CrashVictim,
+    DataQualityStat,
+    Demographic,
+    EtlRun,
+    Hospital,
+    LicensedDriver,
+    RoadMile,
+    SchoolLocation,
+    SpeedLimit,
+    TrafficVolume,
+    UnemploymentRate,
+    VehicleRegistration,
+)
+
+
+def _create_test_db() -> None:
+    admin = create_engine(ADMIN_URL, isolation_level="AUTOCOMMIT")
+    with admin.connect() as conn:
+        conn.execute(text("DROP DATABASE IF EXISTS calsight_test"))
+        conn.execute(text("CREATE DATABASE calsight_test"))
+    admin.dispose()
+
+
+def _run_alembic_migrations() -> None:
+    cfg_path = Path(__file__).parents[2] / "alembic.ini"
+    cfg = AlembicConfig(str(cfg_path))
+    cfg.set_main_option("sqlalchemy.url", TEST_DB_URL)
+    alembic_command.upgrade(cfg, "head")
+
+
+def _seed(session: Session) -> None:
+    # 5 counties
+    counties = [
+        County(code=1, name="Alameda", fips="06001", latitude=37.65, longitude=-121.91, population=1650000, land_area_sq_miles=738.0, geojson="{}"),
+        County(code=19, name="Los Angeles", fips="06037", latitude=34.31, longitude=-118.22, population=9861000, land_area_sq_miles=4058.0, geojson="{}"),
+        County(code=30, name="Orange", fips="06059", latitude=33.70, longitude=-117.76, population=3186000, land_area_sq_miles=791.0, geojson="{}"),
+        County(code=34, name="Sacramento", fips="06067", latitude=38.47, longitude=-121.34, population=1555000, land_area_sq_miles=964.0, geojson="{}"),
+        County(code=38, name="San Francisco", fips="06075", latitude=37.77, longitude=-122.45, population=873965, land_area_sq_miles=46.9, geojson="{}"),
+    ]
+    session.add_all(counties)
+    session.flush()
+
+    # 5 crashes: 2 SWITRS pre-2016, 3 CCRS with alcohol/distraction flags.
+    # IMPORTANT: include a SWITRS and CCRS crash with the SAME collision_id
+    # to lock in the (collision_id, data_source) join-safety test.
+    crashes = [
+        Crash(id=1, collision_id=100, data_source="switrs",
+              crash_datetime=datetime(2015, 6, 1, 14, 0), county_code=19,
+              crash_year=2015, crash_hour=14, severity="Fatal",
+              canonical_cause="dui", number_killed=1, number_injured=0,
+              county_name="Los Angeles", latitude=34.0, longitude=-118.0,
+              is_alcohol_involved=None, is_distraction_involved=None),
+        Crash(id=2, collision_id=200, data_source="switrs",
+              crash_datetime=datetime(2014, 1, 15, 9, 0), county_code=19,
+              crash_year=2014, crash_hour=9, severity="Injury",
+              canonical_cause="speeding", number_killed=0, number_injured=2,
+              county_name="Los Angeles", latitude=34.1, longitude=-118.1,
+              is_alcohol_involved=None, is_distraction_involved=None),
+        Crash(id=3, collision_id=100, data_source="ccrs",
+              crash_datetime=datetime(2022, 3, 10, 22, 0), county_code=19,
+              crash_year=2022, crash_hour=22, severity="Fatal",
+              canonical_cause="dui", number_killed=1, number_injured=1,
+              county_name="Los Angeles", latitude=34.05, longitude=-118.05,
+              is_alcohol_involved=True, is_distraction_involved=False),
+        Crash(id=4, collision_id=300, data_source="ccrs",
+              crash_datetime=datetime(2023, 7, 4, 16, 30), county_code=30,
+              crash_year=2023, crash_hour=16, severity="Injury",
+              canonical_cause="lane_change", number_killed=0, number_injured=3,
+              county_name="Orange", latitude=33.7, longitude=-117.8,
+              is_alcohol_involved=False, is_distraction_involved=True),
+        Crash(id=5, collision_id=400, data_source="ccrs",
+              crash_datetime=datetime(2023, 12, 31, 23, 45), county_code=38,
+              crash_year=2023, crash_hour=23, severity="Property Damage Only",
+              canonical_cause="other", number_killed=0, number_injured=0,
+              county_name="San Francisco", latitude=37.77, longitude=-122.45,
+              is_alcohol_involved=False, is_distraction_involved=False),
+    ]
+    session.add_all(crashes)
+
+    session.add_all([
+        Demographic(county_code=19, year=2023, population=9861000,
+                    median_age=37.5, median_income=82000, poverty_rate=13.4,
+                    population_density=2431.0),
+        Demographic(county_code=30, year=2023, population=3186000,
+                    median_age=38.9, median_income=102000, poverty_rate=9.8,
+                    population_density=4028.0),
+    ])
+
+    session.add_all([
+        Hospital(facility_id="HSP001", facility_name="UCLA Medical",
+                 facility_type="General Acute Care Hospital", county_code=19,
+                 city="Los Angeles", trauma_center="Level I", status="OPEN",
+                 latitude=34.07, longitude=-118.45),
+        SchoolLocation(cds_code="19000000000001", school_name="Venice High",
+                       county_code=19, city="Los Angeles", school_type="High",
+                       status="Active", latitude=33.99, longitude=-118.47),
+        CalenviroScreen(county_code=19, ces_score=45.0, ces_percentile=78.0,
+                        pollution_burden=60.0, pop_characteristics=55.0,
+                        ozone_score=7.0, diesel_pm_score=6.0,
+                        pesticide_score=2.0, traffic_score=9.0),
+        TrafficVolume(county_code=19, total_aadt=1500000, segment_count=250,
+                      avg_aadt_per_segment=6000),
+        SpeedLimit(county_code=19, speed_limit=55, segment_count=40,
+                   avg_lanes=3.5, total_aadt=450000),
+        RoadMile(county_code=19, f_system=1, segment_count=20, total_miles=75.5),
+        UnemploymentRate(county_code=19, year=2023, month=6,
+                         unemployment_rate=4.7),
+        VehicleRegistration(county_code=19, year=2023,
+                            total_vehicles=6200000, ev_vehicles=310000),
+        LicensedDriver(county_code=19, year=2023, driver_count=5800000),
+        DataQualityStat(county_code=19, year=2023, total_crashes=500000,
+                        crashes_with_coords=480000, coords_pct=96.0),
+        DataQualityStat(county_code=19, year=None, total_crashes=4200000,
+                        crashes_with_coords=4000000, coords_pct=95.2),
+    ])
+
+    session.add_all([
+        EtlRun(source="ccrs", status="success", rows_loaded=4350202,
+               started_at=datetime(2026, 4, 15, 3, 0),
+               finished_at=datetime(2026, 4, 15, 4, 0)),
+        EtlRun(source="switrs", status="success", rows_loaded=6779445,
+               started_at=datetime(2026, 4, 15, 3, 0),
+               finished_at=datetime(2026, 4, 15, 3, 45)),
+    ])
+
+    # Crash parties — only for CCRS crashes (3, 4, 5). SWITRS has no party data.
+    # Crash 3 (collision_id=100, ccrs): 2 parties — at-fault drunk male, female passenger driver
+    # Crash 4 (collision_id=300, ccrs): 1 party — distracted male driver, at-fault
+    # Crash 5 (collision_id=400, ccrs): 1 party — sober female driver
+    session.add_all([
+        CrashParty(party_id=1001, collision_id=100, data_source="ccrs",
+                   party_number=1, party_type="Driver", at_fault=True,
+                   gender="M", age=42, sobriety="HBD", vehicle_type="Sedan",
+                   movement="Proceeding Straight"),
+        CrashParty(party_id=1002, collision_id=100, data_source="ccrs",
+                   party_number=2, party_type="Driver", at_fault=False,
+                   gender="F", age=29, sobriety="Not Impaired",
+                   vehicle_type="SUV", movement="Stopped"),
+        CrashParty(party_id=1003, collision_id=300, data_source="ccrs",
+                   party_number=1, party_type="Driver", at_fault=True,
+                   gender="M", age=22, sobriety="Not Impaired",
+                   cell_phone_use="In Use", vehicle_type="Sedan",
+                   movement="Changing Lanes"),
+        CrashParty(party_id=1004, collision_id=400, data_source="ccrs",
+                   party_number=1, party_type="Driver", at_fault=False,
+                   gender="F", age=55, sobriety="Not Impaired",
+                   vehicle_type="Pickup", movement="Backing"),
+    ])
+
+    # Crash victims — same scope (CCRS only).
+    # Crash 3: 1 fatal driver, 1 injured passenger
+    # Crash 4: 3 injured passengers
+    # Crash 5: no victims (PDO crash had no injuries)
+    session.add_all([
+        CrashVictim(victim_id=2001, collision_id=100, data_source="ccrs",
+                    party_number=1, age=42, gender="M",
+                    injury_severity="Fatal", person_type="Driver",
+                    safety_equipment="None", ejected="NotEjected"),
+        CrashVictim(victim_id=2002, collision_id=100, data_source="ccrs",
+                    party_number=2, age=33, gender="F",
+                    injury_severity="Severe", person_type="Passenger",
+                    safety_equipment="Lap+Shoulder Belt", ejected="NotEjected"),
+        CrashVictim(victim_id=2003, collision_id=300, data_source="ccrs",
+                    party_number=1, age=18, gender="F",
+                    injury_severity="Possible", person_type="Passenger",
+                    safety_equipment="Lap+Shoulder Belt"),
+        CrashVictim(victim_id=2004, collision_id=300, data_source="ccrs",
+                    party_number=1, age=20, gender="M",
+                    injury_severity="Possible", person_type="Passenger",
+                    safety_equipment="Lap+Shoulder Belt"),
+        CrashVictim(victim_id=2005, collision_id=300, data_source="ccrs",
+                    party_number=1, age=45, gender="M",
+                    injury_severity="Severe", person_type="Pedestrian",
+                    safety_equipment=None),
+    ])
+
+    session.commit()
+
+    # Refresh the materialized views so /api/stats tests see data.
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_year"))
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_cause"))
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_hour"))
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_crash_victims_by_demographics"))
+    session.commit()
+
+
+@pytest.fixture(scope="session")
+def test_engine():
+    _create_test_db()
+    _run_alembic_migrations()
+    engine = create_engine(TEST_DB_URL)
+
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    _seed(session)
+    session.close()
+
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def db_session(test_engine):
+    """Per-test transactional session, rolled back at teardown."""
+    connection = test_engine.connect()
+    trans = connection.begin()
+    SessionLocal = sessionmaker(bind=connection)
+    session = SessionLocal()
+    yield session
+    session.close()
+    trans.rollback()
+    connection.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    """TestClient with get_db overridden to use the transactional session."""
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()

--- a/backend/tests/api/test_conftest_smoke.py
+++ b/backend/tests/api/test_conftest_smoke.py
@@ -1,0 +1,17 @@
+"""Smoke test: fixtures create and seed the DB, TestClient works."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_client_health(client):
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_seed_counties_present(db_session):
+    from app.models import County
+    names = sorted(c.name for c in db_session.query(County).all())
+    assert names == ["Alameda", "Los Angeles", "Orange", "Sacramento", "San Francisco"]

--- a/backend/tests/api/test_context.py
+++ b/backend/tests/api/test_context.py
@@ -1,0 +1,64 @@
+"""Integration tests for context endpoints."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# --- unemployment ---
+
+def test_unemployment_returns_rows(client):
+    response = client.get("/api/unemployment?county=los-angeles&year=2023")
+    assert response.status_code == 200
+    body = response.json()
+    assert any(r["unemployment_rate"] == 4.7 for r in body)
+
+
+def test_unemployment_field_name_preserved(client):
+    response = client.get("/api/unemployment?county=los-angeles")
+    body = response.json()
+    assert all("unemployment_rate" in r for r in body)
+
+
+# --- vehicles ---
+
+def test_vehicles_returns_rows(client):
+    response = client.get("/api/vehicles?county=los-angeles&year=2023")
+    body = response.json()
+    assert any(r["ev_vehicles"] == 310000 for r in body)
+
+
+# --- licensed-drivers ---
+
+def test_licensed_drivers_returns_rows(client):
+    response = client.get("/api/licensed-drivers?county=los-angeles&year=2023")
+    body = response.json()
+    assert any(r["driver_count"] == 5800000 for r in body)
+
+
+# --- data-quality ---
+
+def test_data_quality_specific_county_year(client):
+    response = client.get("/api/data-quality?county=los-angeles&year=2023")
+    body = response.json()
+    assert any(r["county_code"] == 19 and r["year"] == 2023 for r in body)
+
+
+def test_data_quality_county_only_returns_all_time(client):
+    response = client.get("/api/data-quality?county=los-angeles")
+    body = response.json()
+    assert all(r["county_code"] == 19 and r["year"] is None for r in body)
+
+
+def test_data_quality_no_filter_returns_all(client):
+    response = client.get("/api/data-quality")
+    body = response.json()
+    assert len(body) >= 2
+
+
+# --- insights ---
+
+def test_insights_empty_until_68(client):
+    response = client.get("/api/insights")
+    assert response.status_code == 200
+    assert response.json() == []

--- a/backend/tests/api/test_crash_people.py
+++ b/backend/tests/api/test_crash_people.py
@@ -1,0 +1,135 @@
+"""Integration tests for /api/crashes/{collision_id}/parties|victims and
+/api/parties|victims."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# ── Drill-down (B1) ───────────────────────────────────────────────────
+
+
+def test_drill_down_parties_for_crash(client):
+    # Crash 3 (collision_id=100, ccrs) has 2 parties seeded.
+    response = client.get("/api/crashes/100/parties?data_source=ccrs")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    party_numbers = sorted(p["party_number"] for p in body)
+    assert party_numbers == [1, 2]
+
+
+def test_drill_down_parties_isolates_data_source(client):
+    # collision_id=100 is shared between SWITRS (crash 1) and CCRS (crash 3).
+    # SWITRS has no party data, so this returns empty.
+    response = client.get("/api/crashes/100/parties?data_source=switrs")
+    assert response.json() == []
+
+
+def test_drill_down_parties_requires_data_source(client):
+    response = client.get("/api/crashes/100/parties")
+    assert response.status_code == 422  # FastAPI Query(..., required)
+
+
+def test_drill_down_parties_rejects_bad_data_source(client):
+    response = client.get("/api/crashes/100/parties?data_source=bogus")
+    assert response.status_code == 422
+
+
+def test_drill_down_victims_for_crash(client):
+    # Crash 4 (collision_id=300, ccrs) has 3 victims seeded.
+    response = client.get("/api/crashes/300/victims?data_source=ccrs")
+    body = response.json()
+    assert len(body) == 3
+
+
+def test_drill_down_victims_empty_for_pdo_crash(client):
+    # Crash 5 (collision_id=400, ccrs) is Property Damage Only — no victims.
+    response = client.get("/api/crashes/400/victims?data_source=ccrs")
+    assert response.json() == []
+
+
+# ── Cross-crash list (B2) ─────────────────────────────────────────────
+
+
+def test_parties_pagination(client):
+    response = client.get("/api/parties?limit=2")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["limit"] == 2
+    assert len(body["items"]) <= 2
+    assert body["total"] is None  # always null per docstring
+
+
+def test_parties_filter_by_gender(client):
+    response = client.get("/api/parties?gender=f")
+    body = response.json()
+    assert all(p["gender"] == "F" for p in body["items"])
+
+
+def test_parties_filter_by_age_range(client):
+    response = client.get("/api/parties?age_min=20&age_max=30")
+    body = response.json()
+    for p in body["items"]:
+        assert p["age"] is None or 20 <= p["age"] <= 30
+
+
+def test_parties_filter_at_fault(client):
+    response = client.get("/api/parties?at_fault=true")
+    body = response.json()
+    assert all(p["at_fault"] is True for p in body["items"])
+
+
+def test_parties_county_filter_via_join(client):
+    # Crash 3 + 4 are in LA, crash 5 is in SF. Their parties join correctly.
+    response = client.get("/api/parties?county=los-angeles")
+    body = response.json()
+    # All parties returned must be from LA crashes (collision_id 100 or 300).
+    cids = {p["collision_id"] for p in body["items"]}
+    assert cids.issubset({100, 300})
+
+
+def test_parties_collision_id_filter(client):
+    response = client.get("/api/parties?collision_id=100&data_source=ccrs")
+    body = response.json()
+    assert len(body["items"]) == 2  # 2 parties seeded for this crash
+    assert {p["data_source"] for p in body["items"]} == {"ccrs"}
+
+
+def test_parties_rejects_bad_age_range(client):
+    response = client.get("/api/parties?age_min=50&age_max=20")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "age_min"
+
+
+def test_parties_rejects_unknown_gender(client):
+    response = client.get("/api/parties?gender=z")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "gender"
+
+
+def test_victims_pagination(client):
+    response = client.get("/api/victims?limit=2")
+    body = response.json()
+    assert body["limit"] == 2
+    assert body["total"] is None
+
+
+def test_victims_filter_injury_severity(client):
+    response = client.get("/api/victims?injury_severity=Fatal")
+    body = response.json()
+    assert all(v["injury_severity"] == "Fatal" for v in body["items"])
+
+
+def test_victims_filter_person_type(client):
+    response = client.get("/api/victims?person_type=Pedestrian")
+    body = response.json()
+    assert all(v["person_type"] == "Pedestrian" for v in body["items"])
+
+
+def test_victims_county_filter_via_join(client):
+    response = client.get("/api/victims?county=orange")
+    body = response.json()
+    # Only crash 4 (collision_id=300) is in Orange and has victims.
+    cids = {v["collision_id"] for v in body["items"]}
+    assert cids.issubset({300})

--- a/backend/tests/api/test_crashes.py
+++ b/backend/tests/api/test_crashes.py
@@ -1,0 +1,149 @@
+"""Integration tests for /api/crashes."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_crashes_returns_items_and_pagination(client):
+    response = client.get("/api/crashes?limit=10")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["limit"] == 10
+    assert body["offset"] == 0
+    assert body["total"] is None  # opt-in
+    assert isinstance(body["items"], list)
+
+
+def test_crashes_filter_by_year(client):
+    response = client.get("/api/crashes?year=2023")
+    body = response.json()
+    assert all(c["crash_datetime"].startswith("2023") for c in body["items"])
+
+
+def test_crashes_filter_by_county(client):
+    response = client.get("/api/crashes?county=los-angeles")
+    body = response.json()
+    assert all(c["county_code"] == 19 for c in body["items"])
+
+
+def test_crashes_filter_by_severity_fatal(client):
+    response = client.get("/api/crashes?severity=fatal")
+    body = response.json()
+    assert all(c["severity"] == "Fatal" for c in body["items"])
+
+
+def test_crashes_filter_by_cause_dui(client):
+    response = client.get("/api/crashes?cause=dui")
+    body = response.json()
+    assert all(c["canonical_cause"] == "dui" for c in body["items"])
+
+
+def test_crashes_filter_cause_lane_change_translates_hyphen(client):
+    response = client.get("/api/crashes?cause=lane-change")
+    body = response.json()
+    assert all(c["canonical_cause"] == "lane_change" for c in body["items"])
+
+
+def test_crashes_alcohol_flag_excludes_switrs(client):
+    response = client.get("/api/crashes?alcohol=true")
+    body = response.json()
+    ids = {c["id"] for c in body["items"]}
+    assert 3 in ids
+    # SWITRS rows (1, 2) have NULL for is_alcohol_involved, so excluded.
+    assert 1 not in ids and 2 not in ids
+
+
+def test_crashes_distracted_flag(client):
+    response = client.get("/api/crashes?distracted=true")
+    body = response.json()
+    ids = {c["id"] for c in body["items"]}
+    # Only crash id=4 was seeded with is_distraction_involved=True.
+    assert ids == {4}
+
+
+def test_crashes_rejects_severe_injury_slug(client):
+    response = client.get("/api/crashes?severity=severe-injury")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "severity"
+
+
+def test_crashes_rejects_distracted_as_cause(client):
+    response = client.get("/api/crashes?cause=distracted")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "cause"
+
+
+def test_crashes_rejects_unknown_county(client):
+    response = client.get("/api/crashes?county=atlantis")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "county"
+
+
+def test_crashes_sort_descending_by_datetime(client):
+    response = client.get("/api/crashes?limit=10")
+    body = response.json()
+    dts = [c["crash_datetime"] for c in body["items"]]
+    assert dts == sorted(dts, reverse=True)
+
+
+def test_crashes_include_total(client):
+    # include_total now requires a filter (see #106 / perf docs); year=2015,…
+    # covers every seeded crash.
+    response = client.get("/api/crashes?include_total=true&year=2014,2015,2022,2023&limit=10")
+    body = response.json()
+    assert body["total"] is not None
+    assert body["total"] == 5  # total seeded rows
+
+
+def test_crashes_join_key_is_collision_plus_source(client):
+    # Two crashes seeded with collision_id=100: one SWITRS (2015), one CCRS (2022).
+    r1 = client.get("/api/crashes?year=2015").json()["items"]
+    r2 = client.get("/api/crashes?year=2022").json()["items"]
+    assert {c["data_source"] for c in r1} == {"switrs"}
+    assert {c["data_source"] for c in r2} == {"ccrs"}
+    assert any(c["collision_id"] == 100 for c in r1)
+    assert any(c["collision_id"] == 100 for c in r2)
+
+
+def test_crashes_cache_header(client):
+    response = client.get("/api/crashes")
+    assert response.headers.get("cache-control") == "public, max-age=300"
+
+
+def test_crashes_include_total_without_filter_returns_422(client):
+    """Unfiltered include_total=true is rejected — would require a multi-minute
+    COUNT(*) over 11M rows. Users should add a filter or use /api/stats for
+    aggregate totals. Proper fix is the covering index in #106."""
+    response = client.get("/api/crashes?include_total=true")
+    assert response.status_code == 422
+    body = response.json()
+    assert body["filter"] == "include_total"
+    assert "at least one filter" in body["detail"]
+    assert "/api/stats" in body["detail"]
+
+
+def test_crashes_include_total_timeout_returns_null(client, monkeypatch):
+    """When COUNT(*) exceeds statement_timeout, endpoint returns total=null
+    with items still populated — graceful degradation, not a 500 or a hang.
+
+    We can't reliably trigger a real timeout on a 5-row test fixture (it
+    finishes in <1ms), so we patch `Query.count` to raise OperationalError,
+    which is what Postgres raises when statement_timeout fires.
+    """
+    from sqlalchemy.exc import OperationalError
+    from sqlalchemy.orm import Query
+
+    def raise_timeout(self):
+        raise OperationalError(
+            "COUNT(*)", {}, Exception("canceling statement due to statement timeout")
+        )
+
+    monkeypatch.setattr(Query, "count", raise_timeout)
+
+    # Must include a filter — include_total is rejected without one.
+    response = client.get("/api/crashes?include_total=true&year=2023&limit=2")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] is None
+    assert len(body["items"]) >= 1

--- a/backend/tests/api/test_demographics.py
+++ b/backend/tests/api/test_demographics.py
@@ -1,0 +1,29 @@
+"""Integration tests for /api/demographics."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_demographics_returns_seeded(client):
+    response = client.get("/api/demographics")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) >= 2
+
+
+def test_demographics_county_filter(client):
+    response = client.get("/api/demographics?county=los-angeles")
+    body = response.json()
+    assert all(r["county_code"] == 19 for r in body)
+
+
+def test_demographics_year_filter(client):
+    response = client.get("/api/demographics?year=2023")
+    body = response.json()
+    assert all(r["year"] == 2023 for r in body)
+
+
+def test_demographics_cache_header(client):
+    response = client.get("/api/demographics")
+    assert response.headers.get("cache-control") == "public, max-age=300"

--- a/backend/tests/api/test_error_handling.py
+++ b/backend/tests/api/test_error_handling.py
@@ -1,0 +1,28 @@
+"""Exception-handler behavior tests."""
+
+import pytest
+
+from app.filters import FilterError
+
+pytestmark = pytest.mark.integration
+
+
+def test_filter_error_returns_422(client):
+    from app.main import app as main_app
+
+    @main_app.get("/api/_test_filter_error")
+    def raise_filter_error():
+        raise FilterError("severity", "Unknown severity 'foo'.")
+
+    try:
+        response = client.get("/api/_test_filter_error")
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "Unknown severity 'foo'.",
+            "filter": "severity",
+        }
+    finally:
+        main_app.router.routes = [
+            r for r in main_app.router.routes
+            if getattr(r, "path", "") != "/api/_test_filter_error"
+        ]

--- a/backend/tests/api/test_meta.py
+++ b/backend/tests/api/test_meta.py
@@ -1,0 +1,15 @@
+"""Integration tests for /api/meta/*."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_data_freshness_returns_latest_per_source(client):
+    response = client.get("/api/meta/data-freshness")
+    assert response.status_code == 200
+    body = response.json()
+    assert "ccrs" in body
+    assert body["ccrs"]["rows_loaded"] == 4350202
+    assert "switrs" in body
+    assert body["switrs"]["rows_loaded"] == 6779445

--- a/backend/tests/api/test_reference.py
+++ b/backend/tests/api/test_reference.py
@@ -1,0 +1,126 @@
+"""Integration tests for reference endpoints."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# --- counties ---
+
+def test_counties_returns_all_seeded(client):
+    response = client.get("/api/counties")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    names = sorted(c["name"] for c in body)
+    assert names == ["Alameda", "Los Angeles", "Orange", "Sacramento", "San Francisco"]
+
+
+def test_counties_includes_geojson_by_default(client):
+    response = client.get("/api/counties")
+    body = response.json()
+    assert all("geojson" in c for c in body)
+
+
+def test_counties_can_omit_geojson(client):
+    response = client.get("/api/counties?include_geojson=false")
+    body = response.json()
+    assert all(c.get("geojson") is None for c in body)
+
+
+def test_counties_cache_header(client):
+    response = client.get("/api/counties")
+    assert response.headers.get("cache-control") == "public, max-age=3600"
+
+
+# --- hospitals ---
+
+def test_hospitals_lists_all(client):
+    response = client.get("/api/hospitals")
+    assert response.status_code == 200
+    body = response.json()
+    assert any(h["facility_name"] == "UCLA Medical" for h in body)
+
+
+def test_hospitals_trauma_only_filters(client):
+    response = client.get("/api/hospitals?trauma_only=true")
+    body = response.json()
+    assert all(h["trauma_center"] is not None for h in body)
+
+
+def test_hospitals_county_filter(client):
+    response = client.get("/api/hospitals?county=los-angeles")
+    body = response.json()
+    assert all(h["county_code"] == 19 for h in body)
+
+
+# --- schools ---
+
+def test_schools_paginated(client):
+    response = client.get("/api/schools?limit=10")
+    body = response.json()
+    assert body["limit"] == 10
+    assert body["offset"] == 0
+    assert "items" in body
+    assert body["total"] is None
+
+
+def test_schools_include_total(client):
+    response = client.get("/api/schools?limit=10&include_total=true")
+    body = response.json()
+    assert body["total"] is not None
+    assert isinstance(body["total"], int)
+
+
+def test_schools_school_type_filter(client):
+    response = client.get("/api/schools?school_type=High")
+    body = response.json()
+    assert all(s["school_type"] == "High" for s in body["items"])
+
+
+# --- calenviroscreen ---
+
+def test_calenviroscreen_returns_rows(client):
+    response = client.get("/api/calenviroscreen")
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) >= 1
+
+
+def test_calenviroscreen_county_filter(client):
+    response = client.get("/api/calenviroscreen?county=los-angeles")
+    body = response.json()
+    assert all(r["county_code"] == 19 for r in body)
+
+
+# --- road-miles ---
+
+def test_road_miles_returns_rows(client):
+    response = client.get("/api/road-miles")
+    body = response.json()
+    assert isinstance(body, list)
+    assert all("f_system" in r and "total_miles" in r for r in body)
+
+
+def test_road_miles_f_system_filter(client):
+    response = client.get("/api/road-miles?f_system=1")
+    body = response.json()
+    assert all(r["f_system"] == 1 for r in body)
+
+
+# --- traffic-volumes ---
+
+def test_traffic_volumes_returns_rows(client):
+    response = client.get("/api/traffic-volumes")
+    body = response.json()
+    assert isinstance(body, list)
+    assert all("total_aadt" in r for r in body)
+
+
+# --- speed-limits ---
+
+def test_speed_limits_returns_rows(client):
+    response = client.get("/api/speed-limits")
+    body = response.json()
+    assert isinstance(body, list)
+    assert all("speed_limit" in r for r in body)

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -1,0 +1,134 @@
+"""Integration tests for /api/stats."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_stats_no_group_by_returns_grand_totals(client):
+    response = client.get("/api/stats")
+    assert response.status_code == 200
+    body = response.json()
+    assert "total_crashes" in body
+    assert "total_killed" in body
+    assert "total_injured" in body
+
+
+def test_stats_group_by_county(client):
+    response = client.get("/api/stats?group_by=county")
+    body = response.json()
+    assert isinstance(body, list)
+    for row in body:
+        assert "county_code" in row and "crash_count" in row
+
+
+def test_stats_group_by_year(client):
+    response = client.get("/api/stats?group_by=year")
+    body = response.json()
+    years = {row["year"] for row in body}
+    assert 2023 in years
+
+
+def test_stats_group_by_cause_uses_cause_view(client):
+    response = client.get("/api/stats?group_by=cause")
+    body = response.json()
+    assert all("canonical_cause" in row for row in body)
+    causes = {row["canonical_cause"] for row in body}
+    assert "dui" in causes
+
+
+def test_stats_group_by_hour_no_killed_injured(client):
+    response = client.get("/api/stats?group_by=hour")
+    body = response.json()
+    for row in body:
+        assert "hour" in row
+        assert "crash_count" in row
+        # MV does not carry these; endpoint must not fabricate them.
+        assert "total_killed" not in row
+        assert "total_injured" not in row
+
+
+def test_stats_group_by_severity(client):
+    response = client.get("/api/stats?group_by=severity")
+    body = response.json()
+    severities = {row["severity"] for row in body}
+    assert severities.issubset({"Fatal", "Injury", "Property Damage Only"})
+
+
+def test_stats_filter_year(client):
+    response = client.get("/api/stats?group_by=year&year=2023")
+    body = response.json()
+    assert all(row["year"] == 2023 for row in body)
+
+
+def test_stats_cause_filter_uses_cause_view(client):
+    response = client.get("/api/stats?cause=dui&group_by=county")
+    body = response.json()
+    assert len(body) >= 1
+
+
+def test_stats_rejects_alcohol_filter(client):
+    response = client.get("/api/stats?alcohol=true")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "alcohol"
+
+
+def test_stats_rejects_distracted_filter(client):
+    response = client.get("/api/stats?distracted=true")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "distracted"
+
+
+# --- group_by=gender / age_bracket (mv_crash_victims_by_demographics) ---
+
+
+def test_stats_group_by_gender_returns_victim_buckets(client):
+    response = client.get("/api/stats?group_by=gender")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    genders = {row["gender"] for row in body}
+    # Seed has both M and F victims.
+    assert "M" in genders
+    assert "F" in genders
+    for row in body:
+        assert "victim_count" in row
+        assert "fatal_victim_count" in row
+        # Crash-count fields are NOT present on this MV — must not leak.
+        assert "crash_count" not in row
+
+
+def test_stats_group_by_age_bracket(client):
+    response = client.get("/api/stats?group_by=age_bracket")
+    body = response.json()
+    brackets = {row["age_bracket"] for row in body}
+    # Seed has victims aged 18, 20, 33, 42, 45 — covers 18_24 and 25_44 brackets.
+    assert "18_24" in brackets or "25_44" in brackets
+
+
+def test_stats_gender_with_county_filter(client):
+    response = client.get("/api/stats?group_by=gender&county=los-angeles")
+    body = response.json()
+    # Only crash 3 victims (1 M driver, 1 F passenger) are in LA.
+    assert len(body) >= 1
+
+
+def test_stats_gender_rejects_cause_filter(client):
+    response = client.get("/api/stats?group_by=gender&cause=dui")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "cause"
+
+
+def test_stats_age_bracket_rejects_cause_filter(client):
+    response = client.get("/api/stats?group_by=age_bracket&cause=speeding")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "cause"
+
+
+def test_stats_gender_severity_filter_works(client):
+    """Severity filter IS supported — mv_victims has a severity column."""
+    response = client.get("/api/stats?group_by=gender&severity=fatal")
+    assert response.status_code == 200
+    body = response.json()
+    # Crash 3 has severity=Fatal with 2 victims (M driver, F passenger).
+    assert len(body) >= 1

--- a/backend/tests/test_census_api.py
+++ b/backend/tests/test_census_api.py
@@ -3,9 +3,12 @@
 These use mocking — we fake the HTTP responses so tests don't hit
 the real Census API. This makes tests fast, reliable, and free.
 
-The client now makes 2 requests per year:
-  1. Profile request (race, poverty, education, housing, language, commute)
-  2. Age distribution request (B01001 sex-by-age cells)
+The client now makes 4 requests per year:
+  1. Profile (population, income, race, commute, housing, language, per-capita
+     income, travel time, foreign-born, rent burden, school enrollment, vets)
+  2. Age distribution (B01001 sex-by-age cells, 5 brackets + sex totals)
+  3. Education (B15003, optional — not available pre-2012 ACS5)
+  4. Disability (B18101, optional — graceful skip on missing)
 """
 
 import httpx
@@ -14,9 +17,10 @@ from unittest.mock import patch, MagicMock
 
 from etl.census_api import (
     fetch_county_demographics,
-    PROFILE_VARIABLES,
     AGE_VARIABLES,
+    DISABILITY_VARIABLES,
     EDUCATION_VARIABLES,
+    PROFILE_VARIABLES,
     _pct,
     _sum_cells,
 )
@@ -51,6 +55,19 @@ MOCK_PROFILE_ROW = [
     "900000",   # B16001_001E lang_total
     "540000",   # B16001_002E english_only (60%)
     "270000",   # B16001_003E spanish (30%)
+    "40000",    # B19301_001E per_capita_income
+    "24000000", # B08013_001E travel_time_agg (24M minutes / 800K commute_total = 30 min mean)
+    "1000000",  # B05002_001E birth_total
+    "250000",   # B05002_013E birth_foreign (25%)
+    "200000",   # B25070_001E rent_total
+    "30000",    # B25070_007E rent 30-34.9%
+    "20000",    # B25070_008E rent 35-39.9%
+    "20000",    # B25070_009E rent 40-49.9%
+    "30000",    # B25070_010E rent 50%+
+    "950000",   # B14001_001E school_total (pop 3+)
+    "247000",   # B14001_002E school_enrolled (26%)
+    "700000",   # B21001_001E vet_total
+    "70000",    # B21001_002E vet_veteran (10%)
     "06",       # state
     "001",      # county (Alameda)
 ]
@@ -75,47 +92,27 @@ def _build_age_row():
     row = {}
     row["B01001_001E"] = "1000000"
 
-    # Male under 18: cells 003-006 = 30k each = 120k
-    for i in [3, 4, 5, 6]:
-        row[f"B01001_{i:03d}E"] = "30000"
-    # Female under 18: cells 027-030 = 25k each = 100k
-    for i in [27, 28, 29, 30]:
-        row[f"B01001_{i:03d}E"] = "25000"
-    # Total under 18: 120k + 100k = 220k (22%)
+    # Under-18: M cells 3-6 = 30k ea (120k); F cells 27-30 = 25k ea (100k) → 220k
+    # 18-24: M cells 7-10 = 12.5k; F cells 31-34 = 12.5k → 100k
+    # 25-44: M cells 11-14 = 35k; F cells 35-38 = 35k → 280k
+    # 45-64: M cells 15-19 = 26k; F cells 39-43 = 26k → 260k
+    # 65+:   M cells 20-25 = 11,667; F cells 44-49 = 11,667 → ~140k
+    _bucket_values = [
+        ([3, 4, 5, 6],              "30000"),
+        ([27, 28, 29, 30],          "25000"),
+        ([7, 8, 9, 10],             "12500"),
+        ([31, 32, 33, 34],          "12500"),
+        ([11, 12, 13, 14],          "35000"),
+        ([35, 36, 37, 38],          "35000"),
+        ([15, 16, 17, 18, 19],      "26000"),
+        ([39, 40, 41, 42, 43],      "26000"),
+        ([20, 21, 22, 23, 24, 25],  "11667"),
+        ([44, 45, 46, 47, 48, 49],  "11667"),
+    ]
+    for cells, value in _bucket_values:
+        for i in cells:
+            row[f"B01001_{i:03d}E"] = value
 
-    # Male 18-24: cells 007-010 = 12.5k each = 50k
-    for i in [7, 8, 9, 10]:
-        row[f"B01001_{i:03d}E"] = "12500"
-    # Female 18-24: cells 031-034 = 12.5k each = 50k
-    for i in [31, 32, 33, 34]:
-        row[f"B01001_{i:03d}E"] = "12500"
-    # Total 18-24: 50k + 50k = 100k (10%)
-
-    # Male 25-44: cells 011-014 = 35k each = 140k
-    for i in [11, 12, 13, 14]:
-        row[f"B01001_{i:03d}E"] = "35000"
-    # Female 25-44: cells 035-038 = 35k each = 140k
-    for i in [35, 36, 37, 38]:
-        row[f"B01001_{i:03d}E"] = "35000"
-    # Total 25-44: 140k + 140k = 280k (28%)
-
-    # Male 45-64: cells 015-019 = 26k each = 130k
-    for i in [15, 16, 17, 18, 19]:
-        row[f"B01001_{i:03d}E"] = "26000"
-    # Female 45-64: cells 039-043 = 26k each = 130k
-    for i in [39, 40, 41, 42, 43]:
-        row[f"B01001_{i:03d}E"] = "26000"
-    # Total 45-64: 130k + 130k = 260k (26%)
-
-    # Male 65+: cells 020-025 = ~11.67k each ≈ 70k
-    for i in [20, 21, 22, 23, 24, 25]:
-        row[f"B01001_{i:03d}E"] = "11667"
-    # Female 65+: cells 044-049 = ~11.67k each ≈ 70k
-    for i in [44, 45, 46, 47, 48, 49]:
-        row[f"B01001_{i:03d}E"] = "11667"
-    # Total 65+: ~70k + ~70k = ~140k (14%)
-
-    # Convert to list matching header order
     return [row.get(var, "0") for var in AGE_VARIABLES] + ["06", "001"]
 
 
@@ -144,29 +141,34 @@ MOCK_EDU_ROW = [
 MOCK_EDU_JSON = [MOCK_EDU_HEADER, MOCK_EDU_ROW]
 
 
+# ── Mock data for Request 4: disability ───────────────────────────────
+
+MOCK_DISABILITY_HEADER = DISABILITY_VARIABLES + ["state", "county"]
+
+# Universe 1,000,000; "with a disability" cells total 100,000 (10%)
+# 12 cells × ~8,333 each ≈ 100K
+MOCK_DISABILITY_ROW = ["1000000"] + ["8333"] * 12 + ["06", "001"]
+
+MOCK_DISABILITY_JSON = [MOCK_DISABILITY_HEADER, MOCK_DISABILITY_ROW]
+
+
 # ── Helpers ───────────────────────────────────────────────────────────
 
 def _mock_responses():
-    """Create three mock httpx responses: profile, age, education."""
-    profile_resp = MagicMock()
-    profile_resp.json.return_value = MOCK_PROFILE_JSON
-    profile_resp.raise_for_status = MagicMock()
-
-    age_resp = MagicMock()
-    age_resp.json.return_value = MOCK_AGE_JSON
-    age_resp.raise_for_status = MagicMock()
-
-    edu_resp = MagicMock()
-    edu_resp.json.return_value = MOCK_EDU_JSON
-    edu_resp.raise_for_status = MagicMock()
-
-    return [profile_resp, age_resp, edu_resp]
+    """Create four mock httpx responses: profile, age, education, disability."""
+    responses = []
+    for payload in (MOCK_PROFILE_JSON, MOCK_AGE_JSON, MOCK_EDU_JSON, MOCK_DISABILITY_JSON):
+        resp = MagicMock()
+        resp.json.return_value = payload
+        resp.raise_for_status = MagicMock()
+        responses.append(resp)
+    return responses
 
 
 class TestFetchCountyDemographics:
     @patch("etl.census_api.httpx.get")
     def test_returns_parsed_rows_with_all_fields(self, mock_get):
-        """Profile + age data merge into one dict per county."""
+        """Profile + age + disability data merge into one dict per county."""
         mock_get.side_effect = _mock_responses()
 
         rows = fetch_county_demographics(year=2022, api_key="fake-key")
@@ -196,20 +198,23 @@ class TestFetchCountyDemographics:
         assert row["poverty_rate"] == pytest.approx(12.0)
 
         # Education
-        # HS or higher = 150k+30k+60k+90k+42k+120k+48k+12k+6k = 558k / 600k = 93%
         assert row["pct_high_school_or_higher"] == pytest.approx(93.0)
-        # Bachelor's+ = 120k+48k+12k+6k = 186k / 600k = 31%
         assert row["pct_bachelors_or_higher"] == pytest.approx(31.0)
 
-        # Vehicle (28k / 400k = 7%)
+        # Vehicle / Housing / Language
         assert row["pct_no_vehicle"] == pytest.approx(7.0)
-
-        # Housing (209k / 380k = 55%)
         assert row["pct_owner_occupied_housing"] == pytest.approx(55.0, abs=0.1)
-
-        # Language
         assert row["pct_english_only"] == pytest.approx(60.0)
         assert row["pct_spanish_speaking"] == pytest.approx(30.0)
+
+        # New fields from this PR
+        assert row["per_capita_income"] == 40000
+        assert row["mean_travel_time_to_work"] == pytest.approx(30.0)  # 15M / 500K
+        assert row["pct_foreign_born"] == pytest.approx(25.0)
+        assert row["pct_rent_burdened"] == pytest.approx(50.0)  # 100K / 200K
+        assert row["pct_enrolled_in_school"] == pytest.approx(26.0)  # 247K / 950K
+        assert row["pct_veteran"] == pytest.approx(10.0)
+        assert row["pct_with_disability"] == pytest.approx(10.0, abs=0.01)  # ~100K / 1M
 
     @patch("etl.census_api.httpx.get")
     def test_age_distribution_percentages(self, mock_get):
@@ -223,17 +228,16 @@ class TestFetchCountyDemographics:
         assert row["pct_18_24"] == pytest.approx(10.0)
         assert row["pct_25_44"] == pytest.approx(28.0)
         assert row["pct_45_64"] == pytest.approx(26.0)
-        # 65+ = 11667*12 = 140004 / 1000000 ≈ 14%
         assert row["pct_65_plus"] == pytest.approx(14.0, abs=0.01)
 
     @patch("etl.census_api.httpx.get")
-    def test_makes_three_api_requests(self, mock_get):
-        """Should hit the Census API three times: profile + age + education."""
+    def test_makes_four_api_requests(self, mock_get):
+        """Should hit the Census API four times: profile + age + education + disability."""
         mock_get.side_effect = _mock_responses()
 
         fetch_county_demographics(year=2022, api_key="fake-key")
 
-        assert mock_get.call_count == 3
+        assert mock_get.call_count == 4
 
     @patch("etl.census_api.httpx.get")
     def test_uses_acs5_for_2010_and_later(self, mock_get):
@@ -242,7 +246,6 @@ class TestFetchCountyDemographics:
 
         fetch_county_demographics(year=2015, api_key="fake-key")
 
-        # Both requests should use acs5
         for c in mock_get.call_args_list:
             assert "/acs/acs5" in c[0][0]
 
@@ -271,17 +274,17 @@ class TestFetchCountyDemographics:
             MOCK_EDU_HEADER,
             [None] * len(EDUCATION_VARIABLES) + ["06", "003"],
         ]
-        null_profile_resp = MagicMock()
-        null_profile_resp.json.return_value = null_profile
-        null_profile_resp.raise_for_status = MagicMock()
-        null_age_resp = MagicMock()
-        null_age_resp.json.return_value = null_age
-        null_age_resp.raise_for_status = MagicMock()
-        null_edu_resp = MagicMock()
-        null_edu_resp.json.return_value = null_edu
-        null_edu_resp.raise_for_status = MagicMock()
-
-        mock_get.side_effect = [null_profile_resp, null_age_resp, null_edu_resp]
+        null_disability = [
+            MOCK_DISABILITY_HEADER,
+            [None] * len(DISABILITY_VARIABLES) + ["06", "003"],
+        ]
+        resps = []
+        for payload in (null_profile, null_age, null_edu, null_disability):
+            r = MagicMock()
+            r.json.return_value = payload
+            r.raise_for_status = MagicMock()
+            resps.append(r)
+        mock_get.side_effect = resps
 
         rows = fetch_county_demographics(year=2006, api_key="fake-key")
 
@@ -290,6 +293,8 @@ class TestFetchCountyDemographics:
         assert rows[0]["pct_white"] is None
         assert rows[0]["pct_under_18"] is None
         assert rows[0]["poverty_rate"] is None
+        assert rows[0]["per_capita_income"] is None
+        assert rows[0]["pct_with_disability"] is None
 
     @patch("etl.census_api.httpx.get")
     def test_retries_on_server_error(self, mock_get):

--- a/backend/tests/unit/test_county_slug_map.py
+++ b/backend/tests/unit/test_county_slug_map.py
@@ -1,0 +1,33 @@
+"""Tests for county slug <-> code lookup."""
+
+from app.county_slug_map import build_map, get_code, slugify_name
+
+
+def test_slugify_name_lowercase():
+    assert slugify_name("Los Angeles") == "los-angeles"
+
+
+def test_slugify_name_single_word():
+    assert slugify_name("Orange") == "orange"
+
+
+def test_slugify_name_handles_spaces():
+    assert slugify_name("San Bernardino") == "san-bernardino"
+
+
+def test_build_map_from_rows():
+    rows = [(1, "Alameda"), (19, "Los Angeles"), (30, "Orange")]
+    result = build_map(rows)
+    assert result == {"alameda": 1, "los-angeles": 19, "orange": 30}
+
+
+def test_get_code_returns_code():
+    rows = [(19, "Los Angeles")]
+    slug_map = build_map(rows)
+    assert get_code("los-angeles", slug_map) == 19
+
+
+def test_get_code_returns_none_for_unknown():
+    rows = [(19, "Los Angeles")]
+    slug_map = build_map(rows)
+    assert get_code("atlantis", slug_map) is None

--- a/backend/tests/unit/test_filters.py
+++ b/backend/tests/unit/test_filters.py
@@ -1,0 +1,160 @@
+"""Unit tests for URL-param parsers and predicate builder in app.filters."""
+
+import pytest
+
+from app.filters import (
+    FilterError,
+    build_crash_predicates,
+    parse_bool_flag,
+    parse_cause,
+    parse_county_codes,
+    parse_severity,
+    parse_year,
+)
+
+
+# --- year ---
+
+def test_parse_year_none_returns_none():
+    assert parse_year(None) is None
+
+
+def test_parse_year_empty_returns_none():
+    assert parse_year("") is None
+
+
+def test_parse_year_single():
+    assert parse_year("2023") == {2023}
+
+
+def test_parse_year_comma_separated():
+    assert parse_year("2020,2023") == {2020, 2023}
+
+
+def test_parse_year_whitespace_tolerated():
+    assert parse_year(" 2020 , 2023 ") == {2020, 2023}
+
+
+def test_parse_year_rejects_non_integer():
+    with pytest.raises(FilterError) as exc_info:
+        parse_year("2020,twenty")
+    assert exc_info.value.filter == "year"
+
+
+def test_parse_year_rejects_out_of_range():
+    with pytest.raises(FilterError) as exc_info:
+        parse_year("1990")
+    assert exc_info.value.filter == "year"
+
+
+# --- county ---
+
+def test_parse_county_codes_none():
+    slug_map = {"los-angeles": 19}
+    assert parse_county_codes(None, slug_map) is None
+
+
+def test_parse_county_codes_translates_slugs():
+    slug_map = {"los-angeles": 19, "orange": 30}
+    assert parse_county_codes("los-angeles,orange", slug_map) == {19, 30}
+
+
+def test_parse_county_codes_rejects_unknown_slug():
+    slug_map = {"los-angeles": 19}
+    with pytest.raises(FilterError) as exc_info:
+        parse_county_codes("atlantis", slug_map)
+    assert exc_info.value.filter == "county"
+    assert "atlantis" in exc_info.value.detail
+
+
+# --- severity ---
+
+def test_parse_severity_fatal():
+    assert parse_severity("fatal") == {"Fatal"}
+
+
+def test_parse_severity_multiple():
+    assert parse_severity("fatal,injury") == {"Fatal", "Injury"}
+
+
+def test_parse_severity_property_damage_only():
+    assert parse_severity("property-damage-only") == {"Property Damage Only"}
+
+
+def test_parse_severity_rejects_severe_injury():
+    # FE currently sends this; backend surfaces the mismatch honestly.
+    with pytest.raises(FilterError) as exc_info:
+        parse_severity("severe-injury")
+    assert exc_info.value.filter == "severity"
+    assert "severe-injury" in exc_info.value.detail
+
+
+def test_parse_severity_rejects_minor_injury():
+    with pytest.raises(FilterError) as exc_info:
+        parse_severity("minor-injury")
+    assert exc_info.value.filter == "severity"
+
+
+# --- cause ---
+
+def test_parse_cause_canonical_values():
+    assert parse_cause("dui,speeding,other") == {"dui", "speeding", "other"}
+
+
+def test_parse_cause_translates_hyphen():
+    # FE sends lane-change, DB stores lane_change. Cosmetic translation.
+    assert parse_cause("lane-change") == {"lane_change"}
+
+
+def test_parse_cause_rejects_distracted():
+    with pytest.raises(FilterError) as exc_info:
+        parse_cause("distracted")
+    assert exc_info.value.filter == "cause"
+    assert "distracted=true" in exc_info.value.detail
+
+
+def test_parse_cause_rejects_weather():
+    with pytest.raises(FilterError) as exc_info:
+        parse_cause("weather")
+    assert exc_info.value.filter == "cause"
+
+
+# --- bool ---
+
+def test_parse_bool_flag_true():
+    assert parse_bool_flag("true", "alcohol") is True
+
+
+def test_parse_bool_flag_false():
+    assert parse_bool_flag("false", "alcohol") is False
+
+
+def test_parse_bool_flag_none():
+    assert parse_bool_flag(None, "alcohol") is None
+
+
+def test_parse_bool_flag_rejects_garbage():
+    with pytest.raises(FilterError):
+        parse_bool_flag("yes", "alcohol")
+
+
+# --- predicate builder ---
+
+def test_build_crash_predicates_empty_returns_empty_list():
+    preds = build_crash_predicates()
+    assert preds == []
+
+
+def test_build_crash_predicates_year_in():
+    preds = build_crash_predicates(years={2020, 2023})
+    assert len(preds) == 1
+    compiled = str(preds[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "crashes.crash_year IN" in compiled
+    assert "2020" in compiled and "2023" in compiled
+
+
+def test_build_crash_predicates_combined():
+    preds = build_crash_predicates(
+        years={2023}, county_codes={19}, severities={"Fatal"}
+    )
+    assert len(preds) == 3

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,0 +1,267 @@
+# Database schema
+
+Reference for the CalSight Postgres schema as it exists in production (Azure `calsight-db`) as of 2026-04-18. This document is descriptive — it reflects what the DB actually contains, not what `backend/app/models.py` on `main` currently describes (the ORM lags the DB; see CLAUDE.md).
+
+Run `python backend/scripts/probe_db.py` (when added) to regenerate the row-count summary.
+
+## Entity relationship diagram
+
+```mermaid
+erDiagram
+    counties ||--o{ crashes : "county_code"
+    counties ||--o{ demographics : "county_code"
+    counties ||--o{ data_quality_stats : "county_code (nullable)"
+    counties ||--o{ unemployment_rates : "county_code"
+    counties ||--o{ weather : "county_code"
+    counties ||--o{ vehicle_registrations : "county_code"
+    counties ||--o{ licensed_drivers : "county_code"
+    counties ||--o{ road_miles : "county_code"
+    counties ||--o{ hospitals : "county_code"
+    counties ||--o{ school_locations : "county_code"
+    counties ||--|| calenviroscreen : "county_code (unique)"
+    counties ||--|| traffic_volumes : "county_code (unique)"
+    counties ||--o{ speed_limits : "county_code"
+    counties ||--o{ county_insights : "county_code"
+    counties ||--o{ county_insight_details : "county_code"
+
+    crashes ||..o{ crash_parties : "(collision_id, data_source)"
+    crashes ||..o{ crash_victims : "(collision_id, data_source)"
+
+    crashes ||..o{ mv_crashes_by_year : "derived"
+    crashes ||..o{ mv_crashes_by_cause : "derived"
+    crashes ||..o{ mv_crashes_by_hour : "derived"
+
+    counties {
+        smallint code PK
+        varchar name
+        varchar fips
+        float latitude
+        float longitude
+        int population
+        float land_area_sq_miles
+        text geojson
+    }
+    crashes {
+        bigint id PK
+        bigint collision_id
+        varchar data_source "switrs|ccrs"
+        timestamp crash_datetime
+        smallint county_code FK
+        smallint crash_year "derived"
+        smallint crash_hour "derived"
+        varchar severity "derived: Fatal|Injury|Property Damage Only"
+        varchar canonical_cause "derived: dui|speeding|lane_change|other"
+        boolean is_alcohol_involved "CCRS only"
+        boolean is_distraction_involved "CCRS only"
+        varchar county_name "denormalized"
+        smallint number_killed
+        smallint number_injured
+        float latitude
+        float longitude
+    }
+    crash_parties {
+        bigint id PK
+        bigint party_id
+        bigint collision_id "join with data_source"
+        varchar data_source
+        varchar party_type
+        boolean at_fault
+        smallint age
+        varchar gender
+        varchar sobriety
+    }
+    crash_victims {
+        bigint id PK
+        bigint victim_id
+        bigint collision_id "join with data_source"
+        varchar data_source
+        smallint age
+        varchar gender
+        varchar injury_severity
+        varchar person_type
+    }
+    mv_crashes_by_year {
+        smallint county_code
+        smallint crash_year
+        varchar severity
+        int crash_count
+        int total_killed
+        int total_injured
+    }
+    mv_crashes_by_cause {
+        smallint county_code
+        smallint crash_year
+        varchar severity
+        varchar canonical_cause
+        int crash_count
+        int total_killed
+        int total_injured
+    }
+    mv_crashes_by_hour {
+        smallint county_code
+        smallint crash_year
+        varchar severity
+        varchar canonical_cause
+        smallint crash_hour
+        int crash_count
+    }
+    demographics {
+        int id PK
+        smallint county_code FK
+        smallint year
+        int population
+        float median_age
+        int median_income
+        float pct_white
+        float pct_black
+        float pct_asian
+        float pct_hispanic
+        float poverty_rate
+        float population_density
+    }
+    data_quality_stats {
+        int id PK
+        smallint county_code FK "nullable: NULL = statewide"
+        smallint year "nullable: NULL = all-time"
+        int total_crashes
+        float coords_pct
+        float alcohol_flag_pct
+    }
+```
+
+## Row counts (2026-04-18)
+
+| Table / View | Rows | Notes |
+|---|---:|---|
+| `crashes` | 11,125,881 | SWITRS 6.78M + CCRS 4.35M |
+| `crash_parties` | 8,804,729 | CCRS only (party_id unique within `data_source`) |
+| `crash_victims` | 5,297,539 | CCRS only |
+| `weather` | 17,315 | NOAA, monthly per county |
+| `unemployment_rates` | 14,558 | BLS, monthly per county |
+| `school_locations` | 9,932 | CDE, K-12 public schools |
+| `data_quality_stats` | 1,574 | See "scope" below |
+| `demographics` | 1,012 | ACS, yearly per county; **36 fields** as of 2026-04-18 (added gender + economic + equity + niche fields — see field reference below) |
+| `licensed_drivers` | 969 | DMV, yearly per county |
+| `hospitals` | 560 | HCAI, includes trauma centers |
+| `vehicle_registrations` | 464 | DMV, yearly per county (incl EV count) |
+| `road_miles` | 355 | Caltrans, by county + functional class |
+| `speed_limits` | 171 | Caltrans, segment summary by county+limit |
+| `counties` | 58 | Lookup |
+| `calenviroscreen` | 58 | Population-weighted county avg |
+| `traffic_volumes` | 58 | Caltrans AADT, one row per county |
+| `county_insights` | **0** | Empty until issue #68 generates rows |
+| `county_insight_details` | **0** | Empty until issue #68 generates rows |
+| `mv_crashes_by_year` | 4,405 | Populated. Years 2001–2026. |
+| `mv_crashes_by_cause` | 19,724 | Populated. Includes `canonical_cause`. |
+| `mv_crashes_by_hour` | 306,929 | Populated. **No killed/injured columns.** |
+| `mv_crash_victims_by_demographics` | 26,360 | Populated 2026-04-18. JOINs `crash_victims` to `crashes` on `(collision_id, data_source)`. Aggregates by (county, year, severity, gender, age_bracket). Powers `/api/stats?group_by=gender|age_bracket`. **Counts victims, not crashes.** |
+
+## Key constraints and gotchas
+
+### `(collision_id, data_source)` is the real join key
+
+`crashes`, `crash_parties`, and `crash_victims` all carry `collision_id` and `data_source`. Joining on `collision_id` alone yields **3,845,271** spurious matches — SWITRS and CCRS use overlapping numeric ID spaces. Always join on the pair:
+
+```sql
+-- WRONG
+JOIN crash_parties p ON p.collision_id = c.collision_id
+
+-- RIGHT
+JOIN crash_parties p ON p.collision_id = c.collision_id
+                     AND p.data_source = c.data_source
+```
+
+The unique constraint `uq_crashes_collision_source` enforces `(collision_id, data_source)` uniqueness on `crashes`. Note that `crash_parties.party_id` and `crash_victims.victim_id` similarly need `(_, data_source)` for uniqueness — there is no FK relationship between these tables and `crashes`, only the implied logical join.
+
+### Severity has 3 values, not 4
+
+`crashes.severity` actual distribution:
+
+| Value | Count |
+|---|---:|
+| `Property Damage Only` | 6,705,497 |
+| `Injury` | 4,341,304 |
+| `Fatal` | 82,842 |
+| `NULL` | 4 |
+
+Branch #39's model docstring claims 4 values (`Severe Injury`/`Minor Injury` instead of `Injury`). That docstring is stale; issue #102 plans to align by deriving 4 buckets from `crash_victims.injury_severity` later.
+
+### Canonical_cause has 4 values + NULL
+
+| Value | Count |
+|---|---:|
+| `other` | 5,492,133 |
+| `speeding` | 3,370,827 |
+| `lane_change` | 1,043,473 |
+| `dui` | 842,203 |
+| `NULL` | 381,011 |
+
+`NULL` indicates `primary_factor` was itself NULL. Issue #103 plans to expand the taxonomy.
+
+### Alcohol/distraction flags are CCRS-only
+
+| `data_source` | Total | `is_alcohol_involved` filled | `is_distraction_involved` filled |
+|---|---:|---:|---:|
+| `switrs` | 6,779,445 | 0 | 0 |
+| `ccrs` | 4,350,202 | 4,350,202 (100%) | 4,350,202 (100%) |
+
+Filtering by these flags implicitly limits results to 2016+ (CCRS coverage). Endpoints should not pretend otherwise.
+
+### `data_quality_stats` granularity (NULL semantics)
+
+`(county_code, year)` are both nullable; the NULL pattern encodes scope:
+
+| `county_code` | `year` | Rows | Meaning |
+|---|---|---:|---|
+| not null | not null | 1,490 | County × year fill rates |
+| not null | NULL | 58 | Per-county all-time |
+| NULL | not null | 26 | Statewide per-year |
+| NULL | NULL | 0 | Statewide all-time (not yet populated) |
+
+API consumers should treat NULLs in returned rows as "this scope" markers, not missing data.
+
+### Materialized view granularity
+
+The 4 MVs are not interchangeable — pick the smallest one that supports your filters:
+
+- **`mv_crashes_by_year`** (4.4K rows): no `canonical_cause` column. Use when no cause filter is in play.
+- **`mv_crashes_by_cause`** (19.7K rows): adds `canonical_cause`. Use when filtering or grouping by cause.
+- **`mv_crashes_by_hour`** (307K rows): adds `crash_hour` AND drops `total_killed`/`total_injured`. Only use for hour-grouped queries; can return counts only, not casualty totals.
+- **`mv_crash_victims_by_demographics`** (26K rows): totally different dimensions — counts **victims**, not crashes, and breaks them down by `(county, year, severity, gender, age_bracket)`. Use for `?group_by=gender|age_bracket`. Source rows are `crash_victims` JOINed to `crashes` on `(collision_id, data_source)`; one fatal crash with 3 injured passengers contributes 3 to `victim_count`. Has no `canonical_cause` column, so the cause filter is rejected on these grouping paths.
+
+### Extra bucket values introduced by the MVs
+
+The view DDL uses `COALESCE(severity, 'Unknown')` and `COALESCE(canonical_cause, 'uncategorized')` so NULL keys don't collapse into a single bucket. As a result, output of `/api/stats?group_by=cause|severity` includes two values that are **not** in the base table:
+
+- `canonical_cause = 'uncategorized'` — ~381K crashes (3.4%) where `crashes.canonical_cause` is NULL. Filter input still accepts only `dui|speeding|lane-change|other`; consumers get this value only in grouped output.
+- `severity = 'Unknown'` — 4 crashes (negligible) where `crashes.severity` is NULL.
+
+Ignore or hide both when presenting a fixed taxonomy; keep when plotting distributions so the total matches `COUNT(*)`.
+
+Refresh is concurrent (each view has a UNIQUE index), wired into the ETL orchestrator (issue #101). Until #109 ships a freshness pill, consumers can't see how stale a view is.
+
+### PostGIS is not installed
+
+Spatial endpoints (`?bbox=...`) and any `ST_*` functions will fail. Issue #107 tracks the install. Map UIs render from county-level aggregates (`/api/stats?group_by=county`) until #107 lands.
+
+## Demographics field reference (36 fields)
+
+Per (county, year). Sourced from Census ACS 5-year (2010+) or ACS 1-year (2005-2009; smaller counties absent for those years).
+
+| Group | Fields |
+|---|---|
+| **Identity** | `id`, `county_code`, `year` |
+| **Basics** | `population`, `median_age`, `median_income`, `population_density`, `per_capita_income` (B19301) |
+| **Race/Ethnicity** (B03002) | `pct_white`, `pct_black`, `pct_asian`, `pct_hispanic`, `pct_other_race` |
+| **Age** (B01001) | `pct_under_18`, `pct_18_24`, `pct_25_44`, `pct_45_64`, `pct_65_plus` |
+| **Sex** (B01001) | `pct_male`, `pct_female` |
+| **Socioeconomic** | `poverty_rate` (B17001), `pct_bachelors_or_higher` + `pct_high_school_or_higher` (B15003 — null pre-2012) |
+| **Housing/Transport** | `pct_no_vehicle` (B08201), `pct_owner_occupied_housing` (B25003), `pct_rent_burdened` (B25070; ≥30% of income in rent) |
+| **Commute** (B08006) | `commute_drive_alone_pct`, `commute_carpool_pct`, `commute_transit_pct`, `commute_walk_pct`, `commute_bike_pct`, `commute_wfh_pct`, `mean_travel_time_to_work` (B08013 / commute_total) |
+| **Equity / lifecycle** | `pct_foreign_born` (B05002), `pct_enrolled_in_school` (B14001), `pct_veteran` (B21001), `pct_with_disability` (B18101) |
+| **Language** (B16001) | `pct_english_only`, `pct_spanish_speaking` |
+
+**Coverage caveats** as of 2026-04-18 ETL:
+- `per_capita_income`, `pct_male`, `pct_female`, `pct_foreign_born`, `pct_rent_burdened`, `pct_enrolled_in_school`, `pct_veteran`: **954/1012** (matches existing demographics gap — pre-2010 small counties not in ACS1)
+- `mean_travel_time_to_work`: **912/1012** (B08013 absent in some early-year requests)
+- `pct_with_disability`: **718/1012** (B18101 not consistently published before 2010)


### PR DESCRIPTION
 ## What does this PR do?

  Ships the full `/api/*` layer for the CalSight dashboard — 21 read-only endpoints that unblock the MapPage, StatsPage,
   and AI panels:

  - **Crash data:** `/api/crashes` (paginated detail), `/api/stats` (aggregated, 7 `group_by` modes backed by 4
  materialized views), crash-party and victim drill-down + cross-crash queries
  - **Demographics:** expanded from 27 → 36 fields (gender, per-capita income, commute time, foreign-born share, rent
  burden, school enrollment, veterans, disability)
  - **Context:** unemployment, vehicles, licensed-drivers, data-quality (with NULL-scope semantics), insights
  - **Reference:** counties (optional GeoJSON), hospitals (trauma-only filter), schools (paginated), calenviroscreen,
  road-miles, traffic-volumes, speed-limits
  - **Meta:** `/api/meta/data-freshness` for the "data as of" pill

  All crash-data filters (`year`, `county`, `severity`, `cause`, `alcohol`, `distracted`) go through a single shared
  parser (`backend/app/filters.py`) that returns 422 with a clear `{detail, filter}` envelope on unknown values — no
  silent mismatches. Global exception handler in `main.py` maps `FilterError` → 422 and catches unhandled exceptions →
  500 without leaking stack traces.

  ## How to test
  - [ ] `cd backend && pytest -m "not integration"` — unit tests pass (filters, slug map, ETL, schemas)
  - [ ] `docker-compose up -d db && cd backend && pytest -m integration` — 58+ integration tests pass against a fresh
  seeded Postgres
  - [ ] `cd backend && ruff check .` — lint clean
  - [ ] `uvicorn app.main:app --reload` then hit a few endpoints:
    - `curl "http://localhost:8000/api/stats?group_by=county&year=2023"` → 58 rows
    - `curl "http://localhost:8000/api/crashes?year=2023&severity=fatal&limit=3"` → 3 real fatals
    - `curl "http://localhost:8000/api/stats?group_by=gender"` → 3 rows (M/F/U)
    - `curl "http://localhost:8000/api/crashes?severity=severe-injury"` → 422
  - [ ] Open http://localhost:8000/docs and spot-check the Swagger UI — 21 endpoints grouped by tag
  - [ ] CI green on both the backend (unit + integration via Postgres service) and frontend jobs

  ## Checklist
  - [x] Code builds without errors
  - [x] Tested locally (337 tests pass; also live-probed against Azure)
  - [x] No console errors/warnings