### PR TITLE
122 frontend alert when selected years lack demographics data

### DIFF
--- a/frontend/src/hooks/useChoroplethData.test.tsx
+++ b/frontend/src/hooks/useChoroplethData.test.tsx
@@ -218,6 +218,40 @@ describe("useChoroplethData", () => {
     expect(result.current.dataSummary.totalCrashes).toBe(400_487);
   });
 
+  it("exposes is422 when backend returns 422", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats")) {
+        return new Response(JSON.stringify({ detail: "bad filter" }), { status: 422 });
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(
+      () => useChoroplethData("crashes_per_100k", FILTERS),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.is422).toBe(true);
+  });
+
+  it("is422 is false for non-422 errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats")) {
+        return new Response("Internal Server Error", { status: 500 });
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(
+      () => useChoroplethData("crashes_per_100k", FILTERS),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.is422).toBe(false);
+  });
+
   it("marks a county as no-data when population is missing", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);


### PR DESCRIPTION
## What does this PR do?
Adds a data availability summary to the choropleth legend so users understand why counties show as no-data. Shows total crash count for the current filter selection, flags the current year as in-progress, and warns when per-capita measures lack population data (completely missing years like 2001–2004/2024+ and partially covered years like 2005–2009). Includes a quick-action button to switch to Total Crashes when demographics gaps affect the active measure.

## How to test
 - Select years 2024–2025 with "Crashes per 100k" — legend shows "No population data for 2024–2025" with Switch to Total  Crashes button
  - Select years 2005–2009 with any per-capita measure — legend shows "Partial population data for 2005–2009"
  - Select year 2026 — legend shows "2026: 487 crashes (in progress)"
  - Select year 2021 with DUI + Fatal filters — no "in progress" warning despite low count
  - Switch to Total Crashes or Fatality Rate — demographics warnings disappear
  - Click "Switch to Total Crashes" button — measure changes and warning clears
  - Verify total crash count updates when filters change

## Checklist
- [x] Code builds without errors
- [x] Tested locally
- [x] No console errors/warnings
