### PR TITLE
Deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and restart backend
+        run: docker compose -f docker-compose.prod.yml up --build -d
+
+      - name: Verify backend is healthy
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -sf http://127.0.0.1:8000/docs > /dev/null; then
+              echo "Backend is up"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Backend failed to start"
+          docker compose -f docker-compose.prod.yml logs backend
+          exit 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,10 @@
+services:
+  backend:
+    build: ./backend
+    ports:
+      - "127.0.0.1:8000:8000"
+    env_file:
+      - ./backend/.env
+    environment:
+      DEBUG: "false"
+    restart: unless-stopped

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,1 @@
+export const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";

--- a/frontend/src/hooks/useChoroplethData.ts
+++ b/frontend/src/hooks/useChoroplethData.ts
@@ -8,6 +8,7 @@ import {
   type MeasureResult,
 } from "../lib/choropleth/measures";
 import { CA_COUNTIES, YEARS, SEVERITIES, CAUSES } from "./useFilterParams";
+import { API_BASE } from "../config";
 
 export type ChoroplethFilters = {
   years: number[];           // parsed from URL; empty = no year filter
@@ -74,7 +75,7 @@ function buildStatsUrl(filters: ChoroplethFilters): string {
   if (filters.causes.length) p.set("cause", filters.causes.join(","));
   // alcohol / distracted are NOT forwarded — /api/stats rejects them (MVs
   // don't carry those columns). See stats.py lines 134-143.
-  return `/api/stats?${p}`;
+  return `${API_BASE}/api/stats?${p}`;
 }
 
 function buildYearStatsUrl(filters: ChoroplethFilters): string {
@@ -83,14 +84,14 @@ function buildYearStatsUrl(filters: ChoroplethFilters): string {
   if (filters.years.length) p.set("year", filters.years.join(","));
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.causes.length) p.set("cause", filters.causes.join(","));
-  return `/api/stats?${p}`;
+  return `${API_BASE}/api/stats?${p}`;
 }
 
 function buildDemoUrl(filters: ChoroplethFilters): string {
   const p = new URLSearchParams();
   if (filters.years.length) p.set("year", filters.years.join(","));
   const qs = p.toString();
-  return `/api/demographics${qs ? `?${qs}` : ""}`;
+  return `${API_BASE}/api/demographics${qs ? `?${qs}` : ""}`;
 }
 
 export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFilters): ChoroplethData {

--- a/frontend/src/hooks/useCoordCoverage.ts
+++ b/frontend/src/hooks/useCoordCoverage.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { YEARS } from "./useFilterParams";
+import { API_BASE } from "../config";
 
 type DataQualityRow = {
   county_code: number | null;
@@ -18,7 +19,7 @@ export function useCoordCoverage(selectedYears: number[]): CoordCoverage | null 
   const { data } = useQuery<DataQualityRow[]>({
     queryKey: ["data-quality-statewide"],
     queryFn: async () => {
-      const res = await fetch("/api/data-quality");
+      const res = await fetch(`${API_BASE}/api/data-quality`);
       if (!res.ok) throw new Error("data-quality fetch failed");
       return res.json();
     },

--- a/frontend/src/hooks/useDataQualityDisclaimer.ts
+++ b/frontend/src/hooks/useDataQualityDisclaimer.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { YEARS } from "./useFilterParams";
+import { API_BASE } from "../config";
 
 type QualityRow = {
   county_code: number | null;
@@ -38,8 +39,8 @@ export function useDataQualityDisclaimer(
       : ["data-quality", "statewide"],
     queryFn: async () => {
       const url = singleCounty
-        ? `/api/data-quality?county=${encodeURIComponent(singleCounty)}`
-        : "/api/data-quality";
+        ? `${API_BASE}/api/data-quality?county=${encodeURIComponent(singleCounty)}`
+        : `${API_BASE}/api/data-quality`;
       const res = await fetch(url);
       if (!res.ok) throw new Error("data-quality fetch failed");
       return res.json();

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import { YEARS, SEVERITIES, CAUSES } from "./useFilterParams";
+import { API_BASE } from "../config";
 
 export type StatsFilters = {
   years: number[];
@@ -85,7 +86,7 @@ function buildUrl(groupBy: string, filters: StatsFilters): string {
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.causes.length) p.set("cause", filters.causes.join(","));
   if (filters.counties.length) p.set("county", filters.counties.join(","));
-  return `/api/stats?${p}`;
+  return `${API_BASE}/api/stats?${p}`;
 }
 
 function buildVictimUrl(groupBy: string, filters: StatsFilters): string {
@@ -94,7 +95,7 @@ function buildVictimUrl(groupBy: string, filters: StatsFilters): string {
   if (filters.years.length) p.set("year", filters.years.join(","));
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.counties.length) p.set("county", filters.counties.join(","));
-  return `/api/stats?${p}`;
+  return `${API_BASE}/api/stats?${p}`;
 }
 
 function buildDemoUrl(filters: StatsFilters): string {
@@ -102,7 +103,7 @@ function buildDemoUrl(filters: StatsFilters): string {
   if (filters.years.length) p.set("year", filters.years.join(","));
   if (filters.counties.length) p.set("county", filters.counties.join(","));
   const qs = p.toString();
-  return `/api/demographics${qs ? `?${qs}` : ""}`;
+  return `${API_BASE}/api/demographics${qs ? `?${qs}` : ""}`;
 }
 
 async function fetchJson<T>(url: string): Promise<T> {


### PR DESCRIPTION
 ## What does this PR do?
  Adds Cloudflare Pages + Tunnel deployment infrastructure. Introduces a VITE_API_BASE_URL env var so the frontend can
  call a backend on a separate origin (api.calsight.org), adds docker-compose.prod.yml for the production backend, and a
   GitHub Actions deploy workflow that auto-deploys to the self-hosted runner on VM 101.

  ## How to test
  - Run npm run dev locally — verify API calls still work through the Vite proxy (no VITE_API_BASE_URL set = empty
  string = relative URLs)
  - Run npx tsc --noEmit — passes with no errors
  - Confirm docker-compose up (dev) still works unchanged

  ## Checklist
  - Code builds without errors
  - Tested locally
  - No console errors/warnings

