### PR TITLE
fix(#100): surface data quality gaps across frontend and backend

### DIFF
--- a/backend/etl/ckan_api.py
+++ b/backend/etl/ckan_api.py
@@ -61,6 +61,19 @@ def _safe_int(value):
         return None
 
 
+def _safe_count(value):
+    """Like _safe_int but clamps to >= 0 for fields that are counts (killed, injured).
+
+    Source data occasionally contains negative values (e.g. number_killed = -1)
+    which are impossible and survive as-is through _safe_int. Clamp them here
+    rather than propagating nonsensical negatives into aggregates.
+    """
+    n = _safe_int(value)
+    if n is None:
+        return None
+    return max(0, n)
+
+
 def _safe_float(value):
     """Convert a CCRS string value to float. Returns None for nulls/empty/non-numeric."""
     if value is None or value == "":
@@ -150,9 +163,9 @@ def transform_ccrs(record: dict) -> dict:
         "collision_type": record.get("Collision Type Description"),
         "primary_factor": record.get("Primary Collision Factor Violation"),
         "motor_vehicle_involved_with": record.get("MotorVehicleInvolvedWithDesc"),
-        # NumberKilled is stored as TEXT in CCRS — must cast via _safe_int
-        "number_killed": _safe_int(record.get("NumberKilled")),
-        "number_injured": _safe_int(record.get("NumberInjured")),
+        # NumberKilled is stored as TEXT in CCRS — must cast and clamp via _safe_count
+        "number_killed": _safe_count(record.get("NumberKilled")),
+        "number_injured": _safe_count(record.get("NumberInjured")),
         "weather": record.get("Weather 1"),
         "road_condition": record.get("Road Condition 1"),
         "lighting": record.get("LightingDescription"),

--- a/backend/etl/switrs_api.py
+++ b/backend/etl/switrs_api.py
@@ -54,6 +54,18 @@ def _safe_int(value):
         return None
 
 
+def _safe_count(value):
+    """Like _safe_int but clamps to >= 0 for fields that are counts (killed, injured).
+
+    Source data occasionally contains negative values which are impossible for
+    crash counts and produce nonsensical aggregates (e.g. total_killed: -1).
+    """
+    n = _safe_int(value)
+    if n is None:
+        return None
+    return max(0, n)
+
+
 def _safe_float(value):
     """Convert a SWITRS value to float. Returns None for nulls/empty/non-numeric."""
     if value is None or value == "":
@@ -150,8 +162,8 @@ def transform_switrs(row: dict) -> dict:
         "collision_type": row.get("type_of_collision"),
         "primary_factor": row.get("pcf_violation_category"),
         "motor_vehicle_involved_with": row.get("motor_vehicle_involved_with"),
-        "number_killed": _safe_int(row.get("killed_victims")),
-        "number_injured": _safe_int(row.get("injured_victims")),
+        "number_killed": _safe_count(row.get("killed_victims")),
+        "number_injured": _safe_count(row.get("injured_victims")),
         "weather": row.get("weather_1"),
         "road_condition": row.get("road_surface"),
         "lighting": row.get("lighting"),

--- a/backend/migrations/versions/e6f7a8b9c0d1_clamp_negative_kill_injured_counts.py
+++ b/backend/migrations/versions/e6f7a8b9c0d1_clamp_negative_kill_injured_counts.py
@@ -1,0 +1,28 @@
+"""clamp negative number_killed and number_injured to zero
+
+Revision ID: e6f7a8b9c0d1
+Revises: d4e5f6a7b8c9
+Create Date: 2026-04-26 00:00:00.000000
+
+5 crashes had number_killed < 0 (impossible values that survived ETL).
+They caused total_killed: -1 in /api/stats?group_by=severity for the Injury
+bucket. Clamp them to 0 here; the ETL is also fixed to prevent new negatives.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'e6f7a8b9c0d1'
+down_revision: Union[str, None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE crashes SET number_killed  = 0 WHERE number_killed  < 0")
+    op.execute("UPDATE crashes SET number_injured = 0 WHERE number_injured < 0")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/migrations/versions/e6f7a8b9c0d1_clamp_negative_kill_injured_counts.py
+++ b/backend/migrations/versions/e6f7a8b9c0d1_clamp_negative_kill_injured_counts.py
@@ -14,7 +14,7 @@ from alembic import op
 
 
 revision: str = 'e6f7a8b9c0d1'
-down_revision: Union[str, None] = 'd4e5f6a7b8c9'
+down_revision: Union[str, None] = 'c6f3a2e7b9d1'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/frontend/src/components/map/ChoroplethLegend.test.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.test.tsx
@@ -146,7 +146,7 @@ describe("ChoroplethLegend", () => {
   it("shows partial-demographics alert for years with incomplete county coverage", async () => {
     render(<Harness edges={[0, 10, 20, 30, 40, 50]} dataSummary={{ ...BASE_SUMMARY, partialDemoYears: [2005, 2006, 2007, 2008, 2009] }} />);
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/partial population data for 2005–2009/i);
+    expect(alert).toHaveTextContent(/partial population data for 2005-2009/i);
   });
 
   it("shows both missing and partial alerts together", async () => {

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -4,10 +4,12 @@ import { MEASURES } from "../../lib/choropleth/measures";
 import { getPalette } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 import type { DataSummary } from "../../hooks/useChoroplethData";
+import type { CoordCoverage } from "../../hooks/useCoordCoverage";
 
 type Props = {
   demographicsAvailable: boolean;
   dataSummary?: DataSummary;
+  coordCoverage?: CoordCoverage | null;
   isLoading?: boolean;
   isError?: boolean;
   is422?: boolean;
@@ -20,7 +22,7 @@ function formatYearList(years: number[]): string {
   const sorted = [...years].sort((a, b) => a - b);
   const first = sorted[0];
   const last = sorted[sorted.length - 1];
-  if (last - first + 1 === sorted.length) return `${first}–${last}`;
+  if (last - first + 1 === sorted.length) return `${first}-${last}`;
   return sorted.join(", ");
 }
 
@@ -32,7 +34,7 @@ function formatCount(n: number): string {
 
 const EMPTY_SUMMARY: DataSummary = { totalCrashes: 0, missingDemoYears: [], partialDemoYears: [], sparseYears: [] };
 
-export default function ChoroplethLegend({ demographicsAvailable, dataSummary = EMPTY_SUMMARY, isLoading, isError, is422, searchOpen, onRetry }: Props) {
+export default function ChoroplethLegend({ demographicsAvailable, dataSummary = EMPTY_SUMMARY, coordCoverage, isLoading, isError, is422, searchOpen, onRetry }: Props) {
   const { choroplethOn, measure, palette, bucketEdges, setMeasure } = useLayersState();
   const isDark = useIsDark();
   const [isOpen, setIsOpen] = useState(false);
@@ -148,6 +150,14 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
       {!isLoading && dataSummary.totalCrashes > 0 && (
         <div data-testid="data-summary" className="text-[11px] sm:text-[10px] text-on-surface-variant mt-2 leading-snug">
           <span className="font-mono font-semibold">{formatCount(dataSummary.totalCrashes)}</span> crashes
+
+          {coordCoverage && (
+            <div className="mt-0.5 text-[10px]">
+              <span className="font-mono">{formatCount(coordCoverage.mapped)}</span> of{" "}
+              <span className="font-mono">{formatCount(coordCoverage.total)}</span> mapped (
+              <span className="font-mono">{Math.round(coordCoverage.pct)}%</span>)
+            </div>
+          )}
 
           {dataSummary.sparseYears.length > 0 && (
             <div className="mt-1">

--- a/frontend/src/hooks/useCoordCoverage.ts
+++ b/frontend/src/hooks/useCoordCoverage.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import { YEARS } from "./useFilterParams";
+
+type DataQualityRow = {
+  county_code: number | null;
+  year: number | null;
+  total_crashes: number | null;
+  crashes_with_coords: number | null;
+};
+
+export type CoordCoverage = {
+  mapped: number;
+  total: number;
+  pct: number;
+};
+
+export function useCoordCoverage(selectedYears: number[]): CoordCoverage | null {
+  const { data } = useQuery<DataQualityRow[]>({
+    queryKey: ["data-quality-statewide"],
+    queryFn: async () => {
+      const res = await fetch("/api/data-quality");
+      if (!res.ok) throw new Error("data-quality fetch failed");
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!data) return null;
+
+  // Only statewide per-year rows (county_code null, year present)
+  const statewide = data.filter((r) => r.county_code === null && r.year !== null);
+
+  const allYears = selectedYears.length === 0 || selectedYears.length === YEARS.length;
+  const yearSet = allYears ? null : new Set(selectedYears);
+  const rows = yearSet ? statewide.filter((r) => yearSet.has(r.year!)) : statewide;
+
+  if (!rows.length) return null;
+
+  const mapped = rows.reduce((s, r) => s + (r.crashes_with_coords ?? 0), 0);
+  const total = rows.reduce((s, r) => s + (r.total_crashes ?? 0), 0);
+
+  if (total === 0) return null;
+  return { mapped, total, pct: (mapped / total) * 100 };
+}

--- a/frontend/src/hooks/useDataQualityDisclaimer.ts
+++ b/frontend/src/hooks/useDataQualityDisclaimer.ts
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+import { YEARS } from "./useFilterParams";
+
+type QualityRow = {
+  county_code: number | null;
+  year: number | null;
+  age_pct: number | null;
+  gender_pct: number | null;
+  sobriety_pct: number | null;
+};
+
+export type DataQualityDisclaimers = {
+  /** All selected years are pre-2016 — no CCRS demographic data at all. */
+  preDataOnly: boolean;
+  /** Selection includes some pre-2016 years (demographic charts cover 2016+ only). */
+  hasPreCcrsYears: boolean;
+  agePct: number | null;
+  genderPct: number | null;
+  /** age_pct < 50% for the current scope. */
+  showAgeWarning: boolean;
+  /** gender_pct < 70% for the current scope. */
+  showGenderWarning: boolean;
+};
+
+function slugify(name: string) {
+  return name.toLowerCase().replace(/ /g, "-");
+}
+
+export function useDataQualityDisclaimer(
+  selectedYears: number[],
+  selectedCounties: string[],
+): DataQualityDisclaimers {
+  const singleCounty = selectedCounties.length === 1 ? slugify(selectedCounties[0]) : null;
+
+  const { data } = useQuery<QualityRow[]>({
+    queryKey: singleCounty
+      ? ["data-quality", "county", singleCounty]
+      : ["data-quality", "statewide"],
+    queryFn: async () => {
+      const url = singleCounty
+        ? `/api/data-quality?county=${encodeURIComponent(singleCounty)}`
+        : "/api/data-quality";
+      const res = await fetch(url);
+      if (!res.ok) throw new Error("data-quality fetch failed");
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const allYears = selectedYears.length === 0 || selectedYears.length === YEARS.length;
+  const years = allYears ? [...YEARS] : selectedYears;
+  const preDataOnly = !allYears && years.every((y) => y < 2016);
+  const hasPreCcrsYears = !allYears && !preDataOnly && years.some((y) => y < 2016);
+
+  if (!data) {
+    return { preDataOnly, hasPreCcrsYears, agePct: null, genderPct: null, showAgeWarning: false, showGenderWarning: false };
+  }
+
+  // All-time row for this scope: year IS NULL
+  const allTimeRow = data.find((r) => r.year === null);
+  const agePct = allTimeRow?.age_pct ?? null;
+  const genderPct = allTimeRow?.gender_pct ?? null;
+
+  return {
+    preDataOnly,
+    hasPreCcrsYears,
+    agePct,
+    genderPct,
+    showAgeWarning: agePct !== null && agePct < 50,
+    showGenderWarning: genderPct !== null && genderPct < 70,
+  };
+}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -51,103 +51,159 @@ export default function AboutPage() {
         <span className="font-label text-xs uppercase tracking-[0.3em] text-on-surface-variant">
           DATA SOURCES
         </span>
+
+        {/* Summary stats */}
+        <div className="grid grid-cols-3 gap-4 md:gap-6">
+          {[
+            { value: "11.1M", label: "Police-reported crashes" },
+            { value: "17", label: "Government data sources" },
+            { value: "25.3M", label: "Total rows in database" },
+          ].map(({ value, label }) => (
+            <div key={label} className="bg-surface-container-lowest rounded-lg ambient-shadow flex flex-col items-center justify-center text-center gap-4 py-6 md:py-8 px-6">
+              <p className="font-headline text-3xl md:text-4xl font-bold text-on-surface tracking-tight">
+                {value}
+              </p>
+              <p className="text-[10px] text-on-surface-variant uppercase tracking-widest font-semibold leading-snug">
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between h-48">
+          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">
-                CCRS
-              </h3>
-              <p className="text-sm text-on-surface-variant mt-2">
-                California Crash Reporting System
+              <h3 className="font-headline text-xl font-bold text-on-surface">CCRS</h3>
+              <p className="text-sm text-on-surface-variant mt-1">California Crash Reporting System</p>
+              <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
+                4.35M crashes from 2016-2026. Includes party-level demographics (age, gender, sobriety) and victim records. Published by CHP via data.ca.gov.
               </p>
             </div>
-            <div className="flex items-center justify-between">
-              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">
-                Primary Record Set
-              </p>
-              <a
-                href="https://data.ca.gov/dataset/ccrs"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-primary font-medium hover:underline"
-              >
-                Learn More
-              </a>
+            <div className="flex items-center justify-between mt-6">
+              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">4,350,202 rows · 2016-2026</p>
+              <a href="https://data.ca.gov/dataset/ccrs" target="_blank" rel="noopener noreferrer" className="text-xs text-primary font-medium hover:underline">Learn More</a>
             </div>
           </div>
 
-          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between h-48">
+          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">
-                SWITRS
-              </h3>
-              <p className="text-sm text-on-surface-variant mt-2">
-                Statewide Integrated Traffic Records
+              <h3 className="font-headline text-xl font-bold text-on-surface">SWITRS</h3>
+              <p className="text-sm text-on-surface-variant mt-1">Statewide Integrated Traffic Records System</p>
+              <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
+                6.78M crashes from 2001-2015. Crash-level records only — no party or driver demographics. Archived by UC Berkeley and published by CHP.
               </p>
             </div>
-            <div className="flex items-center justify-between">
-              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">
-                Historical Metadata
-              </p>
-              <a
-                href="https://www.chp.ca.gov/programs-services/services-information/switrs-statewide-integrated-traffic-records-system"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-primary font-medium hover:underline"
-              >
-                Learn More
-              </a>
+            <div className="flex items-center justify-between mt-6">
+              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">6,779,445 rows · 2001-2015</p>
+              <a href="https://www.chp.ca.gov/programs-services/services-information/switrs-statewide-integrated-traffic-records-system" target="_blank" rel="noopener noreferrer" className="text-xs text-primary font-medium hover:underline">Learn More</a>
             </div>
           </div>
 
-          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between h-48">
+          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">
-                US Census Bureau
-              </h3>
-              <p className="text-sm text-on-surface-variant mt-2">
-                Demographic &amp; Economic Context
+              <h3 className="font-headline text-xl font-bold text-on-surface">US Census Bureau</h3>
+              <p className="text-sm text-on-surface-variant mt-1">American Community Survey (ACS)</p>
+              <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
+                28 demographic and economic fields per county per year — population, income, poverty, race, education, vehicle ownership. 5-year estimates for all 58 counties starting 2010; 1-year estimates for larger counties 2005-2009.
               </p>
             </div>
-            <div className="flex items-center justify-between">
-              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">
-                Socio-economic Overlay
-              </p>
-              <a
-                href="https://data.census.gov/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-primary font-medium hover:underline"
-              >
-                Learn More
-              </a>
+            <div className="flex items-center justify-between mt-6">
+              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">1,012 rows · 2005-2022</p>
+              <a href="https://data.census.gov/" target="_blank" rel="noopener noreferrer" className="text-xs text-primary font-medium hover:underline">Learn More</a>
             </div>
           </div>
 
-          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between h-48">
+          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">
-                CHP
-              </h3>
-              <p className="text-sm text-on-surface-variant mt-2">
-                California Highway Patrol Enforcement
+              <h3 className="font-headline text-xl font-bold text-on-surface">NOAA / BLS / DMV</h3>
+              <p className="text-sm text-on-surface-variant mt-1">Weather, Unemployment &amp; Vehicle Data</p>
+              <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
+                Monthly county weather (NOAA, 2001-2025), monthly unemployment rates (BLS, 2005-2025), annual vehicle registrations by county (CA DMV, 2019-2026), and licensed driver counts (CA DMV, 2008-2024).
               </p>
             </div>
-            <div className="flex items-center justify-between">
-              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">
-                Operational Data
+            <div className="flex items-center justify-between mt-6">
+              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">32,306 rows combined</p>
+              <a href="https://www.bls.gov/lau/" target="_blank" rel="noopener noreferrer" className="text-xs text-primary font-medium hover:underline">Learn More</a>
+            </div>
+          </div>
+
+          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
+            <div>
+              <h3 className="font-headline text-xl font-bold text-on-surface">Caltrans</h3>
+              <p className="text-sm text-on-surface-variant mt-1">Traffic Volumes &amp; Road Miles</p>
+              <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
+                Annual average daily traffic (AADT) and road miles for state-managed highways. Covers state routes only — local and county roads are not included.
               </p>
-              <a
-                href="https://www.chp.ca.gov/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-primary font-medium hover:underline"
-              >
-                Learn More
-              </a>
+            </div>
+            <div className="flex items-center justify-between mt-6">
+              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">413 rows · state highways only</p>
+              <a href="https://dot.ca.gov/programs/traffic-operations/census" target="_blank" rel="noopener noreferrer" className="text-xs text-primary font-medium hover:underline">Learn More</a>
+            </div>
+          </div>
+
+          <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
+            <div>
+              <h3 className="font-headline text-xl font-bold text-on-surface">CalEnviroScreen</h3>
+              <p className="text-sm text-on-surface-variant mt-1">CA Office of Environmental Health Hazard Assessment</p>
+              <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
+                Environmental justice scores for all 58 counties, derived from 8,035 census tracts (version 4.0, based on 2021 data). A single snapshot — not a time series.
+              </p>
+            </div>
+            <div className="flex items-center justify-between mt-6">
+              <p className="text-xs text-on-surface-variant font-medium uppercase tracking-wider">58 rows · 2021 snapshot</p>
+              <a href="https://oehha.ca.gov/calenviroscreen" target="_blank" rel="noopener noreferrer" className="text-xs text-primary font-medium hover:underline">Learn More</a>
             </div>
           </div>
         </div>
+      </section>
+
+      {/* Known Limitations Section */}
+      <section id="limitations" className="py-16 md:py-24 space-y-12">
+        <span className="font-label text-xs uppercase tracking-[0.3em] text-on-surface-variant">
+          DATA LIMITATIONS
+        </span>
+        <p className="text-on-surface-variant leading-relaxed text-lg font-light max-w-2xl">
+          We show police-reported crashes only. Here's what that means for the data, and what we're transparent about.
+        </p>
+        <div className="space-y-4">
+          {[
+            {
+              title: "63% of crashes have no coordinates",
+              body: "We know the county for every crash, but most can't be pinned on a map. The missing coordinates depend on which agency filed the report — some county sheriffs geocode consistently, others don't. Choropleth maps are reliable; pin maps show a biased sample.",
+            },
+            {
+              title: "No driver demographics before 2016",
+              body: "SWITRS (2001-2015) records the crash but not who was involved. Age, gender, sobriety, and cell phone data come from CCRS (2016+) only. Charts for those fields are blank or greyed out for pre-2016 years.",
+            },
+            {
+              title: "Underreporting: real crash numbers are probably 2-3x higher",
+              body: "Only crashes that receive a police report end up in the database. NHTSA estimates 50-60% of injury crashes and ~30% of property-damage-only crashes go unreported. Fatal crashes are close to 100% reported. The underreporting rate varies by county, income level, and language access.",
+            },
+            {
+              title: "Education data missing before 2012",
+              body: "The Census Bureau didn't publish the B15003 table (educational attainment) in ACS 5-year estimates before 2012. Bachelor's degree and high school rates are null for earlier years.",
+            },
+            {
+              title: "Small counties missing 2005-2009",
+              body: "ACS 1-year estimates only cover counties with 65K+ population. About 28 smaller counties have no demographic data for those five years. Full 58-county coverage begins with the ACS 5-year estimates in 2010.",
+            },
+            {
+              title: "Traffic volumes cover state highways only",
+              body: "Caltrans AADT data is limited to state-managed roads. Local streets, county roads, and city streets — where many crashes occur — are not included. Per-road-mile rates should be interpreted with this in mind.",
+            },
+          ].map(({ title, body }) => (
+            <div key={title} className="border-t border-outline-variant/20 pt-4">
+              <h4 className="text-sm font-semibold text-on-surface mb-1">{title}</h4>
+              <p className="text-sm text-on-surface-variant leading-relaxed">{body}</p>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-on-surface-variant/60 italic">
+          Full technical detail in{" "}
+          <a href="https://github.com/JeffreySardella/CalSight/blob/main/backend/DATA_GAPS.md" target="_blank" rel="noopener noreferrer" className="underline hover:text-on-surface-variant transition-colors">DATA_GAPS.md</a>
+          {" "}and{" "}
+          <a href="https://github.com/JeffreySardella/CalSight/blob/main/backend/DATA_VALIDATION.md" target="_blank" rel="noopener noreferrer" className="underline hover:text-on-surface-variant transition-colors">DATA_VALIDATION.md</a>.
+        </p>
       </section>
 
       {/* How It Works Section */}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import type { Map as LeafletMap } from "leaflet";
 import { useQueryClient } from "@tanstack/react-query";
 import { useFilterParams, CA_COUNTIES } from "../hooks/useFilterParams";
+import type { CoordCoverage } from "../hooks/useCoordCoverage";
 import { useMapKeyboard } from "../hooks/useMapKeyboard";
 import { LayersStateProvider, useLayersState } from "../hooks/useLayersState";
 import ChoroplethLegend from "../components/map/ChoroplethLegend";
@@ -24,6 +25,7 @@ import AiInsightCard from "../components/map/AiInsightCard";
 import SearchPill from "../components/map/SearchPill";
 import Breadcrumb from "../components/map/Breadcrumb";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
+import { useCoordCoverage } from "../hooks/useCoordCoverage";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
   filters: { title: "Filters", subtitle: "Secondary Parameters" },
@@ -78,6 +80,7 @@ function MapPageInner() {
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
 
   const { measure } = useLayersState();
+  const coordCoverage = useCoordCoverage([...selectedYears]);
   const choroplethFilters = useMemo(
     () => ({
       years: [...selectedYears].sort((a, b) => a - b),
@@ -289,7 +292,7 @@ function MapPageInner() {
           compareCounty={compareCounty}
           onDeselect={handleDeselect}
         />
-        <ChoroplethLegendContainer searchOpen={searchOpen} choroplethData={choroplethData} />
+        <ChoroplethLegendContainer searchOpen={searchOpen} choroplethData={choroplethData} coordCoverage={coordCoverage} />
       </section>
 
       {/* Mobile filter bottom sheet */}
@@ -340,15 +343,18 @@ export default function MapPage() {
 function ChoroplethLegendContainer({
   searchOpen,
   choroplethData,
+  coordCoverage,
 }: {
   searchOpen?: boolean;
   choroplethData: ChoroplethData;
+  coordCoverage?: CoordCoverage | null;
 }) {
   const queryClient = useQueryClient();
   return (
     <ChoroplethLegend
       demographicsAvailable={choroplethData.demographicsAvailable}
       dataSummary={choroplethData.dataSummary}
+      coordCoverage={coordCoverage}
       isLoading={choroplethData.isLoading}
       isError={choroplethData.isError}
       is422={choroplethData.is422}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -14,6 +14,16 @@ import {
   LabelList,
 } from "recharts";
 import { useStats, type HourlyDataPoint, type YearlyDataPoint, type CauseDataPoint } from "../hooks/useStats";
+import { useDataQualityDisclaimer } from "../hooks/useDataQualityDisclaimer";
+
+function DataQualityNote({ text }: { text: string }) {
+  return (
+    <div className="flex items-start gap-1.5 bg-surface-container-high rounded-md px-2.5 py-1.5 mb-3 text-[10px] text-on-surface-variant leading-snug">
+      <span className="material-symbols-outlined text-[13px] mt-px flex-shrink-0">info</span>
+      <span>{text}</span>
+    </div>
+  );
+}
 
 function token(name: string) {
   return `rgb(${getComputedStyle(document.documentElement).getPropertyValue(name).trim()})`;
@@ -76,6 +86,10 @@ export default function StatsPage() {
     counties: [...filters.selectedCounties].map((c) => c.toLowerCase().replace(/ /g, "-")),
   }), [filters.selectedYears, filters.selectedSeverities, filters.selectedCauses, filters.selectedCounties]);
   const { data, loading, error } = useStats(statsFilters);
+  const dqDisclaimers = useDataQualityDisclaimer(
+    [...filters.selectedYears],
+    [...filters.selectedCounties],
+  );
   const [, forceUpdate] = useState(false);
   useEffect(() => {
     const observer = new MutationObserver(() => forceUpdate((v) => !v));
@@ -390,7 +404,7 @@ export default function StatsPage() {
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 gap-4">
             <div>
               <h3 className="text-on-surface font-headline font-bold text-xl leading-tight">
-                Incidents by Year ({yearlyData[0]?.year}–{yearlyData[yearlyData.length - 1]?.year})
+                Incidents by Year ({yearlyData[0]?.year}-{yearlyData[yearlyData.length - 1]?.year})
               </h3>
               <p className="text-on-surface-variant text-sm">
                 Longitudinal dataset showing historical trends
@@ -517,10 +531,22 @@ export default function StatsPage() {
           <h3 className="text-on-surface font-headline font-bold text-lg mb-4 leading-tight">
             Victims by Gender
           </h3>
+          {dqDisclaimers.preDataOnly && (
+            <DataQualityNote text="Driver demographic data is only available from 2016 onward (CCRS)." />
+          )}
+          {!dqDisclaimers.preDataOnly && dqDisclaimers.hasPreCcrsYears && (
+            <DataQualityNote text="Pre-2016 years have no gender data — chart covers 2016+ only." />
+          )}
+          {!dqDisclaimers.preDataOnly && dqDisclaimers.showGenderWarning && dqDisclaimers.genderPct !== null && (
+            <DataQualityNote text={`Gender recorded for ${Math.round(dqDisclaimers.genderPct)}% of parties. Chart may not be fully representative.`} />
+          )}
           {loading ? (
             <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
           ) : !genderData.length ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">No data available.</div>
+            <div className="h-48 flex flex-col items-center justify-center gap-2 text-on-surface-variant text-sm text-center px-4">
+              <span className="material-symbols-outlined text-[28px] opacity-40">person_off</span>
+              <span>{dqDisclaimers.preDataOnly ? "Gender data requires 2016 or later (CCRS)." : "No gender data for the current filters."}</span>
+            </div>
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={genderData} barCategoryGap="25%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
@@ -558,10 +584,22 @@ export default function StatsPage() {
           <h3 className="text-on-surface font-headline font-bold text-lg mb-4 leading-tight">
             Victims by Age
           </h3>
+          {dqDisclaimers.preDataOnly && (
+            <DataQualityNote text="Driver demographic data is only available from 2016 onward (CCRS)." />
+          )}
+          {!dqDisclaimers.preDataOnly && dqDisclaimers.hasPreCcrsYears && (
+            <DataQualityNote text="Pre-2016 years have no age data — chart covers 2016+ only." />
+          )}
+          {!dqDisclaimers.preDataOnly && dqDisclaimers.showAgeWarning && dqDisclaimers.agePct !== null && (
+            <DataQualityNote text={`Age recorded for ${Math.round(dqDisclaimers.agePct)}% of parties. Chart may not be fully representative.`} />
+          )}
           {loading ? (
             <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
           ) : !ageBracketData.length ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">No data available.</div>
+            <div className="h-48 flex flex-col items-center justify-center gap-2 text-on-surface-variant text-sm text-center px-4">
+              <span className="material-symbols-outlined text-[28px] opacity-40">person_off</span>
+              <span>{dqDisclaimers.preDataOnly ? "Age data requires 2016 or later (CCRS)." : "No age data for the current filters."}</span>
+            </div>
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={ageBracketData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>


### PR DESCRIPTION
## Required DB Action
 * Need to migrate `e6f7a8b9c0d1` which patches 5 existing crashes with negative `number_killed`/`number_injured` values.

## What does this PR do?
Handle data quality gaps transparently across the frontend and backend. Surface coordinate coverage, demographic fill rates, and known data limitations to users so they understand what they're looking at.

**Backend fixes:**
* Clamp `number_killed` and `number_injured` to `>= 0` in CCRS and SWITRS ETL loaders to prevent impossible negative values from reaching aggregates
* Add Alembic migration to patch 5 existing rows with negative counts in the database

**Frontend - Map page:**
* Add coordinate coverage badge to choropleth legend showing "X of Y crashes mapped (Z%)" using `data_quality_stats`
* Add `useCoordCoverage` hook that fetches `/api/data-quality` and aggregates statewide fill rates for the selected year range

**Frontend - Stats page:**
* Add `useDataQualityDisclaimer` hook for county-scoped and statewide fill rates
* Show fill-rate warning banners on Age and Gender charts when data quality is low (e.g. SF at 27% age fill rate)
* Show pre-2016 warning when selected years have no CCRS demographic data
* Replace generic "No data available." empty states with contextual messages

**Frontend - About page:**
* Add summary stat bar (11.1M crashes · 17 sources · 25.3M rows) currently hardcoded from DATA_VALIDATION.md
* Enrich data source cards with real row counts and year ranges from DATA_VALIDATION.md
* Add Known Limitations section covering coordinates, pre-2016 demographics, underreporting, education gaps, small county gaps, and highway-only traffic volumes

## How to test
- [x] Open the map page, the legend should show "X of Y crashes mapped (Z%)" below the crash count; change the year filter and the percentage should update
- [x] Open Stats page, set filter to San Francisco - Age and Gender charts should show low fill-rate warning
- [x] Set filter to pre-2016 years only - Age and Gender charts should show "data requires 2016 or later" message with empty state icon
- [x] Open the About Page - verify summary stats, enriched source cards, and Known Limitations section are all there


## Checklist
- [x] Code builds without errors
- [x] Tested locally
- [x] No console errors/warnings
- [x] DB migration applied

Closes #100 