### PR TITLE
115 sub county crash heatmap on county click latlng

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,14 +1,10 @@
 # --- Database -----------------------------------------------------------------
-# CalSight's shared DB lives on the home Proxmox server (LXC CT100). Reach it
-# via Tailscale — works from anywhere once you're added to the tailnet and
-# have Tailscale installed locally.
+# CalSight's shared dev DB lives on VM 109 ("docker-dev") on Jeff's home
+# Proxmox server. Reach it via Tailscale — works from anywhere once you're
+# added to the tailnet and have Tailscale installed locally.
 #
 # Ask Jeff for a Tailscale invite + the password to substitute below.
-DATABASE_URL=postgresql://calsight:CHANGE_ME@100.70.21.75:5433/calsight
-
-# Alternative: same DB via LAN IP (only works when you're on Jeff's home network;
-# no Tailscale required, slightly faster). Swap the URL above if you're on-site.
-# DATABASE_URL=postgresql://calsight:CHANGE_ME@10.27.27.12:5433/calsight
+DATABASE_URL=postgresql://calsight_team:CHANGE_ME@100.121.46.16:5433/calsight
 
 # Alternative: spin up a fresh empty local Postgres in Docker for offline work.
 # Run `docker compose --profile local-db up -d db`, then use the URL below.
@@ -16,8 +12,8 @@ DATABASE_URL=postgresql://calsight:CHANGE_ME@100.70.21.75:5433/calsight
 # DATABASE_URL=postgresql://calsight:calsight_dev@db:5432/calsight
 
 # --- CORS ---------------------------------------------------------------------
-# Comma-separated origins. Frontend dev server runs on port 5180 (see docker-compose.yml).
-CORS_ORIGINS=http://localhost:5180
+# Comma-separated origins. Native vite dev runs on 5173; Docker maps to 5180.
+CORS_ORIGINS=http://localhost:5173,http://localhost:5180
 
 # --- API keys (ask Jeff for the shared values) --------------------------------
 CENSUS_API_KEY=

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from app.routers.context import router as context_router  # noqa: E402
 from app.routers.crash_people import router as crash_people_router  # noqa: E402
 from app.routers.crashes import router as crashes_router  # noqa: E402
 from app.routers.demographics import router as demographics_router  # noqa: E402
+from app.routers.heatmap import router as heatmap_router  # noqa: E402
 from app.routers.meta import router as meta_router  # noqa: E402
 from app.routers.reference import router as reference_router  # noqa: E402
 from app.routers.stats import router as stats_router  # noqa: E402
@@ -49,6 +50,7 @@ app.include_router(demographics_router, prefix="/api")
 app.include_router(context_router, prefix="/api")
 app.include_router(crashes_router, prefix="/api")
 app.include_router(crash_people_router, prefix="/api")
