### PR TITLE
111-frontend-align-filter-values-with-backend-db-truth-severity-cause…

### DIFF
--- a/frontend/src/hooks/useChoroplethData.test.tsx
+++ b/frontend/src/hooks/useChoroplethData.test.tsx
@@ -218,6 +218,40 @@ describe("useChoroplethData", () => {
     expect(result.current.dataSummary.totalCrashes).toBe(400_487);
   });
 
+  it("exposes is422 when backend returns 422", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats")) {
+        return new Response(JSON.stringify({ detail: "bad filter" }), { status: 422 });
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(
+      () => useChoroplethData("crashes_per_100k", FILTERS),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.is422).toBe(true);
+  });
+
+  it("is422 is false for non-422 errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats")) {
+        return new Response("Internal Server Error", { status: 500 });
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(
+      () => useChoroplethData("crashes_per_100k", FILTERS),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.is422).toBe(false);
+  });
+
   it("marks a county as no-data when population is missing", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);


### PR DESCRIPTION
- Severity collapsed to 3 DB values, causes to 4, stale values rejected by parsers
  - Alcohol/distracted boolean toggles with URL params and FiltersPanel UI
  - Stale fixture data fixed bugs
  - Measure dropdown restyled as custom component matching counties dropdown (#120)
  - Legend shifts up on mobile when search is open (#121)
  - Dropdown opens upward to avoid clipping
  - Large numbers on "Total crashes" legend use compact formatting (1.2K, 25K, 1.2M)
  - "All selected" → "none selected" no longer triggers a refetch

  ## What does this PR do?

  Aligns frontend filter values with DB truth and adds involvement toggles.

  Severity: 4 → 3 values. Causes: 6 → 4. Stale values (`Severe Injury`, `distracted`,
  `weather`) removed — they caused 422s. Parsers silently drop unknown URL values.

  New `?alcohol=true` / `?distracted=true` toggle pills in FiltersPanel. These are NOT
  forwarded to `/api/stats` (MVs lack those columns) — preserved in URL for future
  drill-down endpoints. CCRS 2016+ only.

  Choropleth legend: native `<select>` → custom upward-opening dropdown (#120). Legend
  shifts up on mobile when search is open (#121). Compact number formatting on "Total
  crashes". 422s show inline warning instead of blanking the map.

  "All selected" now normalizes to empty array, avoiding redundant refetch.

  ## How to test
  - [x] Verify 3 severities and 4 causes in filter panel
  - [x] Toggle alcohol/distracted — URL updates, CCRS note appears
  - [x] Measure dropdown opens upward, styled like county selector
  - [x] Mobile: search bar open → legend shifts up
  - [x] "Total crashes" shows compact numbers (25K, 1.2M)
  - [x] Select all severities → no network request fires
  - [x] Paste `?severity=severe-injury` → silently dropped

  ## Checklist
  - [x] Code builds without errors
  - [x] Tested locally
  - [x] No console errors/warnings

