### PR TITLE
76-map-county-click-interaction-select-highlight-show-data

### DIFF
--- a/frontend/src/components/map/AiInsightCard.test.tsx
+++ b/frontend/src/components/map/AiInsightCard.test.tsx
@@ -2,31 +2,135 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AiInsightCard from "./AiInsightCard";
+import type { ChoroplethPoint } from "../../hooks/useChoroplethData";
+
+const POINT_A: ChoroplethPoint = {
+  value: 487.2,
+  rawCount: 48291,
+  totalKilled: 412,
+  totalInjured: 12847,
+  hasEnoughData: true,
+};
+
+const POINT_B: ChoroplethPoint = {
+  value: 256.8,
+  rawCount: 8412,
+  totalKilled: 67,
+  totalInjured: 2103,
+  hasEnoughData: true,
+};
 
 describe("AiInsightCard", () => {
-  it("renders default county name 'Fresno' when no prop provided", () => {
-    render(<AiInsightCard onClose={vi.fn()} />);
-    expect(screen.getByText("Fresno County")).toBeInTheDocument();
-  });
-
-  it("renders custom county name when provided", () => {
-    render(<AiInsightCard onClose={vi.fn()} countyName="Los Angeles" />);
+  it("renders county name and real stats in single mode", () => {
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Los Angeles"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={false}
+        onCompare={vi.fn()}
+      />,
+    );
     expect(screen.getByText("Los Angeles County")).toBeInTheDocument();
+    expect(screen.getByText("48,291")).toBeInTheDocument();
+    expect(screen.getByText("412")).toBeInTheDocument();
+    expect(screen.getByText("12,847")).toBeInTheDocument();
+    expect(screen.getByText("487")).toBeInTheDocument();
   });
 
   it("calls onClose when close button is clicked", async () => {
     const onClose = vi.fn();
-    render(<AiInsightCard onClose={onClose} />);
-    const closeButton = screen.getByText("close").closest("button")!;
-    await userEvent.click(closeButton);
+    render(
+      <AiInsightCard
+        onClose={onClose}
+        countyName="Fresno"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={false}
+        onCompare={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByText("close").closest("button")!);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("renders metric cards", () => {
-    render(<AiInsightCard onClose={vi.fn()} />);
-    expect(screen.getByText("Total Crashes")).toBeInTheDocument();
-    expect(screen.getByText("2,847")).toBeInTheDocument();
-    expect(screen.getByText("YoY Trend")).toBeInTheDocument();
-    expect(screen.getByText("-3.1%")).toBeInTheDocument();
+  it("shows Compare button in single mode", () => {
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Fresno"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={false}
+        onCompare={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /compare/i })).toBeInTheDocument();
+  });
+
+  it("calls onCompare when Compare button is clicked", async () => {
+    const onCompare = vi.fn();
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Fresno"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={false}
+        onCompare={onCompare}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /compare/i }));
+    expect(onCompare).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows prompt text when in compare mode without second county", () => {
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Fresno"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={true}
+        onCompare={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/click a county to compare/i)).toBeInTheDocument();
+  });
+
+  it("shows compare layout with both counties and percent diff", () => {
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Los Angeles"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={true}
+        onCompare={vi.fn()}
+        compareCountyName="Orange"
+        compareData={POINT_B}
+      />,
+    );
+    expect(screen.getByText("Los Angeles")).toBeInTheDocument();
+    expect(screen.getByText("Orange")).toBeInTheDocument();
+    expect(screen.getByText("48,291")).toBeInTheDocument();
+    expect(screen.getByText("8,412")).toBeInTheDocument();
+    expect(screen.getByText("-82.6%")).toBeInTheDocument();
+  });
+
+  it("shows N/A for measure value when hasEnoughData is false", () => {
+    const noData: ChoroplethPoint = { value: null, rawCount: 3, totalKilled: 0, totalInjured: 1, hasEnoughData: false };
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Alpine"
+        data={noData}
+        measureLabel="Per 100k"
+        compareMode={false}
+        onCompare={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("N/A")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -1,16 +1,99 @@
+import type { ChoroplethPoint } from "../../hooks/useChoroplethData";
+
 interface AiInsightCardProps {
   onClose: () => void;
-  countyName?: string;
+  countyName: string;
+  data: ChoroplethPoint | undefined;
+  measureLabel: string;
+  compareMode: boolean;
+  onCompare: () => void;
+  compareCountyName?: string;
+  compareData?: ChoroplethPoint;
 }
 
-export default function AiInsightCard({ onClose, countyName = "Fresno" }: AiInsightCardProps) {
+function fmt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function fmtMeasure(n: number): string {
+  return Math.round(n).toLocaleString("en-US");
+}
+
+function pctDiff(a: number, b: number): string | null {
+  if (a === 0 && b === 0) return null;
+  if (a === 0) return null;
+  const diff = ((b - a) / a) * 100;
+  const sign = diff > 0 ? "+" : "";
+  return `${sign}${diff.toFixed(1)}%`;
+}
+
+function measureValue(data: ChoroplethPoint): string {
+  return data.hasEnoughData && data.value != null
+    ? fmtMeasure(data.value)
+    : "N/A";
+}
+
+function MetricGrid({ data, measureLabel }: { data: ChoroplethPoint; measureLabel: string }) {
   return (
-    <div className="fixed bottom-24 left-4 right-4 md:absolute md:bottom-auto md:left-auto md:right-[10%] md:top-[25%] z-30 md:w-[340px] bg-surface-container-lowest/90 backdrop-blur-md p-6 rounded-xl ambient-shadow ghost-border flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex justify-between items-start">
-        <span className="text-[10px] font-bold text-primary uppercase tracking-[0.2em]">
-          AI Insight
-        </span>
+    <div className="grid grid-cols-2 gap-3 md:gap-4 py-1 md:py-2">
+      <MetricCell label="Total Crashes" value={fmt(data.rawCount)} />
+      <MetricCell label="Killed" value={fmt(data.totalKilled)} />
+      <MetricCell label="Injured" value={fmt(data.totalInjured)} />
+      <MetricCell label={measureLabel} value={measureValue(data)} />
+    </div>
+  );
+}
+
+function MetricCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-surface-container-low/50 p-2 md:p-3 rounded-lg">
+      <p className="text-[8px] md:text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-0.5 md:mb-1">
+        {label}
+      </p>
+      <p className="text-base md:text-lg font-bold text-on-surface">{value}</p>
+    </div>
+  );
+}
+
+function CompareRow({ label, aVal, bVal, isMeasure }: { label: string; aVal: number | null; bVal: number | null; isMeasure?: boolean }) {
+  const f = isMeasure ? fmtMeasure : fmt;
+  const aStr = aVal != null ? f(aVal) : "N/A";
+  const bStr = bVal != null ? f(bVal) : "N/A";
+  const diff = aVal != null && bVal != null ? pctDiff(aVal, bVal) : null;
+
+  return (
+    <div className="bg-surface-container-low/50 p-2 md:p-3 rounded-lg">
+      <p className="text-[8px] md:text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-1 md:mb-2">
+        {label}
+      </p>
+      <div className="flex items-baseline justify-between gap-1 md:gap-2">
+        <span className="text-base md:text-lg font-bold text-on-surface">{aStr}</span>
+        {diff && (
+          <span className={`text-[10px] md:text-xs font-semibold ${diff.startsWith("+") ? "text-error" : "text-tertiary"}`}>
+            {diff}
+          </span>
+        )}
+        <span className="text-base md:text-lg font-bold text-on-surface">{bStr}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function AiInsightCard({
+  onClose,
+  countyName,
+  data,
+  measureLabel,
+  compareMode,
+  onCompare,
+  compareCountyName,
+  compareData,
+}: AiInsightCardProps) {
+  const isComparing = compareMode && compareCountyName && compareData;
+
+  return (
+    <div className={`fixed bottom-14 left-2 right-2 max-h-[55vh] overflow-y-auto md:max-h-none md:overflow-visible md:absolute md:bottom-auto md:left-auto md:right-[10%] md:top-[25%] z-30 ${isComparing ? "md:w-[420px]" : "md:w-[340px]"} bg-surface-container-lowest/90 backdrop-blur-md p-4 md:p-6 rounded-xl ambient-shadow ghost-border flex flex-col gap-2 md:gap-4`}>
+      <div className="flex justify-end items-start">
         <button
           onClick={onClose}
           className="p-1 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
@@ -19,38 +102,51 @@ export default function AiInsightCard({ onClose, countyName = "Fresno" }: AiInsi
         </button>
       </div>
 
-      {/* Title + description */}
-      <div className="space-y-1">
-        <h3 className="font-headline text-2xl font-bold text-on-surface tracking-tight leading-tight">
-          {countyName} County
-        </h3>
-        <p className="text-xs text-on-surface-variant leading-relaxed">
-          Significant increase in commercial traffic detected along the CA-99
-          corridor. Predictive models suggest a 12% rise in infrastructure
-          fatigue over the next fiscal quarter.
-        </p>
-      </div>
+      {isComparing && data ? (
+        <>
+          <div className="flex items-center justify-between">
+            <h3 className="font-headline text-sm md:text-base font-bold text-on-surface tracking-tight">{countyName}</h3>
+            <span className="text-[10px] md:text-xs text-on-surface-variant">vs</span>
+            <h3 className="font-headline text-sm md:text-base font-bold text-on-surface tracking-tight">{compareCountyName}</h3>
+          </div>
+          <div className="flex flex-col gap-2 md:gap-3">
+            <CompareRow label="Total Crashes" aVal={data.rawCount} bVal={compareData.rawCount} />
+            <CompareRow label="Killed" aVal={data.totalKilled} bVal={compareData.totalKilled} />
+            <CompareRow label="Injured" aVal={data.totalInjured} bVal={compareData.totalInjured} />
+            <CompareRow
+              label={measureLabel}
+              aVal={data.hasEnoughData ? data.value : null}
+              bVal={compareData.hasEnoughData ? compareData.value : null}
+              isMeasure
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="space-y-1">
+            <h3 className="font-headline text-xl md:text-2xl font-bold text-on-surface tracking-tight leading-tight">
+              {countyName} County
+            </h3>
+          </div>
 
-      {/* 2-column metrics */}
-      <div className="grid grid-cols-2 gap-4 py-2">
-        <div className="bg-surface-container-low/50 p-3 rounded-lg">
-          <p className="text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-1">
-            Total Crashes
-          </p>
-          <p className="text-lg font-bold text-on-surface">2,847</p>
-        </div>
-        <div className="bg-surface-container-low/50 p-3 rounded-lg">
-          <p className="text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-1">
-            YoY Trend
-          </p>
-          <p className="text-lg font-bold text-error">-3.1%</p>
-        </div>
-      </div>
+          {data && <MetricGrid data={data} measureLabel={measureLabel} />}
 
-      {/* CTA */}
-      <button className="w-full bg-primary-container text-on-primary-container py-3 rounded-lg text-[11px] font-bold tracking-widest uppercase hover:opacity-90 transition-opacity">
-        View Full Stats
-      </button>
+          {compareMode && !compareCountyName && (
+            <p className="text-xs md:text-sm text-on-surface-variant text-center py-1 md:py-2">
+              Click a county to compare
+            </p>
+          )}
+
+          {!compareMode && (
+            <button
+              onClick={onCompare}
+              className="w-full bg-primary-container text-on-primary-container py-2 md:py-3 rounded-lg text-[11px] font-bold tracking-widest uppercase hover:opacity-90 transition-opacity"
+            >
+              Compare
+            </button>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/map/Breadcrumb.test.tsx
+++ b/frontend/src/components/map/Breadcrumb.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Breadcrumb from "./Breadcrumb";
+
+describe("Breadcrumb", () => {
+  it("shows default text when no county is selected", () => {
+    render(<Breadcrumb inspectedCounty={null} compareCounty={null} onDeselect={vi.fn()} />);
+    expect(screen.getByText("Map Explorer")).toBeInTheDocument();
+  });
+
+  it("shows county name when a county is inspected", () => {
+    render(<Breadcrumb inspectedCounty="Fresno" compareCounty={null} onDeselect={vi.fn()} />);
+    expect(screen.getByText("Fresno County")).toBeInTheDocument();
+    expect(screen.queryByText("Map Explorer")).not.toBeInTheDocument();
+  });
+
+  it("shows compare text when two counties are selected", () => {
+    render(<Breadcrumb inspectedCounty="Fresno" compareCounty="Alameda" onDeselect={vi.fn()} />);
+    expect(screen.getByText(/Fresno/)).toBeInTheDocument();
+    expect(screen.getByText(/Alameda/)).toBeInTheDocument();
+    expect(screen.getByText(/vs/)).toBeInTheDocument();
+  });
+
+  it("calls onDeselect when State Index is clicked", async () => {
+    const onDeselect = vi.fn();
+    render(<Breadcrumb inspectedCounty="Fresno" compareCounty={null} onDeselect={onDeselect} />);
+    await userEvent.click(screen.getByText("State Index"));
+    expect(onDeselect).toHaveBeenCalledTimes(1);
+  });
+
+  it("State Index is not clickable when no county is selected", () => {
+    render(<Breadcrumb inspectedCounty={null} compareCounty={null} onDeselect={vi.fn()} />);
+    const stateIndex = screen.getByText("State Index");
+    expect(stateIndex.closest("button")).toBeNull();
+  });
+});

--- a/frontend/src/components/map/Breadcrumb.tsx
+++ b/frontend/src/components/map/Breadcrumb.tsx
@@ -1,11 +1,37 @@
-export default function Breadcrumb() {
+interface BreadcrumbProps {
+  inspectedCounty: string | null;
+  compareCounty: string | null;
+  onDeselect: () => void;
+}
+
+export default function Breadcrumb({ inspectedCounty, compareCounty, onDeselect }: BreadcrumbProps) {
+  const hasSelection = inspectedCounty !== null;
+
+  let label: React.ReactNode;
+  if (inspectedCounty && compareCounty) {
+    label = <span className="text-on-surface">{inspectedCounty} <span className="text-on-surface/60">vs</span> {compareCounty}</span>;
+  } else if (inspectedCounty) {
+    label = <span className="text-on-surface">{inspectedCounty} County</span>;
+  } else {
+    label = <span className="text-on-surface">Map Explorer</span>;
+  }
+
   return (
-    <div className="hidden md:block absolute top-8 left-8 z-10 pointer-events-none">
+    <div className="hidden md:block absolute top-8 left-8 z-10 pointer-events-auto">
       <div className="bg-surface-container-lowest/40 backdrop-blur-sm px-4 py-2 rounded-lg">
         <p className="text-[11px] font-medium tracking-[0.3em] text-on-surface/60 uppercase">
-          State Index{" "}
-          <span className="mx-2">/</span>{" "}
-          <span className="text-on-surface">Map Explorer</span>
+          {hasSelection ? (
+            <button
+              onClick={onDeselect}
+              className="hover:underline hover:text-on-surface/80 cursor-pointer transition-colors"
+            >
+              State Index
+            </button>
+          ) : (
+            <span>State Index</span>
+          )}
+          <span className="mx-2">/</span>
+          {label}
         </p>
       </div>
     </div>

--- a/frontend/src/components/map/CountyBoundaries.test.tsx
+++ b/frontend/src/components/map/CountyBoundaries.test.tsx
@@ -180,4 +180,29 @@ describe("CountyBoundaries", () => {
       expect(totalCalls).toBeGreaterThan(0);
     });
   });
+
+  it("applies highlight style to compareCounty", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <MemoryRouter>
+        <QueryClientProvider client={client}>
+          <ThemeProvider>
+          <LayersStateProvider>
+            <CountyBoundaries
+              focusedCounty="Fresno"
+              compareCounty="Alameda"
+              onFocusCounty={onFocusCounty}
+              onSelectCounty={onSelectCounty}
+            />
+          </LayersStateProvider>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(L.geoJSON).toHaveBeenCalled());
+    const totalCalls =
+      featureLayerMocks[0].setStyle.mock.calls.length +
+      featureLayerMocks[1].setStyle.mock.calls.length;
+    expect(totalCalls).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -10,6 +10,7 @@ import { useIsDark } from "../../context/ThemeContext";
 
 interface CountyBoundariesProps {
   focusedCounty: string | null;
+  compareCounty?: string | null;
   onFocusCounty: (name: string | null) => void;
   onSelectCounty: (name: string) => void;
 }
@@ -35,6 +36,7 @@ function getCountyCode(f: GeoJSON.Feature): number | null {
 
 export default function CountyBoundaries({
   focusedCounty,
+  compareCounty = null,
   onFocusCounty,
   onSelectCounty,
 }: CountyBoundariesProps) {
@@ -64,9 +66,15 @@ export default function CountyBoundaries({
   const [geojson, setGeojson] = useState<GeoJSON.FeatureCollection | null>(null);
   const layerRef = useRef<L.GeoJSON | null>(null);
   const tooltipRef = useRef<L.Tooltip | null>(null);
+  const compareTooltipRef = useRef<L.Tooltip | null>(null);
   const edgesRef = useRef<number[] | null>(null);
 
-  // Ref so event handlers (bound once) can read current filter state
+  // Refs so event handlers (bound once) can read current callback/filter state
+  const onFocusCountyRef = useRef(onFocusCounty);
+  onFocusCountyRef.current = onFocusCounty;
+  const onSelectCountyRef = useRef(onSelectCounty);
+  onSelectCountyRef.current = onSelectCounty;
+
   const countyFilterRef = useRef<{ has: Set<string>; active: boolean }>({
     has: selectedCounties,
     active: hasCountyFilter,
@@ -91,7 +99,7 @@ export default function CountyBoundaries({
   const computeStyle = useCallback(
     (feature: GeoJSON.Feature): L.PathOptions => {
       const name = getCountyName(feature);
-      const isFocused = name === focusedCounty;
+      const isFocused = name === focusedCounty || name === compareCounty;
       const outlineColor = isDark ? "#a3a3a3" : "#78716c";
 
       // When counties are filtered via the UI, unselected counties
@@ -146,7 +154,7 @@ export default function CountyBoundaries({
         fillOpacity: 0.75,
       };
     },
-    [choroplethOn, otherLayers.countyBoundaries, focusedCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
+    [choroplethOn, otherLayers.countyBoundaries, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
   );
 
   // Ref so mouseout can re-apply the *current* style (not the stale one
@@ -199,8 +207,8 @@ export default function CountyBoundaries({
           const name = getCountyName(feature);
           featureLayer.on({
             click: () => {
-              onFocusCounty(name);
-              onSelectCounty(name);
+              onFocusCountyRef.current(name);
+              onSelectCountyRef.current(name);
             },
             mouseover: (e) => {
               if (name === focusedCounty) return;
@@ -259,37 +267,65 @@ export default function CountyBoundaries({
   }, [map, rebucketAndRepaint]);
 
   useEffect(() => {
+    const handleMapClick = (e: L.LeafletMouseEvent) => {
+      const target = e.originalEvent?.target as HTMLElement | undefined;
+      if (target?.closest?.(".leaflet-interactive")) return;
+      onFocusCounty(null);
+    };
+    map.on("click", handleMapClick);
+    return () => {
+      map.off("click", handleMapClick);
+    };
+  }, [map, onFocusCounty]);
+
+  useEffect(() => {
     if (tooltipRef.current) {
       map.removeLayer(tooltipRef.current);
       tooltipRef.current = null;
     }
-    if (!focusedCounty || !layerRef.current) return;
-    layerRef.current.eachLayer((fl) => {
-      const f = (fl as L.GeoJSON & { feature: GeoJSON.Feature }).feature;
-      if (f && getCountyName(f) === focusedCounty) {
-        const bounds = (fl as L.Polygon).getBounds();
-        const center = bounds.getCenter();
-        const tooltip = L.tooltip({
-          permanent: true,
-          direction: "center",
-          className: "county-focus-tooltip",
-        })
-          .setLatLng(center)
-          .setContent(focusedCounty)
-          .addTo(map);
-        tooltipRef.current = tooltip;
-        if (!map.getBounds().contains(center)) {
-          map.panTo(center, { animate: true });
+    if (compareTooltipRef.current) {
+      map.removeLayer(compareTooltipRef.current);
+      compareTooltipRef.current = null;
+    }
+
+    if (!layerRef.current) return;
+
+    const showTooltipFor = (name: string, ref: React.MutableRefObject<L.Tooltip | null>) => {
+      layerRef.current!.eachLayer((fl) => {
+        const f = (fl as L.GeoJSON & { feature: GeoJSON.Feature }).feature;
+        if (f && getCountyName(f) === name) {
+          const bounds = (fl as L.Polygon).getBounds();
+          const center = bounds.getCenter();
+          const tooltip = L.tooltip({
+            permanent: true,
+            direction: "center",
+            className: "county-focus-tooltip",
+          })
+            .setLatLng(center)
+            .setContent(name)
+            .addTo(map);
+          ref.current = tooltip;
+          if (!map.getBounds().contains(center)) {
+            map.panTo(center, { animate: true });
+          }
         }
-      }
-    });
+      });
+    };
+
+    if (focusedCounty) showTooltipFor(focusedCounty, tooltipRef);
+    if (compareCounty) showTooltipFor(compareCounty, compareTooltipRef);
+
     return () => {
       if (tooltipRef.current) {
         map.removeLayer(tooltipRef.current);
         tooltipRef.current = null;
       }
+      if (compareTooltipRef.current) {
+        map.removeLayer(compareTooltipRef.current);
+        compareTooltipRef.current = null;
+      }
     };
-  }, [focusedCounty, map]);
+  }, [focusedCounty, compareCounty, map]);
 
   return null;
 }

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -15,6 +15,7 @@ const CA_BOUNDS: LatLngBoundsExpression = [
 
 interface MapCanvasProps {
   focusedCounty: string | null;
+  compareCounty?: string | null;
   onFocusCounty: (name: string | null) => void;
   onSelectCounty: (name: string) => void;
   onMapReady: (map: LeafletMap) => void;
@@ -22,6 +23,7 @@ interface MapCanvasProps {
 
 function MapInternals({
   focusedCounty,
+  compareCounty,
   onFocusCounty,
   onSelectCounty,
   onMapReady,
@@ -35,6 +37,7 @@ function MapInternals({
   return (
     <CountyBoundaries
       focusedCounty={focusedCounty}
+      compareCounty={compareCounty}
       onFocusCounty={onFocusCounty}
       onSelectCounty={onSelectCounty}
     />
@@ -43,6 +46,7 @@ function MapInternals({
 
 export default function MapCanvas({
   focusedCounty,
+  compareCounty,
   onFocusCounty,
   onSelectCounty,
   onMapReady,
@@ -81,6 +85,7 @@ export default function MapCanvas({
 
       <MapInternals
         focusedCounty={focusedCounty}
+        compareCounty={compareCounty}
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onMapReady={onMapReady}

--- a/frontend/src/hooks/useChoroplethData.test.tsx
+++ b/frontend/src/hooks/useChoroplethData.test.tsx
@@ -71,8 +71,30 @@ describe("useChoroplethData", () => {
     expect(result.current.byCountyCode[19]).toEqual({
       value: 20,
       rawCount: 10,
+      totalKilled: 2,
+      totalInjured: 3,
       hasEnoughData: true,
     });
+  });
+
+  it("provides a nameToCode mapping from county_name to county_code", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats")) {
+        return new Response(JSON.stringify([
+          { county_code: 19, county_name: "Fresno", crash_count: 10, total_killed: 2, total_injured: 3 },
+          { county_code: 1, county_name: "Alameda", crash_count: 5, total_killed: 1, total_injured: 2 },
+        ]));
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(
+      () => useChoroplethData("crashes_raw", FILTERS),
+      { wrapper: makeWrapper() },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.nameToCode).toEqual({ Fresno: 19, Alameda: 1 });
   });
 
   it("does NOT refetch when only measure changes", async () => {
@@ -271,6 +293,8 @@ describe("useChoroplethData", () => {
     expect(result.current.byCountyCode[19]).toEqual({
       value: null,
       rawCount: 10,
+      totalKilled: 2,
+      totalInjured: 3,
       hasEnoughData: false,
     });
   });

--- a/frontend/src/hooks/useChoroplethData.ts
+++ b/frontend/src/hooks/useChoroplethData.ts
@@ -25,6 +25,8 @@ export type ChoroplethFilters = {
 
 export type ChoroplethPoint = MeasureResult & {
   rawCount: number;
+  totalKilled: number;
+  totalInjured: number;
 };
 
 export type DataSummary = {
@@ -40,6 +42,7 @@ const CURRENT_YEAR = new Date().getFullYear();
 
 export type ChoroplethData = {
   byCountyCode: Record<number, ChoroplethPoint>;
+  nameToCode: Record<string, number>;
   isLoading: boolean;
   isError: boolean;
   /** True when the backend returned 422 (bad filter value). The map retains
@@ -133,8 +136,8 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
   const demos = demoQ.data;
   const yearStats = yearStatsQ.data;
 
-  const byCountyCode = useMemo<Record<number, ChoroplethPoint>>(() => {
-    if (!stats) return {};
+  const { byCountyCode, nameToCode } = useMemo(() => {
+    if (!stats) return { byCountyCode: {} as Record<number, ChoroplethPoint>, nameToCode: {} as Record<string, number> };
     const demoByCounty = new Map<number, CountyYearDemo[]>();
     for (const d of demos ?? []) {
       const arr = demoByCounty.get(d.county_code) ?? [];
@@ -142,11 +145,13 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
       demoByCounty.set(d.county_code, arr);
     }
     const out: Record<number, ChoroplethPoint> = {};
+    const ntc: Record<string, number> = {};
     for (const s of stats) {
       const result = computeMeasureValue(measure, s, demoByCounty.get(s.county_code) ?? []);
-      out[s.county_code] = { ...result, rawCount: s.crash_count };
+      out[s.county_code] = { ...result, rawCount: s.crash_count, totalKilled: s.total_killed, totalInjured: s.total_injured };
+      ntc[s.county_name] = s.county_code;
     }
-    return out;
+    return { byCountyCode: out, nameToCode: ntc };
   }, [stats, demos, measure]);
 
   const dataSummary = useMemo<DataSummary>(() => {
@@ -183,6 +188,7 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
 
   return {
     byCountyCode,
+    nameToCode,
     isLoading: statsQ.isLoading || demoQ.isLoading || yearStatsQ.isLoading,
     isError: statsQ.isError || demoQ.isError,
     is422: rawError?.status === 422,

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -5,7 +5,8 @@ import { useFilterParams, CA_COUNTIES } from "../hooks/useFilterParams";
 import { useMapKeyboard } from "../hooks/useMapKeyboard";
 import { LayersStateProvider, useLayersState } from "../hooks/useLayersState";
 import ChoroplethLegend from "../components/map/ChoroplethLegend";
-import { useChoroplethData } from "../hooks/useChoroplethData";
+import { useChoroplethData, type ChoroplethData } from "../hooks/useChoroplethData";
+import { MEASURES } from "../lib/choropleth/measures";
 import KeyboardHelpModal from "../components/map/KeyboardHelpModal";
 import IconRail from "../components/map/IconRail";
 import SidePanel from "../components/map/SidePanel";
@@ -67,6 +68,8 @@ function MapPageInner() {
   const [showMobileFilters, setShowMobileFilters] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [focusedCounty, setFocusedCounty] = useState<string | null>(null);
+  const [compareCounty, setCompareCounty] = useState<string | null>(null);
+  const [compareMode, setCompareMode] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [insightCounty, setInsightCounty] = useState("Fresno");
@@ -74,14 +77,59 @@ function MapPageInner() {
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
 
+  const { measure } = useLayersState();
+  const choroplethFilters = useMemo(
+    () => ({
+      years: [...selectedYears].sort((a, b) => a - b),
+      severities: [...selectedSeverities],
+      causes: [...selectedCauses],
+    }),
+    [selectedYears, selectedSeverities, selectedCauses],
+  );
+  const choroplethData = useChoroplethData(measure, choroplethFilters);
+
+  const inspectedCode = focusedCounty ? choroplethData.nameToCode[focusedCounty] : undefined;
+  const inspectedData = inspectedCode != null ? choroplethData.byCountyCode[inspectedCode] : undefined;
+  const compareCode = compareCounty ? choroplethData.nameToCode[compareCounty] : undefined;
+  const comparePointData = compareCode != null ? choroplethData.byCountyCode[compareCode] : undefined;
+  const measureLabel = MEASURES[measure].label;
+
   const handleMapReady = useCallback((map: LeafletMap) => {
     mapRef.current = map;
   }, []);
 
   const handleSelectCounty = useCallback((name: string) => {
-    setInsightCounty(name);
-    setShowInsight(true);
+    if (compareMode && name !== focusedCounty) {
+      setCompareCounty(name);
+    } else {
+      setFocusedCounty(name);
+      setInsightCounty(name);
+      setShowInsight(true);
+      setCompareCounty(null);
+      setCompareMode(false);
+    }
+  }, [compareMode, focusedCounty]);
+
+  const handleDeselect = useCallback(() => {
+    setFocusedCounty(null);
+    setCompareCounty(null);
+    setCompareMode(false);
+    setShowInsight(false);
   }, []);
+
+  const handleStartCompare = useCallback(() => {
+    setCompareMode(true);
+  }, []);
+
+  const handleFocusCounty = useCallback((name: string | null) => {
+    if (compareMode && name !== null) return;
+    setFocusedCounty(name);
+    if (name === null) {
+      setCompareCounty(null);
+      setCompareMode(false);
+      setShowInsight(false);
+    }
+  }, [compareMode]);
 
   function handleClearAll() {
     clearFilters();
@@ -92,19 +140,19 @@ function MapPageInner() {
     if (showHelp) {
       setShowHelp(false);
     } else if (showInsight) {
-      setShowInsight(false);
+      handleDeselect();
     } else if (activePanel) {
       setActivePanel(null);
     } else if (showMobileFilters) {
       setShowMobileFilters(false);
     }
-  }, [showHelp, showInsight, activePanel, showMobileFilters]);
+  }, [showHelp, showInsight, activePanel, showMobileFilters, handleDeselect]);
 
   useMapKeyboard({
     map: mapRef.current,
     counties: countyNames,
     focusedCounty,
-    onFocusCounty: setFocusedCounty,
+    onFocusCounty: handleFocusCounty,
     onSelectCounty: handleSelectCounty,
     onCloseOverlay: handleCloseOverlay,
     onToggleHelp: () => setShowHelp((prev) => !prev),
@@ -208,7 +256,8 @@ function MapPageInner() {
       <section className="flex-1 relative transition-all duration-300">
         <MapCanvas
           focusedCounty={focusedCounty}
-          onFocusCounty={setFocusedCounty}
+          compareCounty={compareCounty}
+          onFocusCounty={handleFocusCounty}
           onSelectCounty={handleSelectCounty}
           onMapReady={handleMapReady}
         />
@@ -222,12 +271,25 @@ function MapPageInner() {
           Filters
         </button>
 
-        {showInsight && (
-          <AiInsightCard onClose={() => setShowInsight(false)} countyName={insightCounty} />
+        {showInsight && focusedCounty && (
+          <AiInsightCard
+            onClose={handleDeselect}
+            countyName={insightCounty}
+            data={inspectedData}
+            measureLabel={measureLabel}
+            compareMode={compareMode}
+            onCompare={handleStartCompare}
+            compareCountyName={compareCounty ?? undefined}
+            compareData={comparePointData}
+          />
         )}
         <SearchPill map={mapRef.current} onExpandedChange={setSearchOpen} />
-        <Breadcrumb />
-        <ChoroplethLegendContainer searchOpen={searchOpen} />
+        <Breadcrumb
+          inspectedCounty={focusedCounty}
+          compareCounty={compareCounty}
+          onDeselect={handleDeselect}
+        />
+        <ChoroplethLegendContainer searchOpen={searchOpen} choroplethData={choroplethData} />
       </section>
 
       {/* Mobile filter bottom sheet */}
@@ -275,30 +337,21 @@ export default function MapPage() {
   );
 }
 
-function ChoroplethLegendContainer({ searchOpen }: { searchOpen?: boolean }) {
-  const { selectedYears, selectedSeverities, selectedCauses } = useFilterParams();
-  const { measure } = useLayersState();
+function ChoroplethLegendContainer({
+  searchOpen,
+  choroplethData,
+}: {
+  searchOpen?: boolean;
+  choroplethData: ChoroplethData;
+}) {
   const queryClient = useQueryClient();
-  // Must match the filter shape used in CountyBoundaries so React Query
-  // dedupes the stats request to a single /api/stats fetch.
-  // NOTE: alcohol/distracted are NOT included — /api/stats can't filter
-  // by those flags (materialized views don't carry them).
-  const filters = useMemo(
-    () => ({
-      years: [...selectedYears].sort((a, b) => a - b),
-      severities: [...selectedSeverities],
-      causes: [...selectedCauses],
-    }),
-    [selectedYears, selectedSeverities, selectedCauses],
-  );
-  const { demographicsAvailable, dataSummary, isError, isLoading, is422 } = useChoroplethData(measure, filters);
   return (
     <ChoroplethLegend
-      demographicsAvailable={demographicsAvailable}
-      dataSummary={dataSummary}
-      isLoading={isLoading}
-      isError={isError}
-      is422={is422}
+      demographicsAvailable={choroplethData.demographicsAvailable}
+      dataSummary={choroplethData.dataSummary}
+      isLoading={choroplethData.isLoading}
+      isError={choroplethData.isError}
+      is422={choroplethData.is422}
       searchOpen={searchOpen}
       onRetry={() => queryClient.invalidateQueries({ queryKey: ["choropleth"] })}
     />


### PR DESCRIPTION
Click a county to inspect its crash stats (total crashes, killed, injured, per-capita rate). Compare button lets you pick a second county for side-by-side view with percent differences. Breadcrumb updates to show selected county names. Click outside, Escape, or X to deselect. Mobile-responsive card layout.

  ## What does this PR do?
  Implements county click interaction (#76). Clicking a county on the map shows a detail card with real stats from the choropleth cache, highlights the county boundary, and updates the breadcrumb. A compare mode lets users select two counties for side-by-side comparison with percent differences. No new API calls — all data comes from the existing useChoroplethData hook.

  ## How to test
  - [ ] Click a county — card appears with stats, breadcrumb shows county name, border highlights
  - [ ] Click a different county — swaps to the new county
  - [ ] Click Compare, then click a second county — side-by-side layout with % diffs
  - [ ] Click X, press Escape, or click outside a county — card dismisses, breadcrumb reverts
  - [ ] Click "State Index" in breadcrumb — deselects
  - [ ] Test on mobile viewport — card stays compact, map remains visible

  ## Checklist
  - [x] Code builds without errors
  - [x] Tested locally
  - [x] No console errors/warnings