+app.include_router(heatmap_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(meta_router, prefix="/api")
 

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -77,12 +77,12 @@ def crash_heatmap(
     distracted_v = parse_bool_flag(distracted, "distracted")
 
     if resolution is None:
-        resolution = Resolution.raw if county_codes else Resolution.medium
+        resolution = Resolution.raw if county_codes else Resolution.low
 
-    if resolution == Resolution.raw and not county_codes:
+    if resolution in (Resolution.raw, Resolution.high) and not county_codes:
         raise FilterError(
             "resolution",
-            "Raw resolution requires a county filter.",
+            f"{resolution.value.capitalize()} resolution requires a county filter.",
         )
 
     preds = build_crash_predicates(

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -37,6 +37,12 @@ _STEP = {
     Resolution.high: 0.001,
 }
 
+_DECIMALS = {
+    Resolution.low: 1,
+    Resolution.medium: 2,
+    Resolution.high: 3,
+}
+
 
 @router.get("/crashes/heatmap", response_model=HeatmapResponse)
 def crash_heatmap(
@@ -104,8 +110,12 @@ def crash_heatmap(
     )
 
     total = sum(r.weight for r in rows)
+    decimals = _DECIMALS[resolution]
 
     return HeatmapResponse(
-        points=[HeatmapPoint(lat=r.lat, lng=r.lng, weight=r.weight) for r in rows],
+        points=[
+            HeatmapPoint(lat=round(float(r.lat), decimals), lng=round(float(r.lng), decimals), weight=r.weight)
+            for r in rows
+        ],
         total_crashes=total,
     )

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -24,8 +24,11 @@ from app.schemas.heatmap import HeatmapPoint, HeatmapResponse
 router = APIRouter(tags=["heatmap"])
 logger = logging.getLogger(__name__)
 
+RAW_POINT_LIMIT = 300_000
+
 
 class Resolution(str, Enum):
+    raw = "raw"
     low = "low"
     medium = "medium"
     high = "high"
@@ -56,15 +59,13 @@ def crash_heatmap(
     resolution: Resolution | None = Query(None),
     db: Session = Depends(get_db),
 ):
-    """Grid-aggregated crash locations for heatmap rendering.
+    """Crash locations for heatmap rendering.
 
-    Buckets crash lat/lng into grid cells and returns {lat, lng, weight}
-    per cell.  Same filter params as /api/crashes.
-
-    Resolution controls grid cell size:
-      - low  (0.1 deg, ~7 mi)  — default for statewide
-      - medium (0.01 deg, ~0.7 mi) — default when county is set
-      - high (0.001 deg, ~350 ft) — county-only, rejected without county
+    Resolution controls output:
+      - raw — individual crash lat/lng (county required, limit 10K)
+      - low  (0.1 deg, ~7 mi)  — grid-aggregated
+      - medium (0.01 deg, ~0.7 mi) — grid-aggregated
+      - high (0.001 deg, ~350 ft) — grid-aggregated
     """
     response.headers["Cache-Control"] = "public, max-age=300"
 
@@ -76,16 +77,13 @@ def crash_heatmap(
     distracted_v = parse_bool_flag(distracted, "distracted")
 
     if resolution is None:
-        resolution = Resolution.medium if county_codes else Resolution.low
+        resolution = Resolution.raw if county_codes else Resolution.medium
 
-    if resolution == Resolution.high and not county_codes:
+    if resolution == Resolution.raw and not county_codes:
         raise FilterError(
             "resolution",
-            "High resolution requires a county filter. "
-            "Use ?resolution=low or ?resolution=medium for statewide queries.",
+            "Raw resolution requires a county filter.",
         )
-
-    step = _STEP[resolution]
 
     preds = build_crash_predicates(
         years=years,
@@ -97,7 +95,23 @@ def crash_heatmap(
     )
     preds.append(Crash.latitude.isnot(None))
     preds.append(Crash.longitude.isnot(None))
+    preds.append(Crash.latitude.between(32.5, 42.05))
+    preds.append(Crash.longitude.between(-124.5, -114.0))
 
+    if resolution == Resolution.raw:
+        total_q = db.query(func.count()).filter(*preds).scalar() or 0
+        rows = (
+            db.query(Crash.latitude, Crash.longitude)
+            .filter(*preds)
+            .limit(RAW_POINT_LIMIT)
+            .all()
+        )
+        return HeatmapResponse(
+            points=[HeatmapPoint(lat=r.latitude, lng=r.longitude, weight=1) for r in rows],
+            total_crashes=total_q,
+        )
+
+    step = _STEP[resolution]
     lat_bucket = (func.round(Crash.latitude / step) * step).label("lat")
     lng_bucket = (func.round(Crash.longitude / step) * step).label("lng")
     weight = func.count().label("weight")

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -1,0 +1,111 @@
+"""Grid-aggregated crash heatmap endpoint."""
+
+import logging
+from enum import Enum
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy import func, literal_column
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import (
+    FilterError,
+    build_crash_predicates,
+    parse_bool_flag,
+    parse_cause,
+    parse_county_codes,
+    parse_severity,
+    parse_year,
+)
+from app.models import Crash
+from app.schemas.heatmap import HeatmapPoint, HeatmapResponse
+
+router = APIRouter(tags=["heatmap"])
+logger = logging.getLogger(__name__)
+
+
+class Resolution(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+_STEP = {
+    Resolution.low: 0.1,
+    Resolution.medium: 0.01,
+    Resolution.high: 0.001,
+}
+
+
+@router.get("/crashes/heatmap", response_model=HeatmapResponse)
+def crash_heatmap(
+    response: Response,
+    year: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    resolution: Resolution | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Grid-aggregated crash locations for heatmap rendering.
+
+    Buckets crash lat/lng into grid cells and returns {lat, lng, weight}
+    per cell.  Same filter params as /api/crashes.
+
+    Resolution controls grid cell size:
+      - low  (0.1 deg, ~7 mi)  — default for statewide
+      - medium (0.01 deg, ~0.7 mi) — default when county is set
+      - high (0.001 deg, ~350 ft) — county-only, rejected without county
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+    years = parse_year(year)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+    alcohol_v = parse_bool_flag(alcohol, "alcohol")
+    distracted_v = parse_bool_flag(distracted, "distracted")
+
+    if resolution is None:
+        resolution = Resolution.medium if county_codes else Resolution.low
+
+    if resolution == Resolution.high and not county_codes:
+        raise FilterError(
+            "resolution",
+            "High resolution requires a county filter. "
+            "Use ?resolution=low or ?resolution=medium for statewide queries.",
+        )
+
+    step = _STEP[resolution]
+
+    preds = build_crash_predicates(
+        years=years,
+        county_codes=county_codes,
+        severities=severities,
+        causes=causes,
+        alcohol=alcohol_v,
+        distracted=distracted_v,
+    )
+    preds.append(Crash.latitude.isnot(None))
+    preds.append(Crash.longitude.isnot(None))
+
+    lat_bucket = (func.round(Crash.latitude / step) * step).label("lat")
+    lng_bucket = (func.round(Crash.longitude / step) * step).label("lng")
+    weight = func.count().label("weight")
+
+    rows = (
+        db.query(lat_bucket, lng_bucket, weight)
+        .filter(*preds)
+        .group_by(literal_column("lat"), literal_column("lng"))
+        .all()
+    )
+
+    total = sum(r.weight for r in rows)
+
+    return HeatmapResponse(
+        points=[HeatmapPoint(lat=r.lat, lng=r.lng, weight=r.weight) for r in rows],
+        total_crashes=total,
+    )

--- a/backend/app/schemas/heatmap.py
+++ b/backend/app/schemas/heatmap.py
@@ -1,0 +1,14 @@
+"""Response models for /api/crashes/heatmap."""
+
+from pydantic import BaseModel
+
+
+class HeatmapPoint(BaseModel):
+    lat: float
+    lng: float
+    weight: int
+
+
+class HeatmapResponse(BaseModel):
+    points: list[HeatmapPoint]
+    total_crashes: int

--- a/backend/tests/api/test_heatmap.py
+++ b/backend/tests/api/test_heatmap.py
@@ -1,0 +1,25 @@
+"""Integration tests for /api/crashes/heatmap."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_heatmap_returns_points_and_total(client):
+    response = client.get("/api/crashes/heatmap?county=los-angeles")
+    assert response.status_code == 200
+    body = response.json()
+    assert "points" in body
+    assert "total_crashes" in body
+    assert isinstance(body["points"], list)
+    assert isinstance(body["total_crashes"], int)
+
+
+def test_heatmap_point_shape(client):
+    response = client.get("/api/crashes/heatmap?county=los-angeles")
+    body = response.json()
+    assert len(body["points"]) > 0
+    point = body["points"][0]
+    assert "lat" in point
+    assert "lng" in point
+    assert "weight" in point

--- a/backend/tests/api/test_heatmap.py
+++ b/backend/tests/api/test_heatmap.py
@@ -23,3 +23,78 @@ def test_heatmap_point_shape(client):
     assert "lat" in point
     assert "lng" in point
     assert "weight" in point
+
+
+def test_heatmap_default_resolution_statewide_is_low(client):
+    """Without county filter, resolution defaults to low (0.1 deg)."""
+    response = client.get("/api/crashes/heatmap")
+    assert response.status_code == 200
+    body = response.json()
+    for pt in body["points"]:
+        decimals = len(str(pt["lat"]).split(".")[-1]) if "." in str(pt["lat"]) else 0
+        assert decimals <= 1
+
+
+def test_heatmap_default_resolution_county_is_medium(client):
+    """With county filter, resolution defaults to medium (0.01 deg)."""
+    response = client.get("/api/crashes/heatmap?county=los-angeles")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_crashes"] > 0
+
+
+def test_heatmap_high_resolution_requires_county(client):
+    response = client.get("/api/crashes/heatmap?resolution=high")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "resolution"
+
+
+def test_heatmap_high_resolution_with_county_works(client):
+    response = client.get("/api/crashes/heatmap?county=los-angeles&resolution=high")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_crashes"] > 0
+
+
+def test_heatmap_filter_by_year(client):
+    response = client.get("/api/crashes/heatmap?year=2023")
+    body = response.json()
+    assert body["total_crashes"] == 2  # crashes 4 (Orange) + 5 (SF)
+
+
+def test_heatmap_filter_by_severity(client):
+    response = client.get("/api/crashes/heatmap?severity=fatal")
+    body = response.json()
+    assert body["total_crashes"] == 2  # crashes 1 (SWITRS) + 3 (CCRS)
+
+
+def test_heatmap_filter_by_cause(client):
+    response = client.get("/api/crashes/heatmap?cause=dui")
+    body = response.json()
+    assert body["total_crashes"] == 2  # crashes 1 + 3
+
+
+def test_heatmap_no_matching_crashes(client):
+    response = client.get("/api/crashes/heatmap?year=2001")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["points"] == []
+    assert body["total_crashes"] == 0
+
+
+def test_heatmap_cache_header(client):
+    response = client.get("/api/crashes/heatmap")
+    assert response.headers.get("cache-control") == "public, max-age=300"
+
+
+def test_heatmap_rejects_unknown_county(client):
+    response = client.get("/api/crashes/heatmap?county=atlantis")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "county"
+
+
+def test_heatmap_total_equals_sum_of_weights(client):
+    response = client.get("/api/crashes/heatmap")
+    body = response.json()
+    weight_sum = sum(p["weight"] for p in body["points"])
+    assert weight_sum == body["total_crashes"]

--- a/db/postgresql.conf
+++ b/db/postgresql.conf
@@ -1,0 +1,76 @@
+# CalSight PostgreSQL 16 tuning
+# Target: 48 GB RAM, 28 cores @ 3.4 GHz, SSD storage
+# Workload: ~25M rows, dashboard reads, materialized view refreshes
+
+# --- Connection handling ---
+max_connections = 200
+superuser_reserved_connections = 3
+
+# --- Memory ---
+# Pre-allocated at startup (~12 GB resident immediately)
+shared_buffers = 12GB
+
+# Planner hint only — not allocated by Postgres.
+# Tells the planner "the OS will probably cache this much."
+effective_cache_size = 36GB
+
+# Per-sort/hash operation. Freed after each operation completes.
+# 200 connections * ~2 ops * 64 MB = 25 GB theoretical max (rarely hit).
+work_mem = 64MB
+
+# Used only during VACUUM, CREATE INDEX, MV refresh.
+# 2 GB lets us rebuild indexes on the 11M-row crashes table fast.
+maintenance_work_mem = 2GB
+
+# Use huge pages if the OS has them configured (reduces TLB misses
+# for the 12 GB shared_buffers region). Falls back gracefully.
+huge_pages = try
+
+# WAL buffers — auto would derive from shared_buffers, cap it.
+wal_buffers = 64MB
+
+# --- Parallelism ---
+max_worker_processes = 28
+max_parallel_workers = 16
+max_parallel_workers_per_gather = 4
+max_parallel_maintenance_workers = 4
+
+# --- Planner cost tuning (SSD) ---
+# With most data cached in RAM, sequential and random reads cost about the same.
+random_page_cost = 1.1
+seq_page_cost = 1.0
+effective_io_concurrency = 200
+
+# --- WAL & checkpoints ---
+wal_level = replica
+min_wal_size = 1GB
+max_wal_size = 4GB
+checkpoint_completion_target = 0.9
+checkpoint_timeout = 10min
+
+# --- Background writer ---
+bgwriter_lru_maxpages = 100
+bgwriter_lru_multiplier = 2.0
+bgwriter_delay = 200ms
+
+# --- Logging (useful for slow query investigation) ---
+log_min_duration_statement = 500
+log_checkpoints = on
+log_connections = on
+log_disconnections = on
+log_lock_waits = on
+log_temp_files = 0
+log_autovacuum_min_duration = 0
+
+# --- Autovacuum (tuned for large tables) ---
+autovacuum_max_workers = 4
+autovacuum_naptime = 30s
+autovacuum_vacuum_threshold = 50
+autovacuum_vacuum_scale_factor = 0.02
+autovacuum_analyze_threshold = 50
+autovacuum_analyze_scale_factor = 0.01
+autovacuum_vacuum_cost_delay = 2ms
+
+# --- Misc ---
+default_statistics_target = 200
+temp_buffers = 32MB

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,6 +1,6 @@
 # Database schema
 
-Reference for the CalSight Postgres schema as it exists in production (Azure `calsight-db`) as of 2026-04-18. This document is descriptive — it reflects what the DB actually contains, not what `backend/app/models.py` on `main` currently describes (the ORM lags the DB; see CLAUDE.md).
+Reference for the CalSight Postgres schema as it exists in production (self-hosted on Proxmox LXC 100) as of 2026-04-28. This document is descriptive — it reflects what the DB actually contains, not what `backend/app/models.py` on `main` currently describes (the ORM lags the DB; see CLAUDE.md).
 
 Run `python backend/scripts/probe_db.py` (when added) to regenerate the row-count summary.
 
@@ -129,11 +129,11 @@ erDiagram
     }
 ```
 
-## Row counts (2026-04-18)
+## Row counts (2026-04-28)
 
 | Table / View | Rows | Notes |
 |---|---:|---|
-| `crashes` | 11,125,881 | SWITRS 6.78M + CCRS 4.35M |
+| `crashes` | 11,129,647 | SWITRS 6.78M + CCRS 4.35M |
 | `crash_parties` | 8,804,729 | CCRS only (party_id unique within `data_source`) |
 | `crash_victims` | 5,297,539 | CCRS only |
 | `weather` | 17,315 | NOAA, monthly per county |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.99.1",
         "autoprefixer": "^10.4.27",
         "leaflet": "^1.9.4",
+        "leaflet.heat": "^0.2.0",
         "postcss": "^8.5.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -151,6 +152,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -512,6 +514,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -560,6 +563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1822,8 +1826,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1988,6 +1991,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1998,6 +2002,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2047,6 +2052,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -2437,6 +2443,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2477,7 +2484,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2681,6 +2687,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3116,8 +3123,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -3225,6 +3231,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3807,6 +3814,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3942,7 +3950,13 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/leaflet.heat": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet.heat/-/leaflet.heat-0.2.0.tgz",
+      "integrity": "sha512-Cd5PbAA/rX3X3XKxfDoUGi9qp78FyhWYurFg3nsfhntcM/MCNK08pRkf4iEenO1KNqwVPKCmkyktjW3UD+h9bQ=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4033,7 +4047,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4328,6 +4341,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4372,6 +4386,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4525,7 +4540,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4541,7 +4555,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4554,8 +4567,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4609,6 +4621,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4618,6 +4631,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5094,6 +5108,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5292,6 +5307,7 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5408,6 +5424,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.99.1",
     "autoprefixer": "^10.4.27",
     "leaflet": "^1.9.4",
+    "leaflet.heat": "^0.2.0",
     "postcss": "^8.5.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/__mocks__/leaflet.ts
+++ b/frontend/src/__mocks__/leaflet.ts
@@ -15,6 +15,11 @@ export function createMockMap() {
     panTo: vi.fn(),
     getBounds,
     removeLayer: vi.fn(),
+    getPane: vi.fn(() => ({ style: {} })),
+    createPane: vi.fn(() => ({ style: {} })),
+    getZoom: vi.fn(() => 6),
+    setMaxZoom: vi.fn(),
+    setZoom: vi.fn(),
     addTo: vi.fn(),
     eachLayer: vi.fn(),
     on: vi.fn((event: string, cb: () => void) => {

--- a/frontend/src/__mocks__/leaflet.ts
+++ b/frontend/src/__mocks__/leaflet.ts
@@ -20,6 +20,7 @@ export function createMockMap() {
     getZoom: vi.fn(() => 6),
     setMaxZoom: vi.fn(),
     setZoom: vi.fn(),
+    fitBounds: vi.fn(),
     addTo: vi.fn(),
     eachLayer: vi.fn(),
     on: vi.fn((event: string, cb: () => void) => {
@@ -78,9 +79,19 @@ const tooltipMock = {
   addTo: vi.fn().mockReturnThis(),
 };
 
+function createBoundsMock() {
+  const bounds: Record<string, unknown> = {
+    getCenter: vi.fn(() => ({ lat: 37, lng: -119 })),
+    extend: vi.fn(() => bounds),
+    intersects: vi.fn(() => true),
+  };
+  return bounds;
+}
+
 const L = {
   geoJSON: vi.fn(() => geoJSONLayerMock),
   tooltip: vi.fn(() => tooltipMock),
+  latLngBounds: vi.fn(() => createBoundsMock()),
   DomUtil: { create: vi.fn(), remove: vi.fn() },
   DomEvent: { disableClickPropagation: vi.fn(), disableScrollPropagation: vi.fn() },
 };

--- a/frontend/src/components/map/AiInsightCard.test.tsx
+++ b/frontend/src/components/map/AiInsightCard.test.tsx
@@ -20,8 +20,13 @@ const POINT_B: ChoroplethPoint = {
   hasEnoughData: true,
 };
 
+async function expandCard() {
+  const bar = screen.getByText(/county/i).closest("[class*=cursor-pointer]");
+  if (bar) await userEvent.click(bar);
+}
+
 describe("AiInsightCard", () => {
-  it("renders county name and real stats in single mode", () => {
+  it("renders county name in collapsed bar", () => {
     render(
       <AiInsightCard
         onClose={vi.fn()}
@@ -33,10 +38,23 @@ describe("AiInsightCard", () => {
       />,
     );
     expect(screen.getByText("Los Angeles County")).toBeInTheDocument();
+  });
+
+  it("shows stats when expanded", async () => {
+    render(
+      <AiInsightCard
+        onClose={vi.fn()}
+        countyName="Los Angeles"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={false}
+        onCompare={vi.fn()}
+      />,
+    );
+    await expandCard();
     expect(screen.getByText("48,291")).toBeInTheDocument();
     expect(screen.getByText("412")).toBeInTheDocument();
     expect(screen.getByText("12,847")).toBeInTheDocument();
-    expect(screen.getByText("487")).toBeInTheDocument();
   });
 
   it("calls onClose when close button is clicked", async () => {
@@ -55,7 +73,7 @@ describe("AiInsightCard", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("shows Compare button in single mode", () => {
+  it("shows Compare button when expanded", async () => {
     render(
       <AiInsightCard
         onClose={vi.fn()}
@@ -66,40 +84,11 @@ describe("AiInsightCard", () => {
         onCompare={vi.fn()}
       />,
     );
+    await expandCard();
     expect(screen.getByRole("button", { name: /compare/i })).toBeInTheDocument();
   });
 
-  it("calls onCompare when Compare button is clicked", async () => {
-    const onCompare = vi.fn();
-    render(
-      <AiInsightCard
-        onClose={vi.fn()}
-        countyName="Fresno"
-        data={POINT_A}
-        measureLabel="Per 100k"
-        compareMode={false}
-        onCompare={onCompare}
-      />,
-    );
-    await userEvent.click(screen.getByRole("button", { name: /compare/i }));
-    expect(onCompare).toHaveBeenCalledTimes(1);
-  });
-
-  it("shows prompt text when in compare mode without second county", () => {
-    render(
-      <AiInsightCard
-        onClose={vi.fn()}
-        countyName="Fresno"
-        data={POINT_A}
-        measureLabel="Per 100k"
-        compareMode={true}
-        onCompare={vi.fn()}
-      />,
-    );
-    expect(screen.getByText(/click a county to compare/i)).toBeInTheDocument();
-  });
-
-  it("shows compare layout with both counties and percent diff", () => {
+  it("shows compare layout with both counties", () => {
     render(
       <AiInsightCard
         onClose={vi.fn()}
@@ -112,14 +101,10 @@ describe("AiInsightCard", () => {
         compareData={POINT_B}
       />,
     );
-    expect(screen.getByText("Los Angeles")).toBeInTheDocument();
-    expect(screen.getByText("Orange")).toBeInTheDocument();
-    expect(screen.getByText("48,291")).toBeInTheDocument();
-    expect(screen.getByText("8,412")).toBeInTheDocument();
-    expect(screen.getByText("-82.6%")).toBeInTheDocument();
+    expect(screen.getByText("Los Angeles vs Orange")).toBeInTheDocument();
   });
 
-  it("shows N/A for measure value when hasEnoughData is false", () => {
+  it("shows N/A for measure value when hasEnoughData is false", async () => {
     const noData: ChoroplethPoint = { value: null, rawCount: 3, totalKilled: 0, totalInjured: 1, hasEnoughData: false };
     render(
       <AiInsightCard
@@ -131,6 +116,7 @@ describe("AiInsightCard", () => {
         onCompare={vi.fn()}
       />,
     );
+    await expandCard();
     expect(screen.getByText("N/A")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ChoroplethPoint } from "../../hooks/useChoroplethData";
 
 interface AiInsightCardProps {
@@ -35,8 +36,8 @@ function measureValue(data: ChoroplethPoint): string {
 
 function MetricGrid({ data, measureLabel }: { data: ChoroplethPoint; measureLabel: string }) {
   return (
-    <div className="grid grid-cols-2 gap-3 md:gap-4 py-1 md:py-2">
-      <MetricCell label="Total Crashes" value={fmt(data.rawCount)} />
+    <div className="grid grid-cols-4 gap-2">
+      <MetricCell label="Crashes" value={fmt(data.rawCount)} />
       <MetricCell label="Killed" value={fmt(data.totalKilled)} />
       <MetricCell label="Injured" value={fmt(data.totalInjured)} />
       <MetricCell label={measureLabel} value={measureValue(data)} />
@@ -46,11 +47,11 @@ function MetricGrid({ data, measureLabel }: { data: ChoroplethPoint; measureLabe
 
 function MetricCell({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-surface-container-low/50 p-2 md:p-3 rounded-lg">
-      <p className="text-[8px] md:text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-0.5 md:mb-1">
+    <div className="bg-surface-container-low/50 p-2 rounded-lg">
+      <p className="text-[8px] text-on-surface-variant font-bold uppercase tracking-widest mb-0.5">
         {label}
       </p>
-      <p className="text-base md:text-lg font-bold text-on-surface">{value}</p>
+      <p className="text-sm font-bold text-on-surface">{value}</p>
     </div>
   );
 }
@@ -62,19 +63,15 @@ function CompareRow({ label, aVal, bVal, isMeasure }: { label: string; aVal: num
   const diff = aVal != null && bVal != null ? pctDiff(aVal, bVal) : null;
 
   return (
-    <div className="bg-surface-container-low/50 p-2 md:p-3 rounded-lg">
-      <p className="text-[8px] md:text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-1 md:mb-2">
-        {label}
-      </p>
-      <div className="flex items-baseline justify-between gap-1 md:gap-2">
-        <span className="text-base md:text-lg font-bold text-on-surface">{aStr}</span>
-        {diff && (
-          <span className={`text-[10px] md:text-xs font-semibold ${diff.startsWith("+") ? "text-error" : "text-tertiary"}`}>
-            {diff}
-          </span>
-        )}
-        <span className="text-base md:text-lg font-bold text-on-surface">{bStr}</span>
-      </div>
+    <div className="flex items-baseline justify-between gap-2 bg-surface-container-low/50 px-3 py-2 rounded-lg">
+      <span className="text-[8px] text-on-surface-variant font-bold uppercase tracking-widest w-16 shrink-0">{label}</span>
+      <span className="text-sm font-bold text-on-surface">{aStr}</span>
+      {diff && (
+        <span className={`text-[10px] font-semibold ${diff.startsWith("+") ? "text-error" : "text-tertiary"}`}>
+          {diff}
+        </span>
+      )}
+      <span className="text-sm font-bold text-on-surface">{bStr}</span>
     </div>
   );
 }
@@ -89,64 +86,85 @@ export default function AiInsightCard({
   compareCountyName,
   compareData,
 }: AiInsightCardProps) {
+  const [expanded, setExpanded] = useState(false);
   const isComparing = compareMode && compareCountyName && compareData;
 
   return (
-    <div className={`fixed bottom-14 left-2 right-2 max-h-[55vh] overflow-y-auto md:max-h-none md:overflow-visible md:absolute md:bottom-auto md:left-auto md:right-[10%] md:top-[25%] z-30 ${isComparing ? "md:w-[420px]" : "md:w-[340px]"} bg-surface-container-lowest/90 backdrop-blur-md p-4 md:p-6 rounded-xl ambient-shadow ghost-border flex flex-col gap-2 md:gap-4`}>
-      <div className="flex justify-end items-start">
-        <button
-          onClick={onClose}
-          className="p-1 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
+    <div className="absolute bottom-0 left-0 right-0 z-30 md:bottom-2 md:left-16 md:right-2">
+      <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden">
+        {/* Collapsed bar — always visible */}
+        <div
+          className="flex items-center justify-between px-4 py-2.5 cursor-pointer select-none"
+          onClick={() => setExpanded((v) => !v)}
         >
-          <span className="material-symbols-outlined text-[18px]">close</span>
-        </button>
-      </div>
-
-      {isComparing && data ? (
-        <>
-          <div className="flex items-center justify-between">
-            <h3 className="font-headline text-sm md:text-base font-bold text-on-surface tracking-tight">{countyName}</h3>
-            <span className="text-[10px] md:text-xs text-on-surface-variant">vs</span>
-            <h3 className="font-headline text-sm md:text-base font-bold text-on-surface tracking-tight">{compareCountyName}</h3>
-          </div>
-          <div className="flex flex-col gap-2 md:gap-3">
-            <CompareRow label="Total Crashes" aVal={data.rawCount} bVal={compareData.rawCount} />
-            <CompareRow label="Killed" aVal={data.totalKilled} bVal={compareData.totalKilled} />
-            <CompareRow label="Injured" aVal={data.totalInjured} bVal={compareData.totalInjured} />
-            <CompareRow
-              label={measureLabel}
-              aVal={data.hasEnoughData ? data.value : null}
-              bVal={compareData.hasEnoughData ? compareData.value : null}
-              isMeasure
-            />
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="space-y-1">
-            <h3 className="font-headline text-xl md:text-2xl font-bold text-on-surface tracking-tight leading-tight">
-              {countyName} County
+          <div className="flex items-center gap-3 min-w-0">
+            <h3 className="font-headline text-sm font-bold text-on-surface tracking-tight truncate">
+              {isComparing ? `${countyName} vs ${compareCountyName}` : `${countyName} County`}
             </h3>
+            {data && !expanded && (
+              <span className="text-xs text-on-surface-variant hidden sm:inline">
+                {fmt(data.rawCount)} crashes · {fmt(data.totalKilled)} killed
+              </span>
+            )}
           </div>
-
-          {data && <MetricGrid data={data} measureLabel={measureLabel} />}
-
-          {compareMode && !compareCountyName && (
-            <p className="text-xs md:text-sm text-on-surface-variant text-center py-1 md:py-2">
-              Click a county to compare
-            </p>
-          )}
-
-          {!compareMode && (
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="material-symbols-outlined text-[18px] text-on-surface-variant transition-transform" style={{ transform: expanded ? "rotate(180deg)" : undefined }}>
+              expand_less
+            </span>
             <button
-              onClick={onCompare}
-              className="w-full bg-primary-container text-on-primary-container py-2 md:py-3 rounded-lg text-[11px] font-bold tracking-widest uppercase hover:opacity-90 transition-opacity"
+              onClick={(e) => { e.stopPropagation(); onClose(); }}
+              className="p-1 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
             >
-              Compare
+              <span className="material-symbols-outlined text-[16px]">close</span>
             </button>
-          )}
-        </>
-      )}
+          </div>
+        </div>
+
+        {/* Expanded content */}
+        {expanded && (
+          <div className="px-4 pb-4 space-y-3">
+            {isComparing && data ? (
+              <>
+                <div className="flex items-center justify-between">
+                  <h3 className="font-headline text-sm font-bold text-on-surface tracking-tight">{countyName}</h3>
+                  <span className="text-[10px] text-on-surface-variant">vs</span>
+                  <h3 className="font-headline text-sm font-bold text-on-surface tracking-tight">{compareCountyName}</h3>
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <CompareRow label="Crashes" aVal={data.rawCount} bVal={compareData.rawCount} />
+                  <CompareRow label="Killed" aVal={data.totalKilled} bVal={compareData.totalKilled} />
+                  <CompareRow label="Injured" aVal={data.totalInjured} bVal={compareData.totalInjured} />
+                  <CompareRow
+                    label={measureLabel}
+                    aVal={data.hasEnoughData ? data.value : null}
+                    bVal={compareData.hasEnoughData ? compareData.value : null}
+                    isMeasure
+                  />
+                </div>
+              </>
+            ) : (
+              <>
+                {data && <MetricGrid data={data} measureLabel={measureLabel} />}
+
+                {compareMode && !compareCountyName && (
+                  <p className="text-xs text-on-surface-variant text-center py-1">
+                    Click a county to compare
+                  </p>
+                )}
+
+                {!compareMode && (
+                  <button
+                    onClick={onCompare}
+                    className="w-full bg-primary-container text-on-primary-container py-2 rounded-lg text-[11px] font-bold tracking-widest uppercase hover:opacity-90 transition-opacity"
+                  >
+                    Compare
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -90,7 +90,7 @@ export default function AiInsightCard({
   const isComparing = compareMode && compareCountyName && compareData;
 
   return (
-    <div className="absolute bottom-0 left-0 right-0 z-30 md:bottom-2 md:left-16 md:right-2">
+    <div className="absolute bottom-0 left-0 right-0 z-30 md:bottom-2 md:left-16 md:right-auto md:max-w-sm">
       <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden">
         {/* Collapsed bar — always visible */}
         <div

--- a/frontend/src/components/map/CaliforniaMask.tsx
+++ b/frontend/src/components/map/CaliforniaMask.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import { useMap } from "react-leaflet";
+import L from "leaflet";
+import { useIsDark } from "../../context/ThemeContext";
+
+const WORLD_RING: [number, number][] = [
+  [-90, -180], [-90, 180], [90, 180], [90, -180], [-90, -180],
+];
+
+interface CaliforniaMaskProps {
+  focusedCounty: string | null;
+  compareCounty: string | null;
+}
+
+export default function CaliforniaMask({ focusedCounty, compareCounty }: CaliforniaMaskProps) {
+  const map = useMap();
+  const isDark = useIsDark();
+  const layerRef = useRef<L.GeoJSON | null>(null);
+  const [geojson, setGeojson] = useState<GeoJSON.FeatureCollection | null>(null);
+
+  useEffect(() => {
+    fetch("/ca-counties.geojson")
+      .then((res) => res.json())
+      .then(setGeojson);
+  }, []);
+
+  useEffect(() => {
+    if (layerRef.current) {
+      map.removeLayer(layerRef.current);
+      layerRef.current = null;
+    }
+    if (!geojson) return;
+
+    const activeCounties = new Set<string>();
+    if (focusedCounty) activeCounties.add(focusedCounty);
+    if (compareCounty) activeCounties.add(compareCounty);
+
+    const holes: [number, number][][] = [];
+    for (const feature of geojson.features) {
+      const name = (feature.properties?.name ?? "").toString();
+      if (activeCounties.size > 0 && !activeCounties.has(name)) continue;
+
+      const geom = feature.geometry;
+      if (geom.type === "Polygon") {
+        holes.push(geom.coordinates[0] as [number, number][]);
+      } else if (geom.type === "MultiPolygon") {
+        for (const poly of geom.coordinates) {
+          holes.push(poly[0] as [number, number][]);
+        }
+      }
+    }
+
+    const invertedPolygon: GeoJSON.Feature<GeoJSON.Polygon> = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          WORLD_RING.map(([lat, lng]) => [lng, lat]),
+          ...holes,
+        ],
+      },
+    };
+
+    const fillColor = isDark ? "#1d1d1d" : "#e8e5e0";
+
+    const layer = L.geoJSON(invertedPolygon, {
+      style: {
+        fillColor,
+        fillOpacity: 0.95,
+        stroke: false,
+      },
+      interactive: false,
+    });
+
+    layer.addTo(map);
+    layerRef.current = layer;
+
+    return () => {
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current);
+        layerRef.current = null;
+      }
+    };
+  }, [map, geojson, isDark, focusedCounty, compareCounty]);
+
+  return null;
+}

--- a/frontend/src/components/map/ChoroplethLegend.test.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useEffect } from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { LayersStateProvider, useLayersState } from "../../hooks/useLayersState";
@@ -39,6 +39,7 @@ function Harness({
 }
 
 describe("ChoroplethLegend", () => {
+  beforeEach(() => { localStorage.clear(); });
   it("renders the measure dropdown with all 5 options", async () => {
     render(<Harness edges={[0, 10, 20, 30, 40, 50]} />);
     const trigger = await screen.findByLabelText(/measure/i);

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -15,6 +15,9 @@ type Props = {
   is422?: boolean;
   searchOpen?: boolean;
   onRetry?: () => void;
+  heatmapCrashes?: number | null;
+  heatmapLoading?: boolean;
+  countyActive?: boolean;
 };
 
 function formatYearList(years: number[]): string {
@@ -34,7 +37,7 @@ function formatCount(n: number): string {
 
 const EMPTY_SUMMARY: DataSummary = { totalCrashes: 0, missingDemoYears: [], partialDemoYears: [], sparseYears: [] };
 
-export default function ChoroplethLegend({ demographicsAvailable, dataSummary = EMPTY_SUMMARY, coordCoverage, isLoading, isError, is422, searchOpen, onRetry }: Props) {
+export default function ChoroplethLegend({ demographicsAvailable, dataSummary = EMPTY_SUMMARY, coordCoverage, isLoading, isError, is422, onRetry, heatmapCrashes, heatmapLoading }: Props) {
   const { choroplethOn, measure, palette, bucketEdges, setMeasure } = useLayersState();
   const isDark = useIsDark();
   const [isOpen, setIsOpen] = useState(false);
@@ -50,6 +53,8 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
     return () => document.removeEventListener("mousedown", handleClick);
   }, []);
 
+  const [mobileExpanded, setMobileExpanded] = useState(false);
+
   if (!choroplethOn) return null;
 
   const colors = getPalette(palette, isDark);
@@ -59,15 +64,27 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
   return (
     <div
       data-testid="choropleth-legend"
-      className={`absolute right-4 z-20 bg-surface-container-lowest/95 backdrop-blur-md rounded-xl p-3 w-[220px] ghost-border transition-all duration-300 ${searchOpen ? "bottom-24 md:bottom-4" : "bottom-4"}`}
+      className={`absolute left-2 md:left-auto md:right-4 z-20 bg-surface-container-lowest/95 backdrop-blur-md rounded-xl p-2 md:p-3 w-[200px] md:w-[250px] ghost-border transition-all duration-300 top-2 md:top-2 md:bottom-auto`}
     >
+      {/* Mobile: tap to expand */}
+      <div
+        className="md:hidden flex items-center justify-between mb-1 cursor-pointer"
+        onClick={() => setMobileExpanded((v) => !v)}
+      >
+        <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">{activeMeasure.label}</span>
+        <span className="material-symbols-outlined text-[14px] text-on-surface-variant transition-transform" style={{ transform: mobileExpanded ? "rotate(180deg)" : undefined }}>
+          expand_less
+        </span>
+      </div>
+
+      {/* Desktop: always show label */}
       <label
-        className="block text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2"
+        className="hidden md:block text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2"
         id="choropleth-measure-label"
       >
         Measure
       </label>
-      <div ref={containerRef} className="relative mb-3">
+      <div ref={containerRef} className={`relative mb-3 ${mobileExpanded ? "" : "hidden md:block"}`}>
         <button
           type="button"
           aria-labelledby="choropleth-measure-label"
@@ -76,7 +93,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           onClick={() => setIsOpen((v) => !v)}
           className="w-full flex items-center justify-between text-sm font-semibold text-on-surface bg-surface-container-high rounded-lg py-2 px-3 cursor-pointer hover:bg-surface-variant transition-colors focus:outline-none focus:ring-2 focus:ring-primary/20"
         >
-          <span className="truncate">{activeMeasure.label}</span>
+          <span>{activeMeasure.label}</span>
           <span className={`material-symbols-outlined text-[16px] text-on-surface-variant transition-transform ${isOpen ? "rotate-180" : ""}`}>
             expand_more
           </span>
@@ -86,7 +103,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           <div
             role="listbox"
             aria-labelledby="choropleth-measure-label"
-            className="absolute z-50 left-0 right-0 bottom-full mb-1 bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15 overflow-hidden"
+            className="absolute z-50 left-0 right-0 top-full mt-1 bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15 overflow-hidden"
           >
             {allMeasures.map((m) => {
               const isSelected = m.key === measure;
@@ -131,22 +148,32 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
         ))}
       </div>
 
-      {isLoading ? (
-        <div className="text-[10px] text-on-surface-variant mt-1 italic">
-          Loading data…
-        </div>
-      ) : bucketEdges ? (
-        <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
-          {bucketEdges.map((e, i) => (
-            <span key={i}>{activeMeasure.formatLabel(e)}</span>
-          ))}
-        </div>
-      ) : (
-        <div className="text-[10px] text-on-surface-variant mt-1 italic">
-          Pan or zoom out to compute scale
+      {(heatmapLoading || (heatmapCrashes != null && heatmapCrashes > 0)) && (
+        <div className="text-[10px] text-on-surface-variant mt-1 font-mono font-semibold">
+          {heatmapLoading ? "Loading heatmap..." : `${heatmapCrashes!.toLocaleString()} crashes mapped`}
         </div>
       )}
 
+      {/* Bucket labels — hide on mobile when collapsed */}
+      <div className={mobileExpanded ? "" : "hidden md:block"}>
+        {isLoading ? (
+          <div className="text-[10px] text-on-surface-variant mt-1 italic">
+            Loading data…
+          </div>
+        ) : bucketEdges ? (
+          <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
+            {bucketEdges.map((e, i) => (
+              <span key={i}>{activeMeasure.formatLabel(e)}</span>
+            ))}
+          </div>
+        ) : (
+          <div className="text-[10px] text-on-surface-variant mt-1 italic">
+            Pan or zoom out to compute scale
+          </div>
+        )}
+      </div>
+
+      <div className={mobileExpanded ? "" : "hidden md:block"}>
       {!isLoading && dataSummary.totalCrashes > 0 && (
         <div data-testid="data-summary" className="text-[11px] sm:text-[10px] text-on-surface-variant mt-2 leading-snug">
           <span className="font-mono font-semibold">{formatCount(dataSummary.totalCrashes)}</span> crashes
@@ -205,6 +232,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           )}
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -81,6 +81,12 @@ export default function CountyBoundaries({
   });
   countyFilterRef.current = { has: selectedCounties, active: hasCountyFilter };
 
+  const focusRef = useRef<{ focused: string | null; compare: string | null }>({
+    focused: focusedCounty,
+    compare: compareCounty ?? null,
+  });
+  focusRef.current = { focused: focusedCounty, compare: compareCounty ?? null };
+
 
 
   useEffect(() => {
@@ -129,6 +135,14 @@ export default function CountyBoundaries({
           : base;
       }
 
+      if (otherLayers.heatmap) {
+        return {
+          color: borderColor,
+          weight: borderWeight,
+          fillOpacity: 0,
+        };
+      }
+
       const code = getCountyCode(feature);
       const point = code != null ? byCountyCode[code] : undefined;
       const colors = getPalette(palette, isDark);
@@ -154,7 +168,7 @@ export default function CountyBoundaries({
         fillOpacity: 0.75,
       };
     },
-    [choroplethOn, otherLayers.countyBoundaries, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
+    [choroplethOn, otherLayers.countyBoundaries, otherLayers.heatmap, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
   );
 
   // Ref so mouseout can re-apply the *current* style (not the stale one
@@ -212,9 +226,10 @@ export default function CountyBoundaries({
             },
             mouseover: (e) => {
               if (name === focusedCounty) return;
-              // Skip hover effect for unselected counties
               const cf = countyFilterRef.current;
               if (cf.active && !cf.has.has(name)) return;
+              const fc = focusRef.current;
+              if (fc.focused && name !== fc.focused && name !== fc.compare) return;
 
               const path = e.target as L.Path;
               path.setStyle({ weight: 2, color: FOCUSED_COLOR });

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -135,7 +135,7 @@ export default function CountyBoundaries({
           : base;
       }
 
-      if (otherLayers.heatmap) {
+      if (otherLayers.heatmapStatewide || otherLayers.heatmapCounty) {
         return {
           color: borderColor,
           weight: borderWeight,
@@ -168,7 +168,7 @@ export default function CountyBoundaries({
         fillOpacity: 0.75,
       };
     },
-    [choroplethOn, otherLayers.countyBoundaries, otherLayers.heatmap, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
+    [choroplethOn, otherLayers.countyBoundaries, otherLayers.heatmapStatewide, otherLayers.heatmapCounty, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
   );
 
   // Ref so mouseout can re-apply the *current* style (not the stale one

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -322,7 +322,7 @@ export default function CountyBoundaries({
             .setContent(name)
             .addTo(map);
           ref.current = tooltip;
-          combined = combined ? combined.extend(bounds) : L.latLngBounds(bounds);
+          combined = combined ? combined.extend(bounds) : bounds;
         }
       });
     };

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -135,7 +135,7 @@ export default function CountyBoundaries({
           : base;
       }
 
-      if (otherLayers.heatmapStatewide || otherLayers.heatmapCounty) {
+      if (otherLayers.heatmapCounty && focusedCounty) {
         return {
           color: borderColor,
           weight: borderWeight,
@@ -305,6 +305,8 @@ export default function CountyBoundaries({
 
     if (!layerRef.current) return;
 
+    let combined: L.LatLngBounds | null = null;
+
     const showTooltipFor = (name: string, ref: React.MutableRefObject<L.Tooltip | null>) => {
       layerRef.current!.eachLayer((fl) => {
         const f = (fl as L.GeoJSON & { feature: GeoJSON.Feature }).feature;
@@ -320,15 +322,17 @@ export default function CountyBoundaries({
             .setContent(name)
             .addTo(map);
           ref.current = tooltip;
-          if (!map.getBounds().contains(center)) {
-            map.panTo(center, { animate: true });
-          }
+          combined = combined ? combined.extend(bounds) : L.latLngBounds(bounds);
         }
       });
     };
 
     if (focusedCounty) showTooltipFor(focusedCounty, tooltipRef);
     if (compareCounty) showTooltipFor(compareCounty, compareTooltipRef);
+
+    if (combined) {
+      map.fitBounds(combined, { animate: true, padding: [40, 40], maxZoom: 11 });
+    }
 
     return () => {
       if (tooltipRef.current) {

--- a/frontend/src/components/map/CrashHeatmap.test.tsx
+++ b/frontend/src/components/map/CrashHeatmap.test.tsx
@@ -6,6 +6,9 @@ vi.mock("react-leaflet", () => ({
     addLayer: vi.fn(),
     removeLayer: vi.fn(),
     hasLayer: vi.fn(() => false),
+    getZoom: vi.fn(() => 6),
+    on: vi.fn(),
+    off: vi.fn(),
   }),
 }));
 

--- a/frontend/src/components/map/CrashHeatmap.test.tsx
+++ b/frontend/src/components/map/CrashHeatmap.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("react-leaflet", () => ({
+  useMap: () => ({
+    addLayer: vi.fn(),
+    removeLayer: vi.fn(),
+    hasLayer: vi.fn(() => false),
+  }),
+}));
+
+vi.mock("leaflet", async () => {
+  const actual = await vi.importActual<typeof import("leaflet")>("leaflet");
+  const heatLayerFn = vi.fn(() => ({
+    setLatLngs: vi.fn().mockReturnThis(),
+    addTo: vi.fn().mockReturnThis(),
+    remove: vi.fn(),
+    setOptions: vi.fn().mockReturnThis(),
+    redraw: vi.fn().mockReturnThis(),
+  }));
+  return {
+    default: {
+      ...(actual as unknown as Record<string, unknown>),
+      heatLayer: heatLayerFn,
+    },
+  };
+});
+
+import L from "leaflet";
+
+describe("CrashHeatmap", () => {
+  it("creates a heat layer when given points", async () => {
+    const { useHeatLayer } = await import("./CrashHeatmap");
+
+    const points = [
+      { lat: 34.0, lng: -118.0, weight: 42 },
+      { lat: 34.1, lng: -118.1, weight: 17 },
+    ];
+
+    renderHook(() => useHeatLayer(points, "medium", "default", false));
+
+    expect(L.heatLayer).toHaveBeenCalled();
+  });
+
+  it("does not create a layer when points are empty", async () => {
+    vi.mocked(L.heatLayer).mockClear();
+    const { useHeatLayer } = await import("./CrashHeatmap");
+
+    renderHook(() => useHeatLayer([], "medium", "default", false));
+
+    expect(L.heatLayer).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/map/CrashHeatmap.tsx
+++ b/frontend/src/components/map/CrashHeatmap.tsx
@@ -8,25 +8,21 @@ import type { PaletteKey } from "../../lib/choropleth/palettes";
 import { getPalette } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 
-const HEAT_CONFIG: Record<HeatmapResolution, { radius: number; blur: number; max: number }> = {
-  low: { radius: 20, blur: 25, max: 0 },
-  medium: { radius: 15, blur: 20, max: 0 },
-  high: { radius: 10, blur: 15, max: 0 },
+const BASE_RADIUS: Record<HeatmapResolution, number> = {
+  raw: 5,
+  low: 18,
+  medium: 12,
+  high: 8,
 };
 
-const DEFAULT_GRADIENT: Record<number, string> = {
-  0.0: "transparent",
-  0.2: "#fef3c7",
-  0.4: "#fcd34d",
-  0.6: "#f59e0b",
-  0.8: "#dc2626",
-  1.0: "#7f1d1d",
-};
+function radiusForZoom(base: number, zoom: number): number {
+  const scale = Math.pow(2, zoom - 6) * 0.5;
+  return Math.max(2, Math.round(base * scale));
+}
 
 function buildGradient(palette: PaletteKey, isDark: boolean): Record<number, string> {
-  if (palette === "default") return DEFAULT_GRADIENT;
   const colors = getPalette(palette, isDark);
-  const stops: Record<number, string> = { 0.0: "transparent" };
+  const stops: Record<number, string> = { 0: "transparent" };
   colors.forEach((c, i) => {
     stops[(i + 1) / colors.length] = c;
   });
@@ -41,6 +37,7 @@ export function useHeatLayer(
 ) {
   const map = useMap();
   const layerRef = useRef<L.HeatLayer | null>(null);
+  const latlngsRef = useRef<[number, number, number][]>([]);
 
   useEffect(() => {
     if (layerRef.current) {
@@ -50,28 +47,45 @@ export function useHeatLayer(
 
     if (points.length === 0) return;
 
-    const maxWeight = Math.max(...points.map((p) => p.weight));
-    const config = HEAT_CONFIG[resolution];
+    let maxWeight = 0;
+    for (const p of points) {
+      if (p.weight > maxWeight) maxWeight = p.weight;
+    }
     const gradient = buildGradient(palette, isDark);
 
-    const latlngs: [number, number, number][] = points.map((p) => [
+    latlngsRef.current = points.map((p) => [
       p.lat,
       p.lng,
       p.weight / (maxWeight || 1),
     ]);
 
-    const layer = L.heatLayer(latlngs, {
-      radius: config.radius,
-      blur: config.blur,
-      maxZoom: 14,
+    const base = BASE_RADIUS[resolution];
+    const isRaw = resolution === "raw";
+    const r = isRaw ? base : radiusForZoom(base, map.getZoom());
+    const blur = isRaw ? Math.round(base * 0.6) : Math.max(1, Math.round(r * 0.3));
+
+    const layer = L.heatLayer(latlngsRef.current, {
+      radius: r,
+      blur,
       max: 1,
+      minOpacity: 0.1,
       gradient,
     });
 
     layer.addTo(map);
     layerRef.current = layer;
 
+    const onZoom = () => {
+      if (!layerRef.current || isRaw) return;
+      const z = map.getZoom();
+      const newR = radiusForZoom(base, z);
+      layerRef.current.setOptions({ radius: newR, blur: Math.max(1, Math.round(newR * 0.3)) });
+      layerRef.current.redraw();
+    };
+    map.on("zoomend", onZoom);
+
     return () => {
+      map.off("zoomend", onZoom);
       if (layerRef.current) {
         map.removeLayer(layerRef.current);
         layerRef.current = null;

--- a/frontend/src/components/map/CrashHeatmap.tsx
+++ b/frontend/src/components/map/CrashHeatmap.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import { useMap } from "react-leaflet";
+import L from "leaflet";
+import "leaflet.heat";
+import type { HeatmapPoint } from "../../hooks/useCrashHeatmap";
+import type { HeatmapResolution } from "../../hooks/useLayersState";
+import type { PaletteKey } from "../../lib/choropleth/palettes";
+import { getPalette } from "../../lib/choropleth/palettes";
+import { useIsDark } from "../../context/ThemeContext";
+
+const HEAT_CONFIG: Record<HeatmapResolution, { radius: number; blur: number; max: number }> = {
+  low: { radius: 20, blur: 25, max: 0 },
+  medium: { radius: 15, blur: 20, max: 0 },
+  high: { radius: 10, blur: 15, max: 0 },
+};
+
+const DEFAULT_GRADIENT: Record<number, string> = {
+  0.0: "transparent",
+  0.2: "#fef3c7",
+  0.4: "#fcd34d",
+  0.6: "#f59e0b",
+  0.8: "#dc2626",
+  1.0: "#7f1d1d",
+};
+
+function buildGradient(palette: PaletteKey, isDark: boolean): Record<number, string> {
+  if (palette === "default") return DEFAULT_GRADIENT;
+  const colors = getPalette(palette, isDark);
+  const stops: Record<number, string> = { 0.0: "transparent" };
+  colors.forEach((c, i) => {
+    stops[(i + 1) / colors.length] = c;
+  });
+  return stops;
+}
+
+export function useHeatLayer(
+  points: HeatmapPoint[],
+  resolution: HeatmapResolution,
+  palette: PaletteKey,
+  isDark: boolean,
+) {
+  const map = useMap();
+  const layerRef = useRef<L.HeatLayer | null>(null);
+
+  useEffect(() => {
+    if (layerRef.current) {
+      map.removeLayer(layerRef.current);
+      layerRef.current = null;
+    }
+
+    if (points.length === 0) return;
+
+    const maxWeight = Math.max(...points.map((p) => p.weight));
+    const config = HEAT_CONFIG[resolution];
+    const gradient = buildGradient(palette, isDark);
+
+    const latlngs: [number, number, number][] = points.map((p) => [
+      p.lat,
+      p.lng,
+      p.weight / (maxWeight || 1),
+    ]);
+
+    const layer = L.heatLayer(latlngs, {
+      radius: config.radius,
+      blur: config.blur,
+      maxZoom: 14,
+      max: 1,
+      gradient,
+    });
+
+    layer.addTo(map);
+    layerRef.current = layer;
+
+    return () => {
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current);
+        layerRef.current = null;
+      }
+    };
+  }, [map, points, resolution, palette, isDark]);
+
+  return layerRef;
+}
+
+interface CrashHeatmapProps {
+  points: HeatmapPoint[];
+  resolution: HeatmapResolution;
+  palette: PaletteKey;
+}
+
+export default function CrashHeatmap({ points, resolution, palette }: CrashHeatmapProps) {
+  const isDark = useIsDark();
+  useHeatLayer(points, resolution, palette, isDark);
+  return null;
+}

--- a/frontend/src/components/map/HeatmapInfoBadge.tsx
+++ b/frontend/src/components/map/HeatmapInfoBadge.tsx
@@ -1,0 +1,18 @@
+interface HeatmapInfoBadgeProps {
+  totalCrashes: number;
+  isLoading: boolean;
+}
+
+export default function HeatmapInfoBadge({ totalCrashes, isLoading }: HeatmapInfoBadgeProps) {
+  if (!isLoading && totalCrashes === 0) return null;
+
+  return (
+    <div className="absolute top-2 left-2 md:top-auto md:bottom-4 md:left-4 z-20 bg-surface-container-lowest/90 backdrop-blur-md px-3 py-1.5 rounded-full text-on-surface text-xs font-medium ghost-border">
+      {isLoading ? (
+        <span className="text-on-surface-variant">Loading heatmap...</span>
+      ) : (
+        <span>{totalCrashes.toLocaleString()} crashes</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -69,19 +69,19 @@ export default function LayersPanel() {
         </div>
       </div>
 
-      {/* Heatmap */}
+      {/* Statewide Heatmap */}
       <div className="space-y-4">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          Heatmap
+          Statewide Heatmap
         </label>
         <div className="space-y-3">
           <div className="flex justify-between items-center">
-            <span className={`text-sm font-medium ${otherLayers.heatmap ? "text-on-surface" : "text-on-surface-variant"}`}>
-              Crash Heatmap
+            <span className={`text-sm font-medium ${otherLayers.heatmapStatewide ? "text-on-surface" : "text-on-surface-variant"}`}>
+              Full State
             </span>
-            <Toggle enabled={otherLayers.heatmap} onToggle={() => toggleOtherLayer("heatmap")} />
+            <Toggle enabled={otherLayers.heatmapStatewide} onToggle={() => toggleOtherLayer("heatmapStatewide")} />
           </div>
-          {otherLayers.heatmap && (
+          {otherLayers.heatmapStatewide && (
             <div className="space-y-2 pl-1">
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
                 Resolution
@@ -90,7 +90,6 @@ export default function LayersPanel() {
                 {([
                   { key: "low" as const, label: "Low" },
                   { key: "medium" as const, label: "Medium" },
-                  { key: "high" as const, label: "High" },
                 ]).map(({ key, label }) => (
                   <button
                     key={key}
@@ -109,6 +108,26 @@ export default function LayersPanel() {
                 Higher resolution shows finer detail but loads slower
               </p>
             </div>
+          )}
+        </div>
+      </div>
+
+      {/* County Heatmap */}
+      <div className="space-y-4">
+        <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
+          County Heatmap
+        </label>
+        <div className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className={`text-sm font-medium ${otherLayers.heatmapCounty ? "text-on-surface" : "text-on-surface-variant"}`}>
+              County Detail
+            </span>
+            <Toggle enabled={otherLayers.heatmapCounty} onToggle={() => toggleOtherLayer("heatmapCounty")} />
+          </div>
+          {otherLayers.heatmapCounty && (
+            <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
+              Shows individual crash locations when a county is selected
+            </p>
           )}
         </div>
       </div>

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -38,6 +38,8 @@ export default function LayersPanel() {
     choroplethOn, setChoroplethOn,
     measure, setMeasure,
     palette: activePalette, setPalette,
+    otherLayers, toggleOtherLayer,
+    heatmapResolution, setHeatmapResolution,
     reset,
   } = useLayersState();
   const isDark = useIsDark();
@@ -64,6 +66,50 @@ export default function LayersPanel() {
             </span>
             <Toggle enabled={choroplethOn} onToggle={() => setChoroplethOn(!choroplethOn)} />
           </div>
+        </div>
+      </div>
+
+      {/* Heatmap */}
+      <div className="space-y-4">
+        <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
+          Heatmap
+        </label>
+        <div className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className={`text-sm font-medium ${otherLayers.heatmap ? "text-on-surface" : "text-on-surface-variant"}`}>
+              Crash Heatmap
+            </span>
+            <Toggle enabled={otherLayers.heatmap} onToggle={() => toggleOtherLayer("heatmap")} />
+          </div>
+          {otherLayers.heatmap && (
+            <div className="space-y-2 pl-1">
+              <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+                Resolution
+              </span>
+              <div className="flex gap-1.5">
+                {([
+                  { key: "low" as const, label: "Low" },
+                  { key: "medium" as const, label: "Medium" },
+                  { key: "high" as const, label: "High" },
+                ]).map(({ key, label }) => (
+                  <button
+                    key={key}
+                    onClick={() => setHeatmapResolution(key)}
+                    className={`px-2.5 py-1 rounded-md text-[11px] font-semibold transition-colors ${
+                      heatmapResolution === key
+                        ? "bg-primary text-on-primary"
+                        : "bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[10px] text-on-surface-variant leading-tight">
+                Higher resolution shows finer detail but loads slower
+              </p>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -38,7 +38,7 @@ export default function LayersPanel() {
     choroplethOn, setChoroplethOn,
     measure, setMeasure,
     palette: activePalette, setPalette,
-    otherLayers, toggleOtherLayer,
+    otherLayers, toggleOtherLayer, setOtherLayer,
     heatmapResolution, setHeatmapResolution,
     reset,
   } = useLayersState();
@@ -54,32 +54,45 @@ export default function LayersPanel() {
 
   return (
     <div className="space-y-8 pb-32 px-0">
-      {/* Data Visualization */}
+      {/* County Colors */}
       <div className="space-y-4">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          Data Visualization
+          County Colors
         </label>
         <div className="space-y-3">
           <div className="flex justify-between items-center">
             <span className={`text-sm font-medium ${choroplethOn ? "text-on-surface" : "text-on-surface-variant"}`}>
-              Choropleth
+              Shade by Measure
             </span>
-            <Toggle enabled={choroplethOn} onToggle={() => setChoroplethOn(!choroplethOn)} />
+            <Toggle enabled={choroplethOn} onToggle={() => {
+              const next = !choroplethOn;
+              setChoroplethOn(next);
+              if (next) setOtherLayer("heatmapStatewide", false);
+            }} />
           </div>
+          {choroplethOn && (
+            <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
+              Colors each county by the selected measure below
+            </p>
+          )}
         </div>
       </div>
 
-      {/* Statewide Heatmap */}
+      {/* Crash Heatmap */}
       <div className="space-y-4">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          Statewide Heatmap
+          Crash Heatmap
         </label>
         <div className="space-y-3">
           <div className="flex justify-between items-center">
             <span className={`text-sm font-medium ${otherLayers.heatmapStatewide ? "text-on-surface" : "text-on-surface-variant"}`}>
-              Full State
+              Statewide
             </span>
-            <Toggle enabled={otherLayers.heatmapStatewide} onToggle={() => toggleOtherLayer("heatmapStatewide")} />
+            <Toggle enabled={otherLayers.heatmapStatewide} onToggle={() => {
+              const next = !otherLayers.heatmapStatewide;
+              setOtherLayer("heatmapStatewide", next);
+              if (next) setChoroplethOn(false);
+            }} />
           </div>
           {otherLayers.heatmapStatewide && (
             <div className="space-y-2 pl-1">
@@ -109,15 +122,6 @@ export default function LayersPanel() {
               </p>
             </div>
           )}
-        </div>
-      </div>
-
-      {/* County Heatmap */}
-      <div className="space-y-4">
-        <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          County Heatmap
-        </label>
-        <div className="space-y-3">
           <div className="flex justify-between items-center">
             <span className={`text-sm font-medium ${otherLayers.heatmapCounty ? "text-on-surface" : "text-on-surface-variant"}`}>
               County Detail
@@ -126,7 +130,7 @@ export default function LayersPanel() {
           </div>
           {otherLayers.heatmapCounty && (
             <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
-              Shows individual crash locations when a county is selected
+              Shows individual crash locations when you click a county
             </p>
           )}
         </div>

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -8,11 +8,24 @@ vi.mock("./CountyBoundaries", () => ({
     <div data-testid="county-boundaries" data-focused={props.focusedCounty} />
   ),
 }));
+vi.mock("./CrashHeatmap", () => ({
+  default: () => null,
+}));
+vi.mock("./CaliforniaMask", () => ({
+  default: () => null,
+}));
 
 import type { Map as LeafletMap } from "leaflet";
 import MapCanvas from "./MapCanvas";
 import { mockMapInstance } from "../../__mocks__/leaflet";
 import { ThemeProvider } from "../../context/ThemeContext";
+
+const defaultHeatmapProps = {
+  heatmapPoints: [] as { lat: number; lng: number; weight: number }[],
+  heatmapActive: false,
+  heatmapResolution: "low" as const,
+  heatmapPalette: "default" as const,
+};
 
 function renderWithTheme(ui: React.ReactElement) {
   return render(<ThemeProvider>{ui}</ThemeProvider>);
@@ -37,6 +50,7 @@ describe("MapCanvas", () => {
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onMapReady={onMapReady}
+        {...defaultHeatmapProps}
       />
     );
     expect(screen.getByTestId("map-container")).toBeInTheDocument();
@@ -49,6 +63,7 @@ describe("MapCanvas", () => {
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onMapReady={onMapReady}
+        {...defaultHeatmapProps}
       />
     );
     expect(onMapReady).toHaveBeenCalledWith(mockMapInstance);
@@ -61,6 +76,7 @@ describe("MapCanvas", () => {
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onMapReady={onMapReady}
+        {...defaultHeatmapProps}
       />
     );
     const boundaries = screen.getByTestId("county-boundaries");

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -3,10 +3,15 @@ import { MapContainer, TileLayer, useMap } from "react-leaflet";
 import type { LatLngBoundsExpression, Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import CountyBoundaries from "./CountyBoundaries";
+import CrashHeatmap from "./CrashHeatmap";
+import CaliforniaMask from "./CaliforniaMask";
+import type { HeatmapPoint } from "../../hooks/useCrashHeatmap";
+import type { HeatmapResolution } from "../../hooks/useLayersState";
+import type { PaletteKey } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 
 const CA_CENTER: [number, number] = [37.2, -119.5];
-const CA_ZOOM = 6;
+const CA_ZOOM = window.innerWidth < 768 ? 5 : 6;
 
 const CA_BOUNDS: LatLngBoundsExpression = [
   [28.0, -127.0],
@@ -19,7 +24,18 @@ interface MapCanvasProps {
   onFocusCounty: (name: string | null) => void;
   onSelectCounty: (name: string) => void;
   onMapReady: (map: LeafletMap) => void;
+  heatmapPoints: HeatmapPoint[];
+  heatmapActive: boolean;
+  heatmapResolution: HeatmapResolution;
+  heatmapPalette: PaletteKey;
 }
+
+const HEATMAP_MAX_ZOOM: Record<string, number> = {
+  raw: 14,
+  low: 8,
+  medium: 9,
+  high: 10,
+};
 
 function MapInternals({
   focusedCounty,
@@ -27,6 +43,10 @@ function MapInternals({
   onFocusCounty,
   onSelectCounty,
   onMapReady,
+  heatmapPoints,
+  heatmapActive,
+  heatmapResolution,
+  heatmapPalette,
 }: MapCanvasProps) {
   const map = useMap();
 
@@ -34,13 +54,42 @@ function MapInternals({
     onMapReady(map);
   }, [map, onMapReady]);
 
+  useEffect(() => {
+    if (!map) return;
+    const pane = map.getPane("labelPane");
+    if (!pane) {
+      map.createPane("labelPane");
+      map.getPane("labelPane")!.style.zIndex = "650";
+    }
+  }, [map]);
+
+  useEffect(() => {
+    const maxZ = heatmapActive ? (HEATMAP_MAX_ZOOM[heatmapResolution] ?? 12) : 14;
+    map.setMaxZoom(maxZ);
+    if (map.getZoom() > maxZ) {
+      map.setZoom(maxZ);
+    }
+  }, [map, heatmapActive, heatmapResolution]);
+
   return (
-    <CountyBoundaries
-      focusedCounty={focusedCounty}
-      compareCounty={compareCounty}
-      onFocusCounty={onFocusCounty}
-      onSelectCounty={onSelectCounty}
-    />
+    <>
+      <CountyBoundaries
+        focusedCounty={focusedCounty}
+        compareCounty={compareCounty}
+        onFocusCounty={onFocusCounty}
+        onSelectCounty={onSelectCounty}
+      />
+      {heatmapActive && (
+        <>
+          <CrashHeatmap
+            points={heatmapPoints}
+            resolution={heatmapResolution}
+            palette={heatmapPalette}
+          />
+          <CaliforniaMask focusedCounty={focusedCounty} compareCounty={compareCounty ?? null} />
+        </>
+      )}
+    </>
   );
 }
 
@@ -50,6 +99,10 @@ export default function MapCanvas({
   onFocusCounty,
   onSelectCounty,
   onMapReady,
+  heatmapPoints,
+  heatmapActive,
+  heatmapResolution,
+  heatmapPalette,
 }: MapCanvasProps) {
   const isDark = useIsDark();
   // CartoDB tile variants — swap between light_* and dark_* so counties
@@ -89,12 +142,17 @@ export default function MapCanvas({
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onMapReady={onMapReady}
+        heatmapPoints={heatmapPoints}
+        heatmapActive={heatmapActive}
+        heatmapResolution={heatmapResolution}
+        heatmapPalette={heatmapPalette}
       />
 
       <TileLayer
         key={labelTileUrl}
         url={labelTileUrl}
         attribution='&copy; <a href="https://carto.com/">CARTO</a>'
+        pane="labelPane"
       />
     </MapContainer>
   );

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -28,6 +28,7 @@ interface MapCanvasProps {
   heatmapActive: boolean;
   heatmapResolution: HeatmapResolution;
   heatmapPalette: PaletteKey;
+  countyDrilldown?: boolean;
 }
 
 const HEATMAP_MAX_ZOOM: Record<string, number> = {
@@ -47,6 +48,7 @@ function MapInternals({
   heatmapActive,
   heatmapResolution,
   heatmapPalette,
+  countyDrilldown,
 }: MapCanvasProps) {
   const map = useMap();
 
@@ -86,7 +88,10 @@ function MapInternals({
             resolution={heatmapResolution}
             palette={heatmapPalette}
           />
-          <CaliforniaMask focusedCounty={focusedCounty} compareCounty={compareCounty ?? null} />
+          <CaliforniaMask
+            focusedCounty={countyDrilldown ? focusedCounty : null}
+            compareCounty={countyDrilldown ? (compareCounty ?? null) : null}
+          />
         </>
       )}
     </>
@@ -103,6 +108,7 @@ export default function MapCanvas({
   heatmapActive,
   heatmapResolution,
   heatmapPalette,
+  countyDrilldown,
 }: MapCanvasProps) {
   const isDark = useIsDark();
   // CartoDB tile variants — swap between light_* and dark_* so counties
@@ -146,6 +152,7 @@ export default function MapCanvas({
         heatmapActive={heatmapActive}
         heatmapResolution={heatmapResolution}
         heatmapPalette={heatmapPalette}
+        countyDrilldown={countyDrilldown}
       />
 
       <TileLayer

--- a/frontend/src/hooks/useCrashHeatmap.test.ts
+++ b/frontend/src/hooks/useCrashHeatmap.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { useCrashHeatmap } from "./useCrashHeatmap";
+
+const MOCK_RESPONSE = {
+  points: [
+    { lat: 34.0, lng: -118.0, weight: 42 },
+    { lat: 34.1, lng: -118.1, weight: 17 },
+  ],
+  total_crashes: 59,
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useCrashHeatmap", () => {
+  it("fetches heatmap data when enabled", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MOCK_RESPONSE)),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCrashHeatmap({
+          enabled: true,
+          county: "los-angeles",
+          years: [2023],
+          severities: [],
+          causes: [],
+          resolution: "medium",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.points).toEqual(MOCK_RESPONSE.points);
+    expect(result.current.totalCrashes).toBe(59);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const url = String(spy.mock.calls[0][0]);
+    expect(url).toContain("/api/crashes/heatmap");
+    expect(url).toContain("county=los-angeles");
+    expect(url).toContain("year=2023");
+    expect(url).toContain("resolution=medium");
+  });
+
+  it("does not fetch when disabled", () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(MOCK_RESPONSE)),
+    );
+
+    renderHook(
+      () =>
+        useCrashHeatmap({
+          enabled: false,
+          county: null,
+          years: [],
+          severities: [],
+          causes: [],
+          resolution: "low",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns empty state on error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("server error", { status: 500 }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCrashHeatmap({
+          enabled: true,
+          county: null,
+          years: [],
+          severities: [],
+          causes: [],
+          resolution: "low",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.points).toEqual([]);
+    expect(result.current.totalCrashes).toBe(0);
+    expect(result.current.error).toBeTruthy();
+  });
+});

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+import type { HeatmapResolution } from "./useLayersState";
+import { slugify } from "./useFilterParams";
+
+export interface HeatmapPoint {
+  lat: number;
+  lng: number;
+  weight: number;
+}
+
+interface HeatmapParams {
+  enabled: boolean;
+  county: string | null;
+  years: number[];
+  severities: string[];
+  causes: string[];
+  alcohol?: boolean | null;
+  distracted?: boolean | null;
+  resolution: HeatmapResolution;
+}
+
+interface HeatmapApiResponse {
+  points: HeatmapPoint[];
+  total_crashes: number;
+}
+
+function buildUrl(params: HeatmapParams): string {
+  const sp = new URLSearchParams();
+  if (params.county) sp.set("county", params.county);
+  if (params.years.length) sp.set("year", params.years.join(","));
+  if (params.severities.length) sp.set("severity", params.severities.map(slugify).join(","));
+  if (params.causes.length) sp.set("cause", params.causes.join(","));
+  if (params.alcohol != null) sp.set("alcohol", String(params.alcohol));
+  if (params.distracted != null) sp.set("distracted", String(params.distracted));
+  sp.set("resolution", params.resolution);
+  return `${API_BASE}/api/crashes/heatmap?${sp.toString()}`;
+}
+
+async function fetchHeatmap(params: HeatmapParams): Promise<HeatmapApiResponse> {
+  const res = await fetch(buildUrl(params));
+  if (!res.ok) throw new Error(`heatmap ${res.status}`);
+  return res.json();
+}
+
+export function useCrashHeatmap(params: HeatmapParams) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [
+      "crashHeatmap",
+      params.county,
+      params.years,
+      params.severities,
+      params.causes,
+      params.alcohol,
+      params.distracted,
+      params.resolution,
+    ],
+    queryFn: () => fetchHeatmap(params),
+    enabled: params.enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    points: data?.points ?? [],
+    totalCrashes: data?.total_crashes ?? 0,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/src/hooks/useLayersState.test.tsx
+++ b/frontend/src/hooks/useLayersState.test.tsx
@@ -45,21 +45,21 @@ describe("useLayersState", () => {
     expect(() => renderHook(() => useLayersState())).toThrow(/LayersStateProvider/);
   });
 
-  it("provides default heatmapResolution of 'low'", () => {
+  it("provides default heatmapResolution of 'high'", () => {
     const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
-    expect(result.current.heatmapResolution).toBe("low");
+    expect(result.current.heatmapResolution).toBe("high");
   });
 
   it("setHeatmapResolution updates resolution", () => {
     const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
-    act(() => result.current.setHeatmapResolution("high"));
-    expect(result.current.heatmapResolution).toBe("high");
+    act(() => result.current.setHeatmapResolution("low"));
+    expect(result.current.heatmapResolution).toBe("low");
   });
 
-  it("reset restores heatmapResolution to low", () => {
+  it("reset restores heatmapResolution to high", () => {
     const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
-    act(() => result.current.setHeatmapResolution("high"));
+    act(() => result.current.setHeatmapResolution("low"));
     act(() => result.current.reset());
-    expect(result.current.heatmapResolution).toBe("low");
+    expect(result.current.heatmapResolution).toBe("high");
   });
 });

--- a/frontend/src/hooks/useLayersState.test.tsx
+++ b/frontend/src/hooks/useLayersState.test.tsx
@@ -45,9 +45,9 @@ describe("useLayersState", () => {
     expect(() => renderHook(() => useLayersState())).toThrow(/LayersStateProvider/);
   });
 
-  it("provides default heatmapResolution of 'high'", () => {
+  it("provides default heatmapResolution of 'low'", () => {
     const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
-    expect(result.current.heatmapResolution).toBe("high");
+    expect(result.current.heatmapResolution).toBe("low");
   });
 
   it("setHeatmapResolution updates resolution", () => {
@@ -56,10 +56,10 @@ describe("useLayersState", () => {
     expect(result.current.heatmapResolution).toBe("low");
   });
 
-  it("reset restores heatmapResolution to high", () => {
+  it("reset restores heatmapResolution to low", () => {
     const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
-    act(() => result.current.setHeatmapResolution("low"));
+    act(() => result.current.setHeatmapResolution("medium"));
     act(() => result.current.reset());
-    expect(result.current.heatmapResolution).toBe("high");
+    expect(result.current.heatmapResolution).toBe("low");
   });
 });

--- a/frontend/src/hooks/useLayersState.test.tsx
+++ b/frontend/src/hooks/useLayersState.test.tsx
@@ -44,4 +44,22 @@ describe("useLayersState", () => {
   it("throws when used outside provider", () => {
     expect(() => renderHook(() => useLayersState())).toThrow(/LayersStateProvider/);
   });
+
+  it("provides default heatmapResolution of 'low'", () => {
+    const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
+    expect(result.current.heatmapResolution).toBe("low");
+  });
+
+  it("setHeatmapResolution updates resolution", () => {
+    const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
+    act(() => result.current.setHeatmapResolution("high"));
+    expect(result.current.heatmapResolution).toBe("high");
+  });
+
+  it("reset restores heatmapResolution to low", () => {
+    const { result } = renderHook(() => useLayersState(), { wrapper: wrap });
+    act(() => result.current.setHeatmapResolution("high"));
+    act(() => result.current.reset());
+    expect(result.current.heatmapResolution).toBe("low");
+  });
 });

--- a/frontend/src/hooks/useLayersState.tsx
+++ b/frontend/src/hooks/useLayersState.tsx
@@ -3,6 +3,7 @@ import { DEFAULT_MEASURE, type MeasureKey } from "../lib/choropleth/measures";
 import type { PaletteKey } from "../lib/choropleth/palettes";
 
 export type OtherLayerKey = "heatmap" | "incidents" | "countyBoundaries" | "roadTypes" | "schoolZones" | "hospitals";
+export type HeatmapResolution = "low" | "medium" | "high";
 
 const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
   heatmap: false,
@@ -27,6 +28,8 @@ type LayersState = {
   setPalette: (p: PaletteKey) => void;
   setBucketEdges: (e: number[] | null) => void;
   toggleOtherLayer: (key: OtherLayerKey) => void;
+  heatmapResolution: HeatmapResolution;
+  setHeatmapResolution: (r: HeatmapResolution) => void;
   reset: () => void;
 };
 
@@ -38,6 +41,7 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
   const [palette, setPalette] = useState<PaletteKey>("default");
   const [bucketEdges, setBucketEdges] = useState<number[] | null>(null);
   const [otherLayers, setOtherLayers] = useState<Record<OtherLayerKey, boolean>>(() => ({ ...OTHER_LAYER_DEFAULTS }));
+  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>("low");
 
   const reset = useCallback(() => {
     setChoroplethOn(true);
@@ -45,6 +49,7 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
     setPalette("default");
     setBucketEdges(null);
     setOtherLayers({ ...OTHER_LAYER_DEFAULTS });
+    setHeatmapResolution("low");
   }, []);
 
   const toggleOtherLayer = useCallback((key: OtherLayerKey) => {
@@ -54,9 +59,11 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
   const value = useMemo<LayersState>(
     () => ({
       choroplethOn, measure, palette, bucketEdges, otherLayers,
-      setChoroplethOn, setMeasure, setPalette, setBucketEdges, toggleOtherLayer, reset,
+      setChoroplethOn, setMeasure, setPalette, setBucketEdges, toggleOtherLayer,
+      heatmapResolution, setHeatmapResolution,
+      reset,
     }),
-    [choroplethOn, measure, palette, bucketEdges, otherLayers, toggleOtherLayer, reset],
+    [choroplethOn, measure, palette, bucketEdges, otherLayers, toggleOtherLayer, heatmapResolution, reset],
   );
 
   return <LayersStateContext.Provider value={value}>{children}</LayersStateContext.Provider>;

--- a/frontend/src/hooks/useLayersState.tsx
+++ b/frontend/src/hooks/useLayersState.tsx
@@ -2,11 +2,12 @@ import { createContext, useCallback, useContext, useMemo, useState, type ReactNo
 import { DEFAULT_MEASURE, type MeasureKey } from "../lib/choropleth/measures";
 import type { PaletteKey } from "../lib/choropleth/palettes";
 
-export type OtherLayerKey = "heatmap" | "incidents" | "countyBoundaries" | "roadTypes" | "schoolZones" | "hospitals";
+export type OtherLayerKey = "heatmapStatewide" | "heatmapCounty" | "incidents" | "countyBoundaries" | "roadTypes" | "schoolZones" | "hospitals";
 export type HeatmapResolution = "raw" | "low" | "medium" | "high";
 
 const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
-  heatmap: false,
+  heatmapStatewide: false,
+  heatmapCounty: false,
   incidents: false,
   countyBoundaries: true,
   roadTypes: false,
@@ -41,7 +42,7 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
   const [palette, setPalette] = useState<PaletteKey>("default");
   const [bucketEdges, setBucketEdges] = useState<number[] | null>(null);
   const [otherLayers, setOtherLayers] = useState<Record<OtherLayerKey, boolean>>(() => ({ ...OTHER_LAYER_DEFAULTS }));
-  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>("high");
+  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>("low");
 
   const reset = useCallback(() => {
     setChoroplethOn(true);
@@ -49,7 +50,7 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
     setPalette("default");
     setBucketEdges(null);
     setOtherLayers({ ...OTHER_LAYER_DEFAULTS });
-    setHeatmapResolution("high");
+    setHeatmapResolution("low");
   }, []);
 
   const toggleOtherLayer = useCallback((key: OtherLayerKey) => {

--- a/frontend/src/hooks/useLayersState.tsx
+++ b/frontend/src/hooks/useLayersState.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_MEASURE, type MeasureKey } from "../lib/choropleth/measures";
 import type { PaletteKey } from "../lib/choropleth/palettes";
 
 export type OtherLayerKey = "heatmap" | "incidents" | "countyBoundaries" | "roadTypes" | "schoolZones" | "hospitals";
-export type HeatmapResolution = "low" | "medium" | "high";
+export type HeatmapResolution = "raw" | "low" | "medium" | "high";
 
 const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
   heatmap: false,
@@ -41,7 +41,7 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
   const [palette, setPalette] = useState<PaletteKey>("default");
   const [bucketEdges, setBucketEdges] = useState<number[] | null>(null);
   const [otherLayers, setOtherLayers] = useState<Record<OtherLayerKey, boolean>>(() => ({ ...OTHER_LAYER_DEFAULTS }));
-  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>("low");
+  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>("high");
 
   const reset = useCallback(() => {
     setChoroplethOn(true);
@@ -49,7 +49,7 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
     setPalette("default");
     setBucketEdges(null);
     setOtherLayers({ ...OTHER_LAYER_DEFAULTS });
-    setHeatmapResolution("low");
+    setHeatmapResolution("high");
   }, []);
 
   const toggleOtherLayer = useCallback((key: OtherLayerKey) => {

--- a/frontend/src/hooks/useLayersState.tsx
+++ b/frontend/src/hooks/useLayersState.tsx
@@ -1,19 +1,56 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
-import { DEFAULT_MEASURE, type MeasureKey } from "../lib/choropleth/measures";
-import type { PaletteKey } from "../lib/choropleth/palettes";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { DEFAULT_MEASURE, MEASURES, type MeasureKey } from "../lib/choropleth/measures";
+import { PALETTES, type PaletteKey } from "../lib/choropleth/palettes";
 
 export type OtherLayerKey = "heatmapStatewide" | "heatmapCounty" | "incidents" | "countyBoundaries" | "roadTypes" | "schoolZones" | "hospitals";
 export type HeatmapResolution = "raw" | "low" | "medium" | "high";
 
 const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
   heatmapStatewide: false,
-  heatmapCounty: false,
+  heatmapCounty: true,
   incidents: false,
   countyBoundaries: true,
   roadTypes: false,
   schoolZones: false,
   hospitals: false,
 };
+
+const STORAGE_KEY = "calsight-layers";
+const VALID_RESOLUTIONS = new Set<HeatmapResolution>(["raw", "low", "medium", "high"]);
+
+type SavedLayers = {
+  measure?: MeasureKey;
+  palette?: PaletteKey;
+  choroplethOn?: boolean;
+  resolution?: HeatmapResolution;
+  otherLayers?: Partial<Record<OtherLayerKey, boolean>>;
+};
+
+function loadSaved(): SavedLayers {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    const result: SavedLayers = {
+      measure: parsed.measure && parsed.measure in MEASURES ? parsed.measure : undefined,
+      palette: parsed.palette && parsed.palette in PALETTES ? parsed.palette : undefined,
+      choroplethOn: typeof parsed.choroplethOn === "boolean" ? parsed.choroplethOn : undefined,
+      resolution: parsed.resolution && VALID_RESOLUTIONS.has(parsed.resolution) ? parsed.resolution : undefined,
+    };
+    if (parsed.otherLayers && typeof parsed.otherLayers === "object") {
+      const valid: Partial<Record<OtherLayerKey, boolean>> = {};
+      for (const key of Object.keys(OTHER_LAYER_DEFAULTS) as OtherLayerKey[]) {
+        if (typeof parsed.otherLayers[key] === "boolean") {
+          valid[key] = parsed.otherLayers[key];
+        }
+      }
+      result.otherLayers = valid;
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
 
 type LayersState = {
   choroplethOn: boolean;
@@ -29,6 +66,7 @@ type LayersState = {
   setPalette: (p: PaletteKey) => void;
   setBucketEdges: (e: number[] | null) => void;
   toggleOtherLayer: (key: OtherLayerKey) => void;
+  setOtherLayer: (key: OtherLayerKey, value: boolean) => void;
   heatmapResolution: HeatmapResolution;
   setHeatmapResolution: (r: HeatmapResolution) => void;
   reset: () => void;
@@ -37,12 +75,24 @@ type LayersState = {
 const LayersStateContext = createContext<LayersState | null>(null);
 
 export function LayersStateProvider({ children }: { children: ReactNode }) {
-  const [choroplethOn, setChoroplethOn] = useState(true);
-  const [measure, setMeasure] = useState<MeasureKey>(DEFAULT_MEASURE);
-  const [palette, setPalette] = useState<PaletteKey>("default");
+  const saved = loadSaved();
+  const [choroplethOn, setChoroplethOn] = useState(saved.choroplethOn ?? true);
+  const [measure, setMeasure] = useState<MeasureKey>(saved.measure ?? DEFAULT_MEASURE);
+  const [palette, setPalette] = useState<PaletteKey>(saved.palette ?? "default");
   const [bucketEdges, setBucketEdges] = useState<number[] | null>(null);
-  const [otherLayers, setOtherLayers] = useState<Record<OtherLayerKey, boolean>>(() => ({ ...OTHER_LAYER_DEFAULTS }));
-  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>("low");
+  const [otherLayers, setOtherLayers] = useState<Record<OtherLayerKey, boolean>>(() => ({
+    ...OTHER_LAYER_DEFAULTS,
+    ...saved.otherLayers,
+  }));
+  const [heatmapResolution, setHeatmapResolution] = useState<HeatmapResolution>(saved.resolution ?? "low");
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+        measure, palette, choroplethOn, resolution: heatmapResolution, otherLayers,
+      }));
+    } catch { /* quota exceeded — ignore */ }
+  }, [measure, palette, choroplethOn, heatmapResolution, otherLayers]);
 
   const reset = useCallback(() => {
     setChoroplethOn(true);
@@ -57,10 +107,14 @@ export function LayersStateProvider({ children }: { children: ReactNode }) {
     setOtherLayers((p) => ({ ...p, [key]: !p[key] }));
   }, []);
 
+  const setOtherLayer = useCallback((key: OtherLayerKey, value: boolean) => {
+    setOtherLayers((p) => ({ ...p, [key]: value }));
+  }, []);
+
   const value = useMemo<LayersState>(
     () => ({
       choroplethOn, measure, palette, bucketEdges, otherLayers,
-      setChoroplethOn, setMeasure, setPalette, setBucketEdges, toggleOtherLayer,
+      setChoroplethOn, setMeasure, setPalette, setBucketEdges, toggleOtherLayer, setOtherLayer,
       heatmapResolution, setHeatmapResolution,
       reset,
     }),

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -95,10 +95,16 @@ function MapPageInner() {
   })();
 
   const hasCountyScope = !!focusedCounty || selectedCounties.size > 0;
-  const effectiveResolution = hasCountyScope ? "raw" as const : heatmapResolution;
+  const effectiveResolution = hasCountyScope
+    ? "raw" as const
+    : (heatmapResolution === "high" || heatmapResolution === "raw" ? "low" : heatmapResolution);
+
+  const heatmapEnabled = hasCountyScope
+    ? otherLayers.heatmapCounty
+    : otherLayers.heatmapStatewide;
 
   const heatmap = useCrashHeatmap({
-    enabled: otherLayers.heatmap,
+    enabled: heatmapEnabled,
     county: heatmapCountySlugs,
     years: [...selectedYears],
     severities: [...selectedSeverities],
@@ -131,22 +137,22 @@ function MapPageInner() {
     if (compareMode && name !== focusedCounty) {
       setCompareCounty(name);
     } else {
-      if (!otherLayers.heatmap) toggleOtherLayer("heatmap");
+      if (!otherLayers.heatmapCounty) toggleOtherLayer("heatmapCounty");
       setFocusedCounty(name);
       setInsightCounty(name);
       setShowInsight(true);
       setCompareCounty(null);
       setCompareMode(false);
     }
-  }, [compareMode, focusedCounty, otherLayers.heatmap, toggleOtherLayer]);
+  }, [compareMode, focusedCounty, otherLayers.heatmapCounty, toggleOtherLayer]);
 
   const handleDeselect = useCallback(() => {
     setFocusedCounty(null);
     setCompareCounty(null);
     setCompareMode(false);
     setShowInsight(false);
-    if (otherLayers.heatmap) toggleOtherLayer("heatmap");
-  }, [otherLayers.heatmap, toggleOtherLayer]);
+    if (otherLayers.heatmapCounty) toggleOtherLayer("heatmapCounty");
+  }, [otherLayers.heatmapCounty, toggleOtherLayer]);
 
   const handleStartCompare = useCallback(() => {
     setCompareMode(true);
@@ -159,9 +165,9 @@ function MapPageInner() {
       setCompareCounty(null);
       setCompareMode(false);
       setShowInsight(false);
-      if (otherLayers.heatmap) toggleOtherLayer("heatmap");
+      if (otherLayers.heatmapCounty) toggleOtherLayer("heatmapCounty");
     }
-  }, [compareMode, otherLayers.heatmap, toggleOtherLayer]);
+  }, [compareMode, otherLayers.heatmapCounty, toggleOtherLayer]);
 
   function handleClearAll() {
     clearFilters();
@@ -293,7 +299,7 @@ function MapPageInner() {
           onSelectCounty={handleSelectCounty}
           onMapReady={handleMapReady}
           heatmapPoints={heatmap.points}
-          heatmapActive={otherLayers.heatmap}
+          heatmapActive={heatmapEnabled}
           heatmapResolution={effectiveResolution}
           heatmapPalette={palette}
         />
@@ -328,8 +334,8 @@ function MapPageInner() {
           searchOpen={searchOpen}
           choroplethData={choroplethData}
           coordCoverage={coordCoverage}
-          heatmapCrashes={otherLayers.heatmap ? heatmap.totalCrashes : null}
-          heatmapLoading={otherLayers.heatmap && heatmap.isLoading}
+          heatmapCrashes={heatmapEnabled ? heatmap.totalCrashes : null}
+          heatmapLoading={heatmapEnabled && heatmap.isLoading}
           countyActive={!!focusedCounty}
         />
       </section>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -23,6 +23,7 @@ import DataExportPanel, {
 import MapCanvas from "../components/map/MapCanvas";
 import AiInsightCard from "../components/map/AiInsightCard";
 import Breadcrumb from "../components/map/Breadcrumb";
+import { useCrashHeatmap } from "../hooks/useCrashHeatmap";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import { useCoordCoverage } from "../hooks/useCoordCoverage";
 
@@ -78,7 +79,33 @@ function MapPageInner() {
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
 
-  const { measure } = useLayersState();
+  const { measure, otherLayers, heatmapResolution, palette, toggleOtherLayer } = useLayersState();
+
+  const heatmapCountySlugs = (() => {
+    if (focusedCounty || compareCounty) {
+      const slugs: string[] = [];
+      if (focusedCounty) slugs.push(focusedCounty.toLowerCase().replace(/\s+/g, "-"));
+      if (compareCounty) slugs.push(compareCounty.toLowerCase().replace(/\s+/g, "-"));
+      return slugs.join(",");
+    }
+    if (selectedCounties.size > 0) {
+      return [...selectedCounties].map((c) => c.toLowerCase().replace(/\s+/g, "-")).join(",");
+    }
+    return null;
+  })();
+
+  const hasCountyScope = !!focusedCounty || selectedCounties.size > 0;
+  const effectiveResolution = hasCountyScope ? "raw" as const : heatmapResolution;
+
+  const heatmap = useCrashHeatmap({
+    enabled: otherLayers.heatmap,
+    county: heatmapCountySlugs,
+    years: [...selectedYears],
+    severities: [...selectedSeverities],
+    causes: [...selectedCauses],
+    resolution: effectiveResolution,
+  });
+
   const coordCoverage = useCoordCoverage([...selectedYears]);
   const choroplethFilters = useMemo(
     () => ({
@@ -104,20 +131,22 @@ function MapPageInner() {
     if (compareMode && name !== focusedCounty) {
       setCompareCounty(name);
     } else {
+      if (!otherLayers.heatmap) toggleOtherLayer("heatmap");
       setFocusedCounty(name);
       setInsightCounty(name);
       setShowInsight(true);
       setCompareCounty(null);
       setCompareMode(false);
     }
-  }, [compareMode, focusedCounty]);
+  }, [compareMode, focusedCounty, otherLayers.heatmap, toggleOtherLayer]);
 
   const handleDeselect = useCallback(() => {
     setFocusedCounty(null);
     setCompareCounty(null);
     setCompareMode(false);
     setShowInsight(false);
-  }, []);
+    if (otherLayers.heatmap) toggleOtherLayer("heatmap");
+  }, [otherLayers.heatmap, toggleOtherLayer]);
 
   const handleStartCompare = useCallback(() => {
     setCompareMode(true);
@@ -130,8 +159,9 @@ function MapPageInner() {
       setCompareCounty(null);
       setCompareMode(false);
       setShowInsight(false);
+      if (otherLayers.heatmap) toggleOtherLayer("heatmap");
     }
-  }, [compareMode]);
+  }, [compareMode, otherLayers.heatmap, toggleOtherLayer]);
 
   function handleClearAll() {
     clearFilters();
@@ -262,6 +292,10 @@ function MapPageInner() {
           onFocusCounty={handleFocusCounty}
           onSelectCounty={handleSelectCounty}
           onMapReady={handleMapReady}
+          heatmapPoints={heatmap.points}
+          heatmapActive={otherLayers.heatmap}
+          heatmapResolution={effectiveResolution}
+          heatmapPalette={palette}
         />
 
         {/* Mobile-only floating Filters chip */}
@@ -290,7 +324,14 @@ function MapPageInner() {
           compareCounty={compareCounty}
           onDeselect={handleDeselect}
         />
-        <ChoroplethLegendContainer searchOpen={searchOpen} choroplethData={choroplethData} coordCoverage={coordCoverage} />
+        <ChoroplethLegendContainer
+          searchOpen={searchOpen}
+          choroplethData={choroplethData}
+          coordCoverage={coordCoverage}
+          heatmapCrashes={otherLayers.heatmap ? heatmap.totalCrashes : null}
+          heatmapLoading={otherLayers.heatmap && heatmap.isLoading}
+          countyActive={!!focusedCounty}
+        />
       </section>
 
       {/* Mobile filter bottom sheet */}
@@ -336,10 +377,16 @@ function ChoroplethLegendContainer({
   searchOpen,
   choroplethData,
   coordCoverage,
+  heatmapCrashes,
+  heatmapLoading,
+  countyActive,
 }: {
   searchOpen?: boolean;
   choroplethData: ChoroplethData;
   coordCoverage?: CoordCoverage | null;
+  heatmapCrashes?: number | null;
+  heatmapLoading?: boolean;
+  countyActive?: boolean;
 }) {
   const queryClient = useQueryClient();
   return (
@@ -352,6 +399,9 @@ function ChoroplethLegendContainer({
       is422={choroplethData.is422}
       searchOpen={searchOpen}
       onRetry={() => queryClient.invalidateQueries({ queryKey: ["choropleth"] })}
+      heatmapCrashes={heatmapCrashes}
+      heatmapLoading={heatmapLoading}
+      countyActive={countyActive}
     />
   );
 }

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -79,9 +79,12 @@ function MapPageInner() {
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
 
-  const { measure, otherLayers, heatmapResolution, palette, toggleOtherLayer } = useLayersState();
+  const { measure, otherLayers, heatmapResolution, palette } = useLayersState();
 
-  const heatmapCountySlugs = (() => {
+  const hasCountyScope = !!focusedCounty || selectedCounties.size > 0;
+  const useCountyDetail = hasCountyScope && otherLayers.heatmapCounty;
+
+  const heatmapCountySlugs = useCountyDetail ? (() => {
     if (focusedCounty || compareCounty) {
       const slugs: string[] = [];
       if (focusedCounty) slugs.push(focusedCounty.toLowerCase().replace(/\s+/g, "-"));
@@ -92,16 +95,13 @@ function MapPageInner() {
       return [...selectedCounties].map((c) => c.toLowerCase().replace(/\s+/g, "-")).join(",");
     }
     return null;
-  })();
+  })() : null;
 
-  const hasCountyScope = !!focusedCounty || selectedCounties.size > 0;
-  const effectiveResolution = hasCountyScope
+  const effectiveResolution = useCountyDetail
     ? "raw" as const
     : (heatmapResolution === "high" || heatmapResolution === "raw" ? "low" : heatmapResolution);
 
-  const heatmapEnabled = hasCountyScope
-    ? otherLayers.heatmapCounty
-    : otherLayers.heatmapStatewide;
+  const heatmapEnabled = useCountyDetail || otherLayers.heatmapStatewide;
 
   const heatmap = useCrashHeatmap({
     enabled: heatmapEnabled,
@@ -133,26 +133,31 @@ function MapPageInner() {
     mapRef.current = map;
   }, []);
 
+  const selectingRef = useRef(false);
+
   const handleSelectCounty = useCallback((name: string) => {
+    if (selectingRef.current) return;
+    selectingRef.current = true;
+
     if (compareMode && name !== focusedCounty) {
       setCompareCounty(name);
+      selectingRef.current = false;
     } else {
-      if (!otherLayers.heatmapCounty) toggleOtherLayer("heatmapCounty");
       setFocusedCounty(name);
       setInsightCounty(name);
       setShowInsight(true);
       setCompareCounty(null);
       setCompareMode(false);
+      setTimeout(() => { selectingRef.current = false; }, 300);
     }
-  }, [compareMode, focusedCounty, otherLayers.heatmapCounty, toggleOtherLayer]);
+  }, [compareMode, focusedCounty]);
 
   const handleDeselect = useCallback(() => {
     setFocusedCounty(null);
     setCompareCounty(null);
     setCompareMode(false);
     setShowInsight(false);
-    if (otherLayers.heatmapCounty) toggleOtherLayer("heatmapCounty");
-  }, [otherLayers.heatmapCounty, toggleOtherLayer]);
+  }, []);
 
   const handleStartCompare = useCallback(() => {
     setCompareMode(true);
@@ -165,9 +170,8 @@ function MapPageInner() {
       setCompareCounty(null);
       setCompareMode(false);
       setShowInsight(false);
-      if (otherLayers.heatmapCounty) toggleOtherLayer("heatmapCounty");
     }
-  }, [compareMode, otherLayers.heatmapCounty, toggleOtherLayer]);
+  }, [compareMode]);
 
   function handleClearAll() {
     clearFilters();
@@ -302,6 +306,7 @@ function MapPageInner() {
           heatmapActive={heatmapEnabled}
           heatmapResolution={effectiveResolution}
           heatmapPalette={palette}
+          countyDrilldown={useCountyDetail}
         />
 
         {/* Mobile-only floating Filters chip */}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -99,13 +99,24 @@ export default function StatsPage() {
 
   // Re-read CSS variables on every render — isDark change triggers a re-render,
   // so these always reflect the current theme.
+  const isDark = document.documentElement.classList.contains("dark");
   const clrPrimary           = token("--primary");
   const clrPrimaryContainer  = token("--primary-container");
   const clrOnSurface         = token("--on-surface");
   const clrOnSurfaceVariant  = token("--on-surface-variant");
   const clrError             = token("--error");
   const clrTertiary          = token("--tertiary");
-  const causeColors          = [clrPrimary, clrError, clrTertiary];
+
+  const causeColorMap: Record<string, string> = isDark
+    ? { "Other": "#8b8b9a", "Speeding": "#c27862", "Lane Change": "#6b8fa3", "DUI": "#a368a0", "Uncategorized": "#5c7b5c" }
+    : { "Other": "#78716c", "Speeding": "#b45309", "Lane Change": "#4a7a8c", "DUI": "#7e3794", "Uncategorized": "#4a7a52" };
+
+  const severityColorMap: Record<string, string> = isDark
+    ? { "Fatal": "#c25560", "Injury": "#b0a050", "Property Damage Only": "#6b8fa3" }
+    : { "Fatal": "#991b1b", "Injury": "#6d7e1e", "Property Damage Only": "#4a7a8c" };
+
+  const causeColor = (label: string) => causeColorMap[label] ?? clrOnSurfaceVariant;
+  const severityColor = (label: string) => severityColorMap[label] ?? clrOnSurfaceVariant;
 
   const years      = filters.selectedYears;
   const severities = filters.selectedSeverities;
@@ -375,17 +386,17 @@ export default function StatsPage() {
                     endAngle={-270}
                     strokeWidth={0}
                   >
-                    {causesWithPct.map((_, i) => (
-                      <Cell key={i} fill={causeColors[i]} />
+                    {causesWithPct.map((c) => (
+                      <Cell key={c.label} fill={causeColor(c.label)} />
                     ))}
                   </Pie>
                   <Tooltip content={<CauseTooltip />} />
                 </PieChart>
               </ResponsiveContainer>
               <div className="space-y-4 mt-2">
-                {causesWithPct.map((cause, i) => (
+                {causesWithPct.map((cause) => (
                   <div key={cause.label} className="flex items-center gap-3">
-                    <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: causeColors[i] }} />
+                    <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: causeColor(cause.label) }} />
                     <div>
                       <p className="text-sm font-bold text-on-surface">{cause.label}</p>
                       <p className="text-[10px] text-on-surface-variant uppercase tracking-widest font-semibold">
@@ -492,17 +503,17 @@ export default function StatsPage() {
                     endAngle={-270}
                     strokeWidth={0}
                   >
-                    {sevWithPct.map((_, i) => (
-                      <Cell key={i} fill={[clrError, clrTertiary, clrPrimaryContainer][i] ?? clrPrimary} />
+                    {sevWithPct.map((s) => (
+                      <Cell key={s.label} fill={severityColor(s.label)} />
                     ))}
                   </Pie>
                   <Tooltip content={<CauseTooltip />} />
                 </PieChart>
               </ResponsiveContainer>
               <div className="space-y-4 mt-2">
-                {sevWithPct.map((sev, i) => (
+                {sevWithPct.map((sev) => (
                   <div key={sev.label} className="flex items-center gap-3">
-                    <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: [clrError, clrTertiary, clrPrimaryContainer][i] ?? clrPrimary }} />
+                    <div className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: severityColor(sev.label) }} />
                     <div>
                       <p className="text-sm font-bold text-on-surface">{sev.label}</p>
                       <p className="text-[10px] text-on-surface-variant uppercase tracking-widest font-semibold">

--- a/frontend/src/types/leaflet.heat.d.ts
+++ b/frontend/src/types/leaflet.heat.d.ts
@@ -1,0 +1,24 @@
+import "leaflet";
+
+declare module "leaflet" {
+  interface HeatLayerOptions {
+    minOpacity?: number;
+    maxZoom?: number;
+    max?: number;
+    radius?: number;
+    blur?: number;
+    gradient?: Record<number, string>;
+  }
+
+  interface HeatLayer extends Layer {
+    setLatLngs(latlngs: Array<[number, number, number?]>): this;
+    addLatLng(latlng: [number, number, number?]): this;
+    setOptions(options: HeatLayerOptions): this;
+    redraw(): this;
+  }
+
+  function heatLayer(
+    latlngs: Array<[number, number, number?]>,
+    options?: HeatLayerOptions,
+  ): HeatLayer;
+}


### PR DESCRIPTION
 ## What does this PR do?

  Adds a sub-county crash heatmap that activates when clicking a county. Uses raw crash coordinates (up to 300K
  points) rendered via leaflet.heat for smooth, detailed hotspot visualization. Includes a California boundary mask,
  collapsible county insight bar, mobile layout improvements, and stats page color fixes.

  ## How to test
  - Click a county — heatmap auto-activates showing crash density
  - Zoom in — see specific corridors and intersections
  - Deselect county — heatmap turns off
  - Toggle heatmap in Layers panel for statewide view
  - Apply year/severity/cause filters — heatmap updates
  - Check mobile — measure legend collapsed at top-left, county bar at bottom
  - Stats page — primary cause and severity charts have distinct colors
  - Dark mode — heatmap and mask render correctly

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
