### PR TITLE
feat(#45): AI insight cards via Groq + heatmap/mobile polish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
           CENSUS_API_KEY=${{ secrets.CENSUS_API_KEY }}
           NOAA_API_TOKEN=${{ secrets.NOAA_API_TOKEN }}
           BLS_API_KEY=${{ secrets.BLS_API_KEY }}
+          LLM_PROVIDER=groq
+          LLM_API_KEY=${{ secrets.GROQ }}
           DEBUG=false
           DELIM
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -23,3 +23,13 @@ BLS_API_KEY=
 # --- App ----------------------------------------------------------------------
 # Set to false in production to disable debug mode and auto-docs.
 DEBUG=true
+
+# --- LLM (AI insight card generation) -----------------------------------------
+# Used by etl/generate_insights.py to produce per-county narrative blurbs.
+# Supported providers: groq | openrouter | together | cerebras | ollama
+# Leave LLM_MODEL and LLM_BASE_URL empty to use provider defaults.
+# For ollama over Tailscale, set LLM_BASE_URL to http://<tailscale-ip>:11434/v1
+LLM_PROVIDER=together
+LLM_API_KEY=
+LLM_MODEL=
+LLM_BASE_URL=

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -1,0 +1,115 @@
+"""Provider-agnostic LLM wrapper using the OpenAI-compatible SDK.
+
+All five supported providers (groq, openrouter, together, cerebras, ollama)
+expose OpenAI-compatible chat completion endpoints. Only ``base_url``,
+``api_key``, and ``model`` differ between them — the rest of the call is
+identical.
+
+This module is intentionally synchronous. ETL scripts run in a plain Python
+process without asyncio, so we use ``openai.OpenAI`` (sync client), not
+``openai.AsyncOpenAI``.
+
+Provider defaults
+-----------------
+The ``_PROVIDER_DEFAULTS`` dict stores base URLs and sensible default models
+for each provider. Settings override these — set ``LLM_MODEL`` or
+``LLM_BASE_URL`` in .env to force a specific value.
+
+Note on Ollama
+--------------
+The Proxmox server has no GPU. When using Ollama, it runs on Jeff's local PC.
+The ETL script can reach it over Tailscale by setting::
+
+    LLM_BASE_URL=http://<tailscale-ip>:11434/v1
+
+Or run ``python -m etl.generate_insights`` directly on the local PC.
+
+Usage
+-----
+::
+
+    from app.llm import generate_narrative
+    text = generate_narrative("Your prompt here")
+"""
+
+import logging
+
+from openai import OpenAI
+
+from app.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Provider defaults: base_url and a sensible default model.
+# These are overridden by LLM_BASE_URL / LLM_MODEL in .env.
+_PROVIDER_DEFAULTS: dict[str, dict[str, str]] = {
+    "groq": {
+        "base_url": "https://api.groq.com/openai/v1",
+        "model": "llama-3.3-70b-versatile",
+    },
+    "openrouter": {
+        "base_url": "https://openrouter.ai/api/v1",
+        "model": "meta-llama/llama-3.3-70b",
+    },
+    "together": {
+        "base_url": "https://api.together.xyz/v1",
+        "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    },
+    "cerebras": {
+        "base_url": "https://api.cerebras.ai/v1",
+        "model": "llama-3.3-70b",
+    },
+    "ollama": {
+        "base_url": "http://localhost:11434/v1",
+        "model": "llama3.3",
+    },
+}
+
+
+def generate_narrative(prompt: str) -> str:
+    """Call the configured LLM provider and return the response text.
+
+    Synchronous — ETL scripts don't use asyncio.
+
+    Raises any OpenAI SDK exception on failure so the ETL caller can catch,
+    log, and skip the county rather than crashing the whole pipeline.
+
+    Parameters
+    ----------
+    prompt:
+        The full user prompt to send to the model.
+
+    Returns
+    -------
+    str
+        The model's response text, stripped of leading/trailing whitespace.
+    """
+    provider = settings.llm_provider.lower()
+    defaults = _PROVIDER_DEFAULTS.get(provider, {})
+
+    base_url = settings.llm_base_url or defaults.get("base_url")
+    model = settings.llm_model or defaults.get("model")
+    # Ollama doesn't require a real API key; other providers do.
+    api_key = settings.llm_api_key or ("ollama" if provider == "ollama" else "")
+
+    if not base_url:
+        raise ValueError(
+            f"Unknown LLM provider {provider!r} and no LLM_BASE_URL set. "
+            f"Supported providers: {', '.join(_PROVIDER_DEFAULTS)}"
+        )
+    if not model:
+        raise ValueError(
+            f"No model configured for provider {provider!r}. "
+            "Set LLM_MODEL in .env or use a supported provider."
+        )
+
+    logger.debug("LLM call: provider=%s model=%s", provider, model)
+
+    client = OpenAI(base_url=base_url, api_key=api_key)
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=200,
+        temperature=0.7,
+    )
+    return resp.choices[0].message.content.strip()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ from app.routers.crash_people import router as crash_people_router  # noqa: E402
 from app.routers.crashes import router as crashes_router  # noqa: E402
 from app.routers.demographics import router as demographics_router  # noqa: E402
 from app.routers.heatmap import router as heatmap_router  # noqa: E402
+from app.routers.insights import router as insights_router  # noqa: E402
 from app.routers.meta import router as meta_router  # noqa: E402
 from app.routers.reference import router as reference_router  # noqa: E402
 from app.routers.stats import router as stats_router  # noqa: E402
@@ -53,6 +54,7 @@ app.include_router(crash_people_router, prefix="/api")
 app.include_router(heatmap_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(meta_router, prefix="/api")
+app.include_router(insights_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -101,13 +101,13 @@ def crash_heatmap(
     if resolution == Resolution.raw:
         total_q = db.query(func.count()).filter(*preds).scalar() or 0
         rows = (
-            db.query(Crash.latitude, Crash.longitude)
+            db.query(Crash.latitude, Crash.longitude, Crash.severity)
             .filter(*preds)
             .limit(RAW_POINT_LIMIT)
             .all()
         )
         return HeatmapResponse(
-            points=[HeatmapPoint(lat=r.latitude, lng=r.longitude, weight=1) for r in rows],
+            points=[HeatmapPoint(lat=r.latitude, lng=r.longitude, weight=1, severity=r.severity) for r in rows],
             total_crashes=total_q,
         )
 

--- a/backend/app/routers/insights.py
+++ b/backend/app/routers/insights.py
@@ -1,0 +1,110 @@
+"""GET /api/insights/{county_slug} — pre-computed per-county insight cards.
+
+Returns the structured crash stats and AI-generated narrative for a single
+county. Stats are computed deterministically at ETL time and are always
+reliable. The ``narrative`` field may be null if the LLM step was skipped or
+failed for that county.
+
+Endpoint
+--------
+::
+
+    GET /api/insights/{county_slug}?year={year}
+
+Parameters
+----------
+county_slug : str
+    County name in slug form (lowercase, hyphens for spaces).
+    Examples: ``los-angeles``, ``san-francisco``, ``el-dorado``.
+    Matches the convention in ``frontend/src/hooks/useFilterParams.ts``.
+
+year : int, optional
+    If omitted, returns the latest available year for this county.
+
+Response
+--------
+200 JSON with the full insight payload (narrative may be null).
+404 if the slug doesn't map to a known county, or if no insight data exists.
+
+Cache
+-----
+``Cache-Control: public, max-age=300`` — matches the pattern used by
+``/api/stats`` and ``/api/demographics``.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_code, get_slug_map
+from app.database import get_db
+from app.models import County, CountyInsight
+
+router = APIRouter(tags=["insights"])
+
+
+@router.get("/insights/{county_slug}")
+def get_insight(
+    county_slug: str,
+    response: Response,
+    year: int | None = Query(None, description="Insight year; defaults to latest available"),
+    db: Session = Depends(get_db),
+):
+    """Return the pre-computed insight card for a single county.
+
+    Returns ``narrative: null`` (not 404) when structured stats exist but the
+    LLM hasn't run or failed for this county — the frontend hides the blurb
+    section gracefully in that case.
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+
+    # Resolve slug → county_code
+    slug_map = get_slug_map(db)
+    county_code = get_code(county_slug, slug_map)
+    if county_code is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"County slug '{county_slug}' not found. "
+                   "Use lowercase-hyphenated form, e.g. 'los-angeles'.",
+        )
+
+    # Fetch insight row
+    q = db.query(CountyInsight).filter(CountyInsight.county_code == county_code)
+    if year is not None:
+        q = q.filter(CountyInsight.year == year)
+    else:
+        q = q.order_by(CountyInsight.year.desc())
+
+    insight: CountyInsight | None = q.first()
+    if insight is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No insight data found for '{county_slug}'"
+                   + (f" year={year}" if year else "")
+                   + ". Run etl/generate_insights.py first.",
+        )
+
+    # County name for the response
+    county: County | None = (
+        db.query(County).filter(County.code == county_code).first()
+    )
+    county_name = county.name if county else county_slug
+
+    return {
+        "county_name": county_name,
+        "year": insight.year,
+        "total_crashes": insight.total_crashes,
+        "total_killed": insight.total_killed,
+        "total_injured": insight.total_injured,
+        "crash_rate_per_capita": insight.crash_rate_per_capita,
+        "top_cause": insight.top_cause,
+        "top_cause_pct": insight.top_cause_pct,
+        "yoy_change_pct": insight.yoy_change_pct,
+        "peak_hour": insight.peak_hour,
+        "dui_pct": insight.dui_pct,
+        "narrative": insight.narrative,
+        "generated_at": (
+            insight.generated_at.isoformat() if insight.generated_at else None
+        ),
+    }

--- a/backend/app/schemas/heatmap.py
+++ b/backend/app/schemas/heatmap.py
@@ -7,6 +7,7 @@ class HeatmapPoint(BaseModel):
     lat: float
     lng: float
     weight: int
+    severity: str | None = None
 
 
 class HeatmapResponse(BaseModel):

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -47,6 +47,15 @@ class Settings(BaseSettings):
     # -- App --
     debug: bool = True
 
+    # -- LLM (AI insight card generation) --
+    # Supports: groq | openrouter | together | cerebras | ollama
+    # Leave llm_model / llm_base_url empty to use provider defaults.
+    # For ollama over Tailscale, set llm_base_url to the Tailscale IP.
+    llm_provider: str = "together"
+    llm_api_key: str = ""
+    llm_model: str = ""
+    llm_base_url: str = ""
+
     @property
     def cors_origin_list(self) -> list[str]:
         """Parse the comma-separated CORS_ORIGINS string into a list."""

--- a/backend/etl/generate_insights.py
+++ b/backend/etl/generate_insights.py
@@ -47,7 +47,7 @@ from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
 from app.llm import generate_narrative
-from app.models import County, CountyInsight, Demographic
+from app.models import County, CountyInsight
 from etl._utils import track_etl_run
 
 logger = logging.getLogger(__name__)

--- a/backend/etl/generate_insights.py
+++ b/backend/etl/generate_insights.py
@@ -41,7 +41,7 @@ import logging
 import time
 from datetime import datetime, timezone
 
-from sqlalchemy import func, text
+from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 

--- a/backend/etl/generate_insights.py
+++ b/backend/etl/generate_insights.py
@@ -1,0 +1,516 @@
+"""ETL step 18 — generate per-county AI insight cards.
+
+For each of the 58 California counties this script:
+
+1. Queries deterministic crash stats for the latest full year available:
+   total crashes, fatalities, injuries, YoY change, top cause + %, peak
+   crash hour, DUI %, and crash rate per capita.
+
+2. Queries census demographics as prompt context (population, median income,
+   commute split, poverty rate, population density). These are NOT stored in
+   the DB — they exist only to enrich the LLM prompt.
+
+3. Calls the configured LLM provider to generate a 2–3 sentence narrative
+   (see ``app.llm``). If the call fails the county is skipped — the rest of
+   the pipeline continues and the frontend renders ``narrative: null``
+   gracefully.
+
+4. Upserts into ``county_insights`` (one row per county per year). Structured
+   stats are always written. Narrative is written only when the LLM succeeds.
+
+Rate limit
+----------
+A 1-second sleep between LLM calls keeps us well within typical provider
+rate limits. 58 counties = ~1 minute total.
+
+Usage
+-----
+::
+
+    # As part of the full ETL run (step 18):
+    python -m etl.generate_insights
+
+    # Standalone for a quick test:
+    cd backend
+    python -m etl.generate_insights
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+
+from sqlalchemy import func, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.llm import generate_narrative
+from app.models import County, CountyInsight, Demographic
+from etl._utils import track_etl_run
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+_PROMPT_TEMPLATE = (
+    "You're a data analyst writing a 2-3 sentence insight about {county} County's "
+    "crash data. Be engaging — mix one surprising comparison or fun fact with the "
+    "key trend. Data: {stats}. Don't restate raw numbers — the UI already shows "
+    "those. Focus on what's *interesting*."
+)
+
+
+# ---------------------------------------------------------------------------
+# Stat queries
+# ---------------------------------------------------------------------------
+
+_MIN_CRASHES_FOR_FULL_YEAR = 50
+
+
+def _all_years(db: Session, county_code: int) -> list[int]:
+    """Return all crash years with enough data for this county."""
+    rows = db.execute(
+        text(
+            "SELECT crash_year FROM crashes "
+            "WHERE county_code = :c "
+            "GROUP BY crash_year "
+            "HAVING COUNT(*) >= :min "
+            "ORDER BY crash_year DESC"
+        ),
+        {"c": county_code, "min": _MIN_CRASHES_FOR_FULL_YEAR},
+    ).all()
+    return [r[0] for r in rows]
+
+
+def _latest_year(db: Session, county_code: int) -> int | None:
+    """Return the most recent full crash year for this county.
+
+    Skips partial years (e.g. current calendar year with only a few hundred
+    records) by requiring at least _MIN_CRASHES_FOR_FULL_YEAR crashes.
+    """
+    row = db.execute(
+        text(
+            "SELECT crash_year FROM crashes "
+            "WHERE county_code = :c "
+            "GROUP BY crash_year "
+            "HAVING COUNT(*) >= :min "
+            "ORDER BY crash_year DESC LIMIT 1"
+        ),
+        {"c": county_code, "min": _MIN_CRASHES_FOR_FULL_YEAR},
+    ).scalar()
+    return row  # type: ignore[return-value]
+
+
+def _query_stats(
+    db: Session, county_code: int, year: int
+) -> dict | None:
+    """Return deterministic crash stats dict for the county/year.
+
+    Returns None if there's no crash data at all (shouldn't happen after
+    ``_latest_year`` but guards against edge cases).
+    """
+    # --- grand totals ---
+    totals = db.execute(
+        text(
+            """
+            SELECT
+                COUNT(*)                        AS total_crashes,
+                COALESCE(SUM(number_killed), 0) AS total_killed,
+                COALESCE(SUM(number_injured),0) AS total_injured
+            FROM crashes
+            WHERE county_code = :c AND crash_year = :y
+            """
+        ),
+        {"c": county_code, "y": year},
+    ).one()
+
+    if totals.total_crashes == 0:
+        return None
+
+    # --- YoY change vs prior year ---
+    prior = db.execute(
+        text(
+            "SELECT COUNT(*) AS cnt FROM crashes "
+            "WHERE county_code = :c AND crash_year = :y"
+        ),
+        {"c": county_code, "y": year - 1},
+    ).scalar() or 0
+
+    if prior > 0:
+        yoy_change_pct = round(
+            ((totals.total_crashes - prior) / prior) * 100, 2
+        )
+    else:
+        yoy_change_pct = None
+
+    # --- top canonical_cause ---
+    cause_row = db.execute(
+        text(
+            """
+            SELECT
+                canonical_cause,
+                COUNT(*) AS cnt
+            FROM crashes
+            WHERE county_code = :c AND crash_year = :y
+              AND canonical_cause IS NOT NULL
+            GROUP BY canonical_cause
+            ORDER BY cnt DESC
+            LIMIT 1
+            """
+        ),
+        {"c": county_code, "y": year},
+    ).first()
+
+    top_cause = cause_row.canonical_cause if cause_row else None
+    top_cause_pct = (
+        round((cause_row.cnt / totals.total_crashes) * 100, 2)
+        if cause_row else None
+    )
+
+    # --- peak crash hour ---
+    hour_row = db.execute(
+        text(
+            """
+            SELECT crash_hour, COUNT(*) AS cnt
+            FROM crashes
+            WHERE county_code = :c AND crash_year = :y
+              AND crash_hour IS NOT NULL
+            GROUP BY crash_hour
+            ORDER BY cnt DESC
+            LIMIT 1
+            """
+        ),
+        {"c": county_code, "y": year},
+    ).first()
+    peak_hour = hour_row.crash_hour if hour_row else None
+
+    # --- DUI % ---
+    dui_count = db.execute(
+        text(
+            "SELECT COUNT(*) FROM crashes "
+            "WHERE county_code = :c AND crash_year = :y "
+            "AND canonical_cause = 'dui'"
+        ),
+        {"c": county_code, "y": year},
+    ).scalar() or 0
+
+    dui_pct = round((dui_count / totals.total_crashes) * 100, 2)
+
+    # --- crash rate per capita (from counties.population) ---
+    pop = db.execute(
+        text("SELECT population FROM counties WHERE code = :c"),
+        {"c": county_code},
+    ).scalar()
+
+    crash_rate_per_capita = (
+        round((totals.total_crashes / pop) * 100_000, 2)
+        if pop and pop > 0 else None
+    )
+
+    return {
+        "total_crashes": totals.total_crashes,
+        "total_killed": totals.total_killed,
+        "total_injured": totals.total_injured,
+        "yoy_change_pct": yoy_change_pct,
+        "top_cause": top_cause,
+        "top_cause_pct": top_cause_pct,
+        "peak_hour": peak_hour,
+        "dui_pct": dui_pct,
+        "crash_rate_per_capita": crash_rate_per_capita,
+    }
+
+
+def _query_demographics(
+    db: Session, county_code: int, year: int
+) -> dict:
+    """Return demographic context for the LLM prompt (not stored in DB).
+
+    Falls back to an empty dict if no demographics row exists for this year
+    (some early years or small counties may be missing).
+    """
+    row = db.execute(
+        text(
+            """
+            SELECT
+                population,
+                median_income,
+                commute_drive_alone_pct,
+                commute_transit_pct,
+                poverty_rate,
+                population_density
+            FROM demographics
+            WHERE county_code = :c AND year = :y
+            LIMIT 1
+            """
+        ),
+        {"c": county_code, "y": year},
+    ).first()
+
+    if row is None:
+        return {}
+
+    return {
+        "population": row.population,
+        "median_income": row.median_income,
+        "commute_drive_alone_pct": row.commute_drive_alone_pct,
+        "commute_transit_pct": row.commute_transit_pct,
+        "poverty_rate": row.poverty_rate,
+        "population_density": row.population_density,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+def _build_prompt(county_name: str, stats: dict, demo: dict) -> str:
+    parts = [
+        f"total_crashes={stats['total_crashes']}",
+        f"total_killed={stats['total_killed']}",
+    ]
+    if stats.get("yoy_change_pct") is not None:
+        parts.append(f"yoy_change={stats['yoy_change_pct']:+.1f}%")
+    if stats.get("top_cause"):
+        parts.append(
+            f"top_cause={stats['top_cause']} ({stats['top_cause_pct']:.1f}%)"
+        )
+    if stats.get("peak_hour") is not None:
+        parts.append(f"peak_hour={stats['peak_hour']}:00")
+    if stats.get("dui_pct") is not None:
+        parts.append(f"dui_pct={stats['dui_pct']:.1f}%")
+    if demo.get("population"):
+        parts.append(f"population={demo['population']:,}")
+    if demo.get("median_income"):
+        parts.append(f"median_income=${demo['median_income']:,}")
+    if demo.get("poverty_rate") is not None:
+        parts.append(f"poverty_rate={demo['poverty_rate']:.1f}%")
+    if demo.get("population_density") is not None:
+        parts.append(f"pop_density={demo['population_density']:.0f}/sq mi")
+
+    return _PROMPT_TEMPLATE.format(
+        county=county_name,
+        stats=", ".join(parts),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main ETL function
+# ---------------------------------------------------------------------------
+
+@track_etl_run("generate_insights")
+def run() -> int:
+    """Generate insight cards for all counties. Returns number of rows upserted."""
+    db = SessionLocal()
+    try:
+        counties: list[County] = (
+            db.query(County).order_by(County.name).all()
+        )
+        upserted = 0
+
+        for county in counties:
+            # ---- Step 1: latest year ----
+            year = _latest_year(db, county.code)
+            if year is None:
+                logger.warning(
+                    "No crash data for %s (code=%d) — skipping",
+                    county.name, county.code,
+                )
+                continue
+
+            # ---- Step 2: structured stats ----
+            stats = _query_stats(db, county.code, year)
+            if stats is None:
+                logger.warning(
+                    "Zero crashes for %s in %d — skipping",
+                    county.name, year,
+                )
+                continue
+
+            # ---- Step 3: demographics (prompt context only) ----
+            demo = _query_demographics(db, county.code, year)
+
+            # ---- Step 4: LLM narrative ----
+            narrative: str | None = None
+            try:
+                prompt = _build_prompt(county.name, stats, demo)
+                narrative = generate_narrative(prompt)
+                logger.info(
+                    "Generated narrative for %s (%d)", county.name, year
+                )
+            except Exception as exc:
+                logger.error(
+                    "LLM failed for %s: %s — storing stats without narrative",
+                    county.name, exc,
+                )
+
+            # ---- Step 5: upsert ----
+            now = datetime.now(tz=timezone.utc)
+            stmt = (
+                pg_insert(CountyInsight)
+                .values(
+                    county_code=county.code,
+                    year=year,
+                    total_crashes=stats["total_crashes"],
+                    total_killed=stats["total_killed"],
+                    total_injured=stats["total_injured"],
+                    crash_rate_per_capita=stats["crash_rate_per_capita"],
+                    top_cause=stats["top_cause"],
+                    top_cause_pct=stats["top_cause_pct"],
+                    yoy_change_pct=stats["yoy_change_pct"],
+                    peak_hour=stats["peak_hour"],
+                    dui_pct=stats["dui_pct"],
+                    narrative=narrative,
+                    generated_at=now if narrative else None,
+                )
+                .on_conflict_do_update(
+                    index_elements=["county_code", "year"],
+                    set_=dict(
+                        total_crashes=stats["total_crashes"],
+                        total_killed=stats["total_killed"],
+                        total_injured=stats["total_injured"],
+                        crash_rate_per_capita=stats["crash_rate_per_capita"],
+                        top_cause=stats["top_cause"],
+                        top_cause_pct=stats["top_cause_pct"],
+                        yoy_change_pct=stats["yoy_change_pct"],
+                        peak_hour=stats["peak_hour"],
+                        dui_pct=stats["dui_pct"],
+                        narrative=narrative,
+                        generated_at=now if narrative else None,
+                    ),
+                )
+            )
+            db.execute(stmt)
+            db.commit()
+            upserted += 1
+
+            # Rate-limit LLM calls — 3 s between counties (~3 min total)
+            time.sleep(3)
+
+        logger.info("generate_insights complete: %d counties upserted", upserted)
+        return upserted
+
+    finally:
+        db.close()
+
+
+_ALL_YEARS_DELAY = 5
+
+
+def run_all_years() -> int:
+    """Generate insight cards for all counties across all available years."""
+    db = SessionLocal()
+    try:
+        counties: list[County] = (
+            db.query(County).order_by(County.name).all()
+        )
+        upserted = 0
+        skipped_existing = 0
+
+        for county in counties:
+            years = _all_years(db, county.code)
+            if not years:
+                logger.warning(
+                    "No crash data for %s (code=%d) — skipping",
+                    county.name, county.code,
+                )
+                continue
+
+            for year in years:
+                existing = (
+                    db.query(CountyInsight)
+                    .filter(
+                        CountyInsight.county_code == county.code,
+                        CountyInsight.year == year,
+                        CountyInsight.narrative.isnot(None),
+                    )
+                    .first()
+                )
+                if existing:
+                    skipped_existing += 1
+                    continue
+
+                stats = _query_stats(db, county.code, year)
+                if stats is None:
+                    continue
+
+                demo = _query_demographics(db, county.code, year)
+
+                narrative: str | None = None
+                try:
+                    prompt = _build_prompt(county.name, stats, demo)
+                    narrative = generate_narrative(prompt)
+                    logger.info(
+                        "Generated narrative for %s (%d)", county.name, year
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "LLM failed for %s %d: %s", county.name, year, exc
+                    )
+
+                now = datetime.now(tz=timezone.utc)
+                stmt = (
+                    pg_insert(CountyInsight)
+                    .values(
+                        county_code=county.code,
+                        year=year,
+                        total_crashes=stats["total_crashes"],
+                        total_killed=stats["total_killed"],
+                        total_injured=stats["total_injured"],
+                        crash_rate_per_capita=stats["crash_rate_per_capita"],
+                        top_cause=stats["top_cause"],
+                        top_cause_pct=stats["top_cause_pct"],
+                        yoy_change_pct=stats["yoy_change_pct"],
+                        peak_hour=stats["peak_hour"],
+                        dui_pct=stats["dui_pct"],
+                        narrative=narrative,
+                        generated_at=now if narrative else None,
+                    )
+                    .on_conflict_do_update(
+                        index_elements=["county_code", "year"],
+                        set_=dict(
+                            total_crashes=stats["total_crashes"],
+                            total_killed=stats["total_killed"],
+                            total_injured=stats["total_injured"],
+                            crash_rate_per_capita=stats["crash_rate_per_capita"],
+                            top_cause=stats["top_cause"],
+                            top_cause_pct=stats["top_cause_pct"],
+                            yoy_change_pct=stats["yoy_change_pct"],
+                            peak_hour=stats["peak_hour"],
+                            dui_pct=stats["dui_pct"],
+                            narrative=narrative,
+                            generated_at=now if narrative else None,
+                        ),
+                    )
+                )
+                db.execute(stmt)
+                db.commit()
+                upserted += 1
+
+                time.sleep(_ALL_YEARS_DELAY)
+
+        logger.info(
+            "generate_insights (all years) complete: %d upserted, %d skipped (existing)",
+            upserted, skipped_existing,
+        )
+        return upserted
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+    mode = sys.argv[1] if len(sys.argv) > 1 else "latest"
+    if mode == "all":
+        sys.exit(0 if run_all_years() is not None else 1)
+    else:
+        sys.exit(0 if run() is not None else 1)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ psycopg2-binary==2.9.11
 httpx==0.28.1
 python-dotenv==1.2.2
 pydantic-settings==2.8.1
+openai>=1.0.0
 ruff==0.15.8
 pytest==9.0.2
 pytest-asyncio==1.3.0

--- a/backend/run_all_etl.sh
+++ b/backend/run_all_etl.sh
@@ -96,16 +96,21 @@ python -m etl.compute_data_quality
 echo "=== Data quality stats done ==="
 
 echo ""
-echo "=== 17/18  Refresh materialized views (StatsPage aggregates) ==="
+echo "=== 17/19  Refresh materialized views (StatsPage aggregates) ==="
 python -m etl.refresh_materialized_views
 echo "=== Materialized views done ==="
 
 echo ""
-echo "=== 18/18  VACUUM ANALYZE (refresh planner statistics) ==="
+echo "=== 18/19  Generate AI insight cards ==="
+python -m etl.generate_insights
+echo "=== AI insights done ==="
+
+echo ""
+echo "=== 19/19  VACUUM ANALYZE (refresh planner statistics) ==="
 python -m etl.vacuum_analyze
 echo "=== VACUUM ANALYZE done ==="
 
 echo ""
 echo "============================================"
-echo "  All 18 ETL jobs complete!"
+echo "  All 19 ETL jobs complete!"
 echo "============================================"

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -10,6 +10,8 @@ interface AiInsightCardProps {
   onCompare: () => void;
   compareCountyName?: string;
   compareData?: ChoroplethPoint;
+  /** LLM-generated narrative blurb. null/undefined = section hidden. */
+  narrative?: string | null;
 }
 
 function fmt(n: number): string {
@@ -85,12 +87,13 @@ export default function AiInsightCard({
   onCompare,
   compareCountyName,
   compareData,
+  narrative,
 }: AiInsightCardProps) {
   const [expanded, setExpanded] = useState(false);
   const isComparing = compareMode && compareCountyName && compareData;
 
   return (
-    <div className="absolute bottom-0 left-0 right-0 z-30 md:bottom-2 md:left-16 md:right-auto md:max-w-sm">
+    <div className="fixed bottom-card-mobile left-0 right-0 z-40 md:absolute md:bottom-2 md:left-16 md:right-auto md:max-w-sm md:z-30">
       <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden">
         {/* Collapsed bar — always visible */}
         <div
@@ -145,6 +148,18 @@ export default function AiInsightCard({
             ) : (
               <>
                 {data && <MetricGrid data={data} measureLabel={measureLabel} />}
+
+                {/* AI narrative blurb — single-county mode only, hidden when null */}
+                {!compareMode && narrative && (
+                  <div className="flex gap-2 items-start bg-surface-container-lowest rounded-lg px-3 py-2.5 animate-[fadeIn_0.4s_ease]">
+                    <span className="material-symbols-outlined text-[16px] text-primary shrink-0 mt-0.5">
+                      auto_awesome
+                    </span>
+                    <p className="text-xs text-on-surface-variant font-body leading-relaxed">
+                      {narrative}
+                    </p>
+                  </div>
+                )}
 
                 {compareMode && !compareCountyName && (
                   <p className="text-xs text-on-surface-variant text-center py-1">

--- a/frontend/src/components/map/ChoroplethLegend.test.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.test.tsx
@@ -140,21 +140,20 @@ describe("ChoroplethLegend", () => {
   it("shows missing-demographics alert when per-capita measure is active and years are missing", async () => {
     render(<Harness edges={[0, 10, 20, 30, 40, 50]} dataSummary={{ ...BASE_SUMMARY, missingDemoYears: [2024, 2025] }} />);
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/no population data for 2024, 2025/i);
+    expect(alert).toHaveTextContent(/no census data for 2024, 2025/i);
     expect(screen.getByRole("button", { name: /switch to total crashes/i })).toBeInTheDocument();
   });
 
   it("shows partial-demographics alert for years with incomplete county coverage", async () => {
     render(<Harness edges={[0, 10, 20, 30, 40, 50]} dataSummary={{ ...BASE_SUMMARY, partialDemoYears: [2005, 2006, 2007, 2008, 2009] }} />);
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/partial population data for 2005-2009/i);
+    expect(alert).toHaveTextContent(/switch to total crashes/i);
   });
 
   it("shows both missing and partial alerts together", async () => {
     render(<Harness edges={[0, 10, 20, 30, 40, 50]} dataSummary={{ ...BASE_SUMMARY, missingDemoYears: [2024], partialDemoYears: [2007] }} />);
     const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(/no population data for 2024/i);
-    expect(alert).toHaveTextContent(/partial population data for 2007/i);
+    expect(alert).toHaveTextContent(/no census data for 2024/i);
   });
 
   it("does not show missing-demographics alert for raw measures", () => {

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -1,8 +1,15 @@
 import { useState, useRef, useEffect } from "react";
 import { useLayersState } from "../../hooks/useLayersState";
 import { MEASURES } from "../../lib/choropleth/measures";
-import { getPalette } from "../../lib/choropleth/palettes";
+import { getPalette, type PaletteKey } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
+
+const FATAL_DOT_COLORS: Record<PaletteKey, string> = {
+  default: "#dc2626",
+  warm: "#7c3aed",
+  cool: "#dc2626",
+  colorblind: "#e66100",
+};
 import type { DataSummary } from "../../hooks/useChoroplethData";
 import type { CoordCoverage } from "../../hooks/useCoordCoverage";
 
@@ -16,8 +23,10 @@ type Props = {
   searchOpen?: boolean;
   onRetry?: () => void;
   heatmapCrashes?: number | null;
+  heatmapDisplayed?: number | null;
   heatmapLoading?: boolean;
   countyActive?: boolean;
+  countyTotalCrashes?: number | null;
 };
 
 function formatYearList(years: number[]): string {
@@ -37,7 +46,7 @@ function formatCount(n: number): string {
 
 const EMPTY_SUMMARY: DataSummary = { totalCrashes: 0, missingDemoYears: [], partialDemoYears: [], sparseYears: [] };
 
-export default function ChoroplethLegend({ demographicsAvailable, dataSummary = EMPTY_SUMMARY, coordCoverage, isLoading, isError, is422, onRetry, heatmapCrashes, heatmapLoading }: Props) {
+export default function ChoroplethLegend({ demographicsAvailable, dataSummary = EMPTY_SUMMARY, coordCoverage, isLoading, isError, is422, searchOpen, onRetry, heatmapCrashes, heatmapDisplayed, heatmapLoading, countyActive, countyTotalCrashes }: Props) {
   const { choroplethOn, measure, palette, bucketEdges, setMeasure } = useLayersState();
   const isDark = useIsDark();
   const [isOpen, setIsOpen] = useState(false);
@@ -64,27 +73,32 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
   return (
     <div
       data-testid="choropleth-legend"
-      className={`absolute left-2 md:left-auto md:right-4 z-20 bg-surface-container-lowest/95 backdrop-blur-md rounded-xl p-2 md:p-3 w-[200px] md:w-[250px] ghost-border transition-all duration-300 top-2 md:top-2 md:bottom-auto`}
+      className={`absolute z-20 bg-surface-container-lowest/95 backdrop-blur-md rounded-xl p-2 md:p-3 w-[200px] md:w-[250px] ghost-border transition-all duration-300 top-3 left-2 md:top-2 md:left-auto md:right-4 ${searchOpen ? "hidden md:block" : ""}`}
     >
-      {/* Mobile: tap to expand */}
-      <div
-        className="md:hidden flex items-center justify-between mb-1 cursor-pointer"
-        onClick={() => setMobileExpanded((v) => !v)}
-      >
-        <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">{activeMeasure.label}</span>
-        <span className="material-symbols-outlined text-[14px] text-on-surface-variant transition-transform" style={{ transform: mobileExpanded ? "rotate(180deg)" : undefined }}>
-          expand_less
+      {countyActive ? (
+        <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant mb-1 block">
+          Crash Detail
         </span>
-      </div>
-
-      {/* Desktop: always show label */}
-      <label
-        className="hidden md:block text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2"
-        id="choropleth-measure-label"
-      >
-        Measure
-      </label>
-      <div ref={containerRef} className={`relative mb-3 ${mobileExpanded ? "" : "hidden md:block"}`}>
+      ) : (
+        <>
+          <div
+            className="md:hidden flex items-center justify-between mb-1 cursor-pointer"
+            onClick={() => setMobileExpanded((v) => !v)}
+          >
+            <span className="text-[9px] font-bold uppercase tracking-widest text-on-surface-variant">{activeMeasure.label}</span>
+            <span className="material-symbols-outlined text-[14px] text-on-surface-variant transition-transform" style={{ transform: mobileExpanded ? "rotate(180deg)" : undefined }}>
+              expand_less
+            </span>
+          </div>
+          <label
+            className="hidden md:block text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2"
+            id="choropleth-measure-label"
+          >
+            Measure
+          </label>
+        </>
+      )}
+      <div ref={containerRef} className={`relative mb-3 ${countyActive ? "hidden" : mobileExpanded ? "" : "hidden md:block"}`}>
         <button
           type="button"
           aria-labelledby="choropleth-measure-label"
@@ -142,39 +156,81 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
         )}
       </div>
 
-      <div className={`flex h-3 rounded-sm overflow-hidden ${isLoading ? "animate-pulse opacity-40" : ""}`}>
-        {colors.map((c, i) => (
-          <div key={i} className="flex-1" style={{ backgroundColor: c }} />
-        ))}
-      </div>
-
-      {(heatmapLoading || (heatmapCrashes != null && heatmapCrashes > 0)) && (
-        <div className="text-[10px] text-on-surface-variant mt-1 font-mono font-semibold">
-          {heatmapLoading ? "Loading heatmap..." : `${heatmapCrashes!.toLocaleString()} crashes mapped`}
+      {!countyActive ? (
+        <div className={`flex h-3 rounded-sm overflow-hidden ${isLoading ? "animate-pulse opacity-40" : ""}`}>
+          {colors.map((c, i) => (
+            <div key={i} className="flex-1" style={{ backgroundColor: c }} />
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 mt-1">
+          <div className="flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: colors[colors.length - 1] }} />
+            <span className="text-[10px] text-on-surface-variant font-semibold">Crash</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: FATAL_DOT_COLORS[palette] }} />
+            <span className="text-[10px] text-on-surface-variant font-semibold">Fatal</span>
+          </div>
         </div>
       )}
 
-      {/* Bucket labels — hide on mobile when collapsed */}
-      <div className={mobileExpanded ? "" : "hidden md:block"}>
-        {isLoading ? (
-          <div className="text-[10px] text-on-surface-variant mt-1 italic">
-            Loading data…
-          </div>
-        ) : bucketEdges ? (
-          <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
-            {bucketEdges.map((e, i) => (
-              <span key={i}>{activeMeasure.formatLabel(e)}</span>
-            ))}
-          </div>
-        ) : (
-          <div className="text-[10px] text-on-surface-variant mt-1 italic">
-            Pan or zoom out to compute scale
-          </div>
-        )}
-      </div>
+      {/* Statewide summary — hide when county focused */}
+      {!mobileExpanded && !isLoading && dataSummary.totalCrashes > 0 && !countyActive && (
+        <div className="md:hidden text-[10px] text-on-surface-variant mt-1 font-mono font-semibold">
+          {formatCount(dataSummary.totalCrashes)} crashes
+        </div>
+      )}
+
+      {(heatmapLoading || (heatmapCrashes != null && heatmapCrashes > 0)) && (
+        <div className="text-[10px] text-on-surface-variant mt-1 font-mono font-semibold">
+          {heatmapLoading
+            ? "Loading heatmap..."
+            : countyActive && countyTotalCrashes && heatmapDisplayed != null
+              ? `${formatCount(heatmapDisplayed)} mapped (${Math.round((heatmapDisplayed / countyTotalCrashes) * 100)}%)`
+              : heatmapDisplayed != null && heatmapDisplayed < heatmapCrashes!
+                ? `${formatCount(heatmapDisplayed)} of ${formatCount(heatmapCrashes!)} mapped`
+                : `${formatCount(heatmapCrashes!)} mapped`}
+        </div>
+      )}
+
+      {/* Bucket labels — hide when county heatmap active */}
+      {!countyActive && (
+        <div className={mobileExpanded ? "" : "hidden md:block"}>
+          {isLoading ? (
+            <div className="text-[10px] text-on-surface-variant mt-1 italic">
+              Loading data…
+            </div>
+          ) : bucketEdges ? (
+            <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
+              {bucketEdges.map((e, i) => (
+                <span key={i}>{activeMeasure.formatLabel(e)}</span>
+              ))}
+            </div>
+          ) : (
+            <div className="text-[10px] text-on-surface-variant mt-1 italic">
+              Pan or zoom out to compute scale
+            </div>
+          )}
+        </div>
+      )}
+
+      {!countyActive && activeMeasure.kind === "perCapita" && (dataSummary.missingDemoYears.length > 0 || dataSummary.partialDemoYears.length > 0) && (
+        <div role="alert" className="bg-red-500/15 rounded-md px-2 py-1.5 mt-1.5 text-[10px] text-red-600 dark:text-red-400 font-semibold">
+          {dataSummary.missingDemoYears.length > 0 && (
+            <div>No census data for {formatYearList(dataSummary.missingDemoYears)}</div>
+          )}
+          <button
+            className="block mt-1 underline"
+            onClick={() => setMeasure("crashes_raw")}
+          >
+            Switch to Total Crashes
+          </button>
+        </div>
+      )}
 
       <div className={mobileExpanded ? "" : "hidden md:block"}>
-      {!isLoading && dataSummary.totalCrashes > 0 && (
+      {!countyActive && !isLoading && dataSummary.totalCrashes > 0 && (
         <div data-testid="data-summary" className="text-[11px] sm:text-[10px] text-on-surface-variant mt-2 leading-snug">
           <span className="font-mono font-semibold">{formatCount(dataSummary.totalCrashes)}</span> crashes
 
@@ -196,22 +252,6 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
             </div>
           )}
 
-          {activeMeasure.kind === "perCapita" && (dataSummary.missingDemoYears.length > 0 || dataSummary.partialDemoYears.length > 0) && (
-            <div role="alert" className="bg-surface-container-high/60 rounded-md px-2 py-1.5 mt-1.5">
-              {dataSummary.missingDemoYears.length > 0 && (
-                <div>No population data for {formatYearList(dataSummary.missingDemoYears)}</div>
-              )}
-              {dataSummary.partialDemoYears.length > 0 && (
-                <div>Partial population data for {formatYearList(dataSummary.partialDemoYears)}</div>
-              )}
-              <button
-                className="block mt-1 underline font-semibold"
-                onClick={() => setMeasure("crashes_raw")}
-              >
-                Switch to Total Crashes
-              </button>
-            </div>
-          )}
         </div>
       )}
 

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -11,6 +11,7 @@ import { useIsDark } from "../../context/ThemeContext";
 interface CountyBoundariesProps {
   focusedCounty: string | null;
   compareCounty?: string | null;
+  heatmapActive?: boolean;
   onFocusCounty: (name: string | null) => void;
   onSelectCounty: (name: string) => void;
 }
@@ -37,6 +38,7 @@ function getCountyCode(f: GeoJSON.Feature): number | null {
 export default function CountyBoundaries({
   focusedCounty,
   compareCounty = null,
+  heatmapActive = false,
   onFocusCounty,
   onSelectCounty,
 }: CountyBoundariesProps) {
@@ -135,7 +137,7 @@ export default function CountyBoundaries({
           : base;
       }
 
-      if (otherLayers.heatmapCounty && focusedCounty) {
+      if (heatmapActive && focusedCounty) {
         return {
           color: borderColor,
           weight: borderWeight,
@@ -168,7 +170,7 @@ export default function CountyBoundaries({
         fillOpacity: 0.75,
       };
     },
-    [choroplethOn, otherLayers.countyBoundaries, otherLayers.heatmapStatewide, otherLayers.heatmapCounty, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
+    [choroplethOn, otherLayers.countyBoundaries, otherLayers.heatmapStatewide, heatmapActive, focusedCounty, compareCounty, hasCountyFilter, selectedCounties, byCountyCode, palette, isDark],
   );
 
   // Ref so mouseout can re-apply the *current* style (not the stale one

--- a/frontend/src/components/map/CrashHeatmap.tsx
+++ b/frontend/src/components/map/CrashHeatmap.tsx
@@ -9,7 +9,7 @@ import { getPalette } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 
 const BASE_RADIUS: Record<HeatmapResolution, number> = {
-  raw: 5,
+  raw: 8,
   low: 18,
   medium: 12,
   high: 8,
@@ -20,8 +20,13 @@ function radiusForZoom(base: number, zoom: number): number {
   return Math.max(2, Math.round(base * scale));
 }
 
-function buildGradient(palette: PaletteKey, isDark: boolean): Record<number, string> {
+function buildGradient(palette: PaletteKey, isDark: boolean, raw = false): Record<number, string> {
   const colors = getPalette(palette, isDark);
+  if (raw) {
+    const strong = colors[colors.length - 1];
+    const mid = colors[Math.floor(colors.length * 0.6)];
+    return { 0: "transparent", 0.3: mid, 1.0: strong };
+  }
   const stops: Record<number, string> = { 0: "transparent" };
   colors.forEach((c, i) => {
     stops[(i + 1) / colors.length] = c;
@@ -51,7 +56,6 @@ export function useHeatLayer(
     for (const p of points) {
       if (p.weight > maxWeight) maxWeight = p.weight;
     }
-    const gradient = buildGradient(palette, isDark);
 
     latlngsRef.current = points.map((p) => [
       p.lat,
@@ -61,6 +65,7 @@ export function useHeatLayer(
 
     const base = BASE_RADIUS[resolution];
     const isRaw = resolution === "raw";
+    const gradient = buildGradient(palette, isDark, isRaw);
     const r = isRaw ? base : radiusForZoom(base, map.getZoom());
     const blur = isRaw ? Math.round(base * 0.6) : Math.max(1, Math.round(r * 0.3));
 
@@ -68,24 +73,48 @@ export function useHeatLayer(
       radius: r,
       blur,
       max: 1,
-      minOpacity: 0.1,
+      minOpacity: 0.25,
       gradient,
     });
 
     layer.addTo(map);
     layerRef.current = layer;
 
-    const onZoom = () => {
-      if (!layerRef.current || isRaw) return;
-      const z = map.getZoom();
-      const newR = radiusForZoom(base, z);
-      layerRef.current.setOptions({ radius: newR, blur: Math.max(1, Math.round(newR * 0.3)) });
-      layerRef.current.redraw();
+    type HeatInternals = {
+      _canvas: HTMLCanvasElement;
+      _animateZoom: (e: L.ZoomAnimEvent) => void;
+      _reset: () => void;
     };
-    map.on("zoomend", onZoom);
+    const internals = layer as unknown as HeatInternals;
+
+    // Unbind leaflet.heat's broken _animateZoom — it miscalculates the
+    // canvas CSS transform during mobile pinch-to-zoom.
+    map.off("zoomanim", internals._animateZoom, layer);
+
+    const onZoomStart = () => {
+      if (!layerRef.current) return;
+      const c = (layerRef.current as unknown as HeatInternals)._canvas;
+      if (c) c.style.display = "none";
+    };
+
+    const onZoomEnd = () => {
+      if (!layerRef.current) return;
+      const cast = layerRef.current as unknown as HeatInternals;
+      if (cast._canvas) cast._canvas.style.display = "";
+      if (!isRaw) {
+        const z = map.getZoom();
+        const newR = radiusForZoom(base, z);
+        layerRef.current.setOptions({ radius: newR, blur: Math.max(1, Math.round(newR * 0.3)) });
+      }
+      cast._reset();
+    };
+
+    map.on("zoomstart", onZoomStart);
+    map.on("zoomend", onZoomEnd);
 
     return () => {
-      map.off("zoomend", onZoom);
+      map.off("zoomstart", onZoomStart);
+      map.off("zoomend", onZoomEnd);
       if (layerRef.current) {
         map.removeLayer(layerRef.current);
         layerRef.current = null;
@@ -94,6 +123,93 @@ export function useHeatLayer(
   }, [map, points, resolution, palette, isDark]);
 
   return layerRef;
+}
+
+const FATAL_GRADIENTS: Record<PaletteKey, Record<number, string>> = {
+  default: {
+    0: "transparent",
+    0.3: "rgba(255, 80, 60, 0.4)",
+    0.6: "rgba(220, 40, 30, 0.7)",
+    1.0: "rgba(180, 20, 15, 1)",
+  },
+  warm: {
+    0: "transparent",
+    0.3: "rgba(124, 58, 237, 0.4)",
+    0.6: "rgba(109, 40, 217, 0.7)",
+    1.0: "rgba(91, 33, 182, 1)",
+  },
+  cool: {
+    0: "transparent",
+    0.3: "rgba(255, 80, 60, 0.4)",
+    0.6: "rgba(220, 40, 30, 0.7)",
+    1.0: "rgba(180, 20, 15, 1)",
+  },
+  colorblind: {
+    0: "transparent",
+    0.3: "rgba(230, 97, 0, 0.4)",
+    0.6: "rgba(210, 80, 0, 0.7)",
+    1.0: "rgba(180, 60, 0, 1)",
+  },
+};
+
+function useFatalLayer(points: HeatmapPoint[], resolution: HeatmapResolution, palette: PaletteKey) {
+  const map = useMap();
+  const layerRef = useRef<L.HeatLayer | null>(null);
+
+  useEffect(() => {
+    if (layerRef.current) {
+      map.removeLayer(layerRef.current);
+      layerRef.current = null;
+    }
+
+    if (resolution !== "raw") return;
+
+    const fatal = points.filter((p) => p.severity === "Fatal");
+    if (fatal.length === 0) return;
+
+    const latlngs: [number, number, number][] = fatal.map((p) => [p.lat, p.lng, 1]);
+
+    const layer = L.heatLayer(latlngs, {
+      radius: 8,
+      blur: 4,
+      max: 1,
+      minOpacity: 0.4,
+      gradient: FATAL_GRADIENTS[palette],
+    });
+
+    layer.addTo(map);
+    layerRef.current = layer;
+
+    type HeatInternals = {
+      _canvas: HTMLCanvasElement;
+      _animateZoom: (e: L.ZoomAnimEvent) => void;
+      _reset: () => void;
+    };
+    const internals = layer as unknown as HeatInternals;
+    map.off("zoomanim", internals._animateZoom, layer);
+
+    const onZoomStart = () => {
+      const c = (layerRef.current as unknown as HeatInternals)?._canvas;
+      if (c) c.style.display = "none";
+    };
+    const onZoomEnd = () => {
+      const cast = layerRef.current as unknown as HeatInternals;
+      if (cast?._canvas) cast._canvas.style.display = "";
+      cast?._reset();
+    };
+
+    map.on("zoomstart", onZoomStart);
+    map.on("zoomend", onZoomEnd);
+
+    return () => {
+      map.off("zoomstart", onZoomStart);
+      map.off("zoomend", onZoomEnd);
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current);
+        layerRef.current = null;
+      }
+    };
+  }, [map, points, resolution, palette]);
 }
 
 interface CrashHeatmapProps {
@@ -105,5 +221,6 @@ interface CrashHeatmapProps {
 export default function CrashHeatmap({ points, resolution, palette }: CrashHeatmapProps) {
   const isDark = useIsDark();
   useHeatLayer(points, resolution, palette, isDark);
+  useFatalLayer(points, resolution, palette);
   return null;
 }

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -52,6 +52,11 @@ export default function LayersPanel() {
     return () => window.removeEventListener("layers:reset-defaults", handleReset);
   }, [reset]);
 
+  // At least one of choroplethOn / heatmapStatewide must always be active.
+  // If one is the sole active layer, its toggle is locked (can't be turned off).
+  const choroplethLocked = choroplethOn && !otherLayers.heatmapStatewide;
+  const heatmapStatewideL = !choroplethOn && otherLayers.heatmapStatewide;
+
   return (
     <div className="space-y-8 pb-32 px-0">
       {/* County Colors */}
@@ -64,12 +69,29 @@ export default function LayersPanel() {
             <span className={`text-sm font-medium ${choroplethOn ? "text-on-surface" : "text-on-surface-variant"}`}>
               Shade by Measure
             </span>
-            <Toggle enabled={choroplethOn} onToggle={() => {
-              const next = !choroplethOn;
-              setChoroplethOn(next);
-              if (next) setOtherLayer("heatmapStatewide", false);
-            }} />
+            <div className="relative">
+              <Toggle
+                enabled={choroplethOn}
+                onToggle={() => {
+                  if (choroplethLocked) return;
+                  const next = !choroplethOn;
+                  setChoroplethOn(next);
+                  if (next) setOtherLayer("heatmapStatewide", false);
+                }}
+              />
+              {choroplethLocked && (
+                <span
+                  title="At least one base layer must be active"
+                  className="absolute inset-0 cursor-not-allowed rounded-full"
+                />
+              )}
+            </div>
           </div>
+          {choroplethLocked && (
+            <p className="text-[10px] text-on-surface-variant/60 leading-tight pl-1 italic">
+              Enable Statewide Heatmap first to turn this off
+            </p>
+          )}
           {choroplethOn && (
             <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
               Colors each county by the selected measure below
@@ -88,12 +110,29 @@ export default function LayersPanel() {
             <span className={`text-sm font-medium ${otherLayers.heatmapStatewide ? "text-on-surface" : "text-on-surface-variant"}`}>
               Statewide
             </span>
-            <Toggle enabled={otherLayers.heatmapStatewide} onToggle={() => {
-              const next = !otherLayers.heatmapStatewide;
-              setOtherLayer("heatmapStatewide", next);
-              if (next) setChoroplethOn(false);
-            }} />
+            <div className="relative">
+              <Toggle
+                enabled={otherLayers.heatmapStatewide}
+                onToggle={() => {
+                  if (heatmapStatewideL) return;
+                  const next = !otherLayers.heatmapStatewide;
+                  setOtherLayer("heatmapStatewide", next);
+                  if (next) setChoroplethOn(false);
+                }}
+              />
+              {heatmapStatewideL && (
+                <span
+                  title="At least one base layer must be active"
+                  className="absolute inset-0 cursor-not-allowed rounded-full"
+                />
+              )}
+            </div>
           </div>
+          {heatmapStatewideL && (
+            <p className="text-[10px] text-on-surface-variant/60 leading-tight pl-1 italic">
+              Enable County Colors first to turn this off
+            </p>
+          )}
           {otherLayers.heatmapStatewide && (
             <div className="space-y-2 pl-1">
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -141,13 +141,11 @@ export default function MapCanvas({
       // The tile ghosting is fixed separately via CSS (will-change: auto).
       zoomAnimation={true}
       zoomAnimationThreshold={4}
-      // Pre-load 2 extra rows/cols of tiles beyond the viewport to reduce
-      // blank-tile flicker when panning.
-      keepBuffer={2}
     >
       <TileLayer
         key={baseTileUrl}
         url={baseTileUrl}
+        keepBuffer={2}
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
       />
 
@@ -167,6 +165,7 @@ export default function MapCanvas({
       <TileLayer
         key={labelTileUrl}
         url={labelTileUrl}
+        keepBuffer={2}
         attribution='&copy; <a href="https://carto.com/">CARTO</a>'
         pane="labelPane"
       />

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -11,7 +11,8 @@ import type { PaletteKey } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 
 const CA_CENTER: [number, number] = [37.2, -119.5];
-const CA_ZOOM = window.innerWidth < 768 ? 5 : 6;
+const isMobile = window.innerWidth < 768;
+const CA_ZOOM = isMobile ? 5 : 6;
 
 const CA_BOUNDS: LatLngBoundsExpression = [
   [28.0, -127.0],
@@ -32,7 +33,7 @@ interface MapCanvasProps {
 }
 
 const HEATMAP_MAX_ZOOM: Record<string, number> = {
-  raw: 14,
+  raw: 18,
   low: 8,
   medium: 9,
   high: 10,
@@ -78,6 +79,7 @@ function MapInternals({
       <CountyBoundaries
         focusedCounty={focusedCounty}
         compareCounty={compareCounty}
+        heatmapActive={heatmapActive}
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
       />
@@ -132,9 +134,16 @@ export default function MapCanvas({
       maxBounds={CA_BOUNDS}
       maxBoundsViscosity={1.0}
       minZoom={5}
-      maxZoom={14}
+      maxZoom={18}
+      // Keep zoom animation on — leaflet.heat's _animateZoom handler needs it
+      // to CSS-transform the canvas during pinch. Without this the canvas
+      // stays at the old position while the map pane moves underneath it.
+      // The tile ghosting is fixed separately via CSS (will-change: auto).
       zoomAnimation={true}
       zoomAnimationThreshold={4}
+      // Pre-load 2 extra rows/cols of tiles beyond the viewport to reduce
+      // blank-tile flicker when panning.
+      keepBuffer={2}
     >
       <TileLayer
         key={baseTileUrl}

--- a/frontend/src/components/map/MapSearchBar.tsx
+++ b/frontend/src/components/map/MapSearchBar.tsx
@@ -1,0 +1,166 @@
+/**
+ * MapSearchBar — top-of-map expanding search bar for county lookup.
+ *
+ * Mobile: a compact pill anchored to the top of the map that expands into a
+ * full-width search field when tapped. Collapses automatically when the map
+ * is panned/zoomed.
+ *
+ * Desktop: a centered pill at the top of the map that stays expanded with a
+ * full-width input. Blurs itself when the user pans.
+ *
+ * The actual search logic (county matching, fly-to, etc.) is handled by the
+ * parent via the `onSearch` callback — this component is pure UI.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { Map as LeafletMap } from "leaflet";
+import { CA_COUNTIES } from "../../hooks/useFilterParams";
+
+interface MapSearchBarProps {
+  map: LeafletMap | null;
+  /** Called when user confirms a county selection (Enter or tap result). */
+  onSelectCounty: (name: string) => void;
+}
+
+const COUNTY_NAMES = (CA_COUNTIES as unknown as string[]).sort();
+
+export default function MapSearchBar({ map, onSelectCounty }: MapSearchBarProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Collapse when map starts moving
+  useEffect(() => {
+    if (!map) return;
+    const collapse = () => { setExpanded(false); setQuery(""); setResults([]); };
+    map.on("movestart", collapse);
+    return () => { map.off("movestart", collapse); };
+  }, [map]);
+
+  // Filter county names as user types
+  useEffect(() => {
+    if (!query.trim()) { setResults([]); return; }
+    const q = query.toLowerCase();
+    setResults(COUNTY_NAMES.filter((n) => n.toLowerCase().includes(q)).slice(0, 6));
+  }, [query]);
+
+  // Focus input when expanded
+  useEffect(() => {
+    if (expanded && inputRef.current) inputRef.current.focus();
+  }, [expanded]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!expanded) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setExpanded(false);
+        setQuery("");
+        setResults([]);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [expanded]);
+
+  const handleSelect = useCallback((name: string) => {
+    onSelectCounty(name);
+    setExpanded(false);
+    setQuery("");
+    setResults([]);
+  }, [onSelectCounty]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") { setExpanded(false); setQuery(""); setResults([]); }
+    if (e.key === "Enter" && results.length > 0) handleSelect(results[0]);
+  };
+
+  return (
+    <>
+      {/* Desktop only — mobile search is handled by MapPage icon button + overlay */}
+      <div
+        ref={containerRef}
+        className={`
+          hidden md:block
+          absolute top-3 z-20 transition-all duration-300
+          left-1/2 -translate-x-1/2
+          ${expanded ? "w-96" : "w-auto"}
+        `}
+      >
+      {/* Search pill / expanded bar */}
+      <div
+        className={`
+          flex items-center gap-2
+          bg-surface-container-lowest/95 backdrop-blur-md
+          ghost-border shadow-lg
+          transition-all duration-300
+          ${expanded ? "rounded-2xl px-4 py-2.5" : "rounded-full px-4 py-2.5 cursor-pointer"}
+        `}
+        onClick={() => !expanded && setExpanded(true)}
+      >
+        <span className="material-symbols-outlined text-[20px] text-on-surface-variant shrink-0">
+          search
+        </span>
+
+        {expanded ? (
+          <>
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Search counties…"
+              className="
+                flex-1 bg-transparent text-sm text-on-surface
+                placeholder:text-on-surface-variant/60
+                outline-none border-none focus:outline-none focus:ring-0
+              "
+            />
+            <button
+              onClick={(e) => { e.stopPropagation(); setExpanded(false); setQuery(""); setResults([]); }}
+              className="p-0.5 rounded-full hover:bg-surface-container transition-colors"
+            >
+              <span className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
+            </button>
+          </>
+        ) : (
+          <span className="text-sm text-on-surface-variant font-medium whitespace-nowrap pr-1">
+            Search counties
+          </span>
+        )}
+      </div>
+
+      {/* Results dropdown */}
+      {expanded && results.length > 0 && (
+        <div className="mt-1.5 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg overflow-hidden">
+          {results.map((name) => (
+            <button
+              key={name}
+              onClick={() => handleSelect(name)}
+              className="
+                w-full flex items-center gap-3 px-4 py-3
+                text-sm text-on-surface text-left
+                hover:bg-surface-container transition-colors
+                first:pt-3.5 last:pb-3.5
+              "
+            >
+              <span className="material-symbols-outlined text-[16px] text-on-surface-variant">location_on</span>
+              <span>{name} County</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {expanded && query.trim() && results.length === 0 && (
+        <div className="mt-1.5 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg px-4 py-3">
+          <p className="text-sm text-on-surface-variant">No counties match "{query}"</p>
+        </div>
+      )}
+      </div>{/* end containerRef div */}
+    </>
+  );
+}

--- a/frontend/src/hooks/useCountyInsight.ts
+++ b/frontend/src/hooks/useCountyInsight.ts
@@ -1,0 +1,71 @@
+/**
+ * useCountyInsight — fetches pre-computed AI insight data for a county.
+ *
+ * Calls GET /api/insights/{county_slug}?year={year} and returns the
+ * structured stats + optional LLM narrative for the requested county.
+ *
+ * Graceful degradation:
+ * - countyName null/undefined → query disabled, returns { data: null }
+ * - API returns 404 → returns { data: null } (no error — county hasn't been
+ *   processed yet or ETL hasn't run)
+ * - narrative field null → caller hides the blurb; stats are still returned
+ *
+ * Cache: staleTime matches the API's Cache-Control: public, max-age=300.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+export interface CountyInsightData {
+  county_name: string;
+  year: number;
+  total_crashes: number | null;
+  total_killed: number | null;
+  total_injured: number | null;
+  crash_rate_per_capita: number | null;
+  top_cause: string | null;
+  top_cause_pct: number | null;
+  yoy_change_pct: number | null;
+  peak_hour: number | null;
+  dui_pct: number | null;
+  /** LLM-generated narrative blurb. null when ETL hasn't run or LLM failed. */
+  narrative: string | null;
+  generated_at: string | null;
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "-");
+}
+
+async function fetchInsight(
+  slug: string,
+  year?: number,
+): Promise<CountyInsightData | null> {
+  const params = year ? `?year=${year}` : "";
+  const res = await fetch(`${API_BASE}/api/insights/${slug}${params}`);
+  // 404 = county not yet processed — treat as "no data", not an error
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`insight fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export function useCountyInsight(
+  countyName: string | null | undefined,
+  year?: number,
+): { data: CountyInsightData | null; isLoading: boolean; error: unknown } {
+  const slug = countyName ? slugify(countyName) : null;
+
+  const query = useQuery<CountyInsightData | null>({
+    queryKey: ["insight", slug, year ?? null],
+    queryFn: () => fetchInsight(slug!, year),
+    enabled: !!slug,
+    // 5 min — aligns with Cache-Control: public, max-age=300 on the API
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+}

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -7,6 +7,7 @@ export interface HeatmapPoint {
   lat: number;
   lng: number;
   weight: number;
+  severity?: string | null;
 }
 
 interface HeatmapParams {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -157,6 +157,40 @@
   }
 }
 
+/*
+ * County card bottom offset on mobile.
+ * Sits above the 56px bottom tab bar + iOS safe area inset.
+ * On md+ screens the card uses bottom-2 via Tailwind (see AiInsightCard.tsx).
+ */
+.bottom-card-mobile {
+  bottom: calc(3.5rem + env(safe-area-inset-bottom, 0px));
+}
+
+@media (min-width: 768px) {
+  .bottom-card-mobile {
+    bottom: auto; /* overridden by md:bottom-2 from Tailwind */
+  }
+}
+
+/*
+ * Leaflet mobile tile anti-ghosting.
+ *
+ * During a pinch-zoom animation Leaflet promotes each tile to its own
+ * compositor layer via will-change:transform. On mobile GPUs this causes
+ * neighbouring tiles to "ghost" — seams and smearing between tiles while
+ * the animation runs. Removing will-change from TILES ONLY forces them to
+ * composite as a single layer, eliminating the seams.
+ *
+ * DO NOT apply this to .leaflet-zoom-animated — that class is also on the
+ * heatmap canvas overlay pane, and stripping its GPU layer breaks the
+ * _animateZoom CSS transform that keeps the canvas anchored to the map.
+ */
+@media (max-width: 767px) {
+  .leaflet-tile {
+    will-change: auto !important;
+  }
+}
+
 .material-symbols-outlined {
   font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
   display: inline-block;
@@ -191,6 +225,16 @@
 @keyframes scaleIn {
   from { opacity: 0.8; transform: scale(0.99); }
   to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-8px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 /* Respect OS-level reduced motion preference */

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -26,6 +26,7 @@ import Breadcrumb from "../components/map/Breadcrumb";
 import { useCrashHeatmap } from "../hooks/useCrashHeatmap";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import { useCoordCoverage } from "../hooks/useCoordCoverage";
+import { useCountyInsight } from "../hooks/useCountyInsight";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
   filters: { title: "Filters", subtitle: "Secondary Parameters" },
@@ -68,12 +69,12 @@ function MapPageInner() {
   const [activePanel, setActivePanel] = useState<string | null>(null);
   const [showInsight, setShowInsight] = useState(true);
   const [showMobileFilters, setShowMobileFilters] = useState(false);
+  const [mobileSearchExpanded, setMobileSearchExpanded] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [focusedCounty, setFocusedCounty] = useState<string | null>(null);
   const [compareCounty, setCompareCounty] = useState<string | null>(null);
   const [compareMode, setCompareMode] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
-  const [searchOpen] = useState(false);
   const [insightCounty, setInsightCounty] = useState("Fresno");
   const mapRef = useRef<LeafletMap | null>(null);
 
@@ -81,20 +82,13 @@ function MapPageInner() {
 
   const { measure, otherLayers, heatmapResolution, palette } = useLayersState();
 
-  const hasCountyScope = !!focusedCounty || selectedCounties.size > 0;
-  const useCountyDetail = hasCountyScope && otherLayers.heatmapCounty;
+  const useCountyDetail = !!focusedCounty && otherLayers.heatmapCounty && (!compareMode || !!compareCounty);
 
   const heatmapCountySlugs = useCountyDetail ? (() => {
-    if (focusedCounty || compareCounty) {
-      const slugs: string[] = [];
-      if (focusedCounty) slugs.push(focusedCounty.toLowerCase().replace(/\s+/g, "-"));
-      if (compareCounty) slugs.push(compareCounty.toLowerCase().replace(/\s+/g, "-"));
-      return slugs.join(",");
-    }
-    if (selectedCounties.size > 0) {
-      return [...selectedCounties].map((c) => c.toLowerCase().replace(/\s+/g, "-")).join(",");
-    }
-    return null;
+    const slugs: string[] = [];
+    if (focusedCounty) slugs.push(focusedCounty.toLowerCase().replace(/\s+/g, "-"));
+    if (compareCounty) slugs.push(compareCounty.toLowerCase().replace(/\s+/g, "-"));
+    return slugs.join(",") || null;
   })() : null;
 
   const effectiveResolution = useCountyDetail
@@ -129,6 +123,19 @@ function MapPageInner() {
   const comparePointData = compareCode != null ? choroplethData.byCountyCode[compareCode] : undefined;
   const measureLabel = MEASURES[measure].label;
 
+  // When exactly one year is selected, pass it to the insight API so the
+  // narrative matches the active filter context. Otherwise use the API
+  // default (latest available year).
+  const insightYear = selectedYears.size === 1 ? [...selectedYears][0] : undefined;
+  // Gate on focusedCounty so we never fire before a county is actually clicked.
+  // insightCounty can lag behind by one render (it's preserved after deselect
+  // so the closing animation has a name to show), so use focusedCounty as the
+  // real enable gate.
+  const { data: insightData } = useCountyInsight(
+    focusedCounty ? insightCounty : null,
+    insightYear,
+  );
+
   const handleMapReady = useCallback((map: LeafletMap) => {
     mapRef.current = map;
   }, []);
@@ -161,6 +168,7 @@ function MapPageInner() {
 
   const handleStartCompare = useCallback(() => {
     setCompareMode(true);
+    mapRef.current?.flyTo([37.2, -119.5], 6, { duration: 0.8 });
   }, []);
 
   const handleFocusCounty = useCallback((name: string | null) => {
@@ -309,14 +317,34 @@ function MapPageInner() {
           countyDrilldown={useCountyDetail}
         />
 
-        {/* Mobile-only floating Filters chip */}
-        <button
-          onClick={() => setShowMobileFilters(true)}
-          className="absolute top-4 right-4 z-20 md:hidden flex items-center gap-1.5 bg-surface-container-lowest/90 backdrop-blur-md px-4 py-2 rounded-full shadow-lg ghost-border text-on-surface text-sm font-semibold"
-        >
-          <span className="material-symbols-outlined text-[18px]">tune</span>
-          Filters
-        </button>
+        {/* Mobile: search + filter icon buttons (right), hide when search expanded */}
+        {!mobileSearchExpanded && (
+          <div className="absolute top-3 right-3 z-20 md:hidden flex items-center gap-2">
+            <button
+              onClick={() => setMobileSearchExpanded(true)}
+              className="flex items-center justify-center w-10 h-10 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
+              aria-label="Search"
+            >
+              <span className="material-symbols-outlined text-[20px]">search</span>
+            </button>
+            <button
+              onClick={() => setShowMobileFilters(true)}
+              className="flex items-center justify-center w-10 h-10 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
+              aria-label="Open filters"
+            >
+              <span className="material-symbols-outlined text-[20px]">tune</span>
+            </button>
+          </div>
+        )}
+        {mobileSearchExpanded && (
+          <MobileSearchPill
+            expanded={true}
+            onExpand={() => setMobileSearchExpanded(true)}
+            onCollapse={() => setMobileSearchExpanded(false)}
+            onSelect={(name) => { handleSelectCounty(name); setMobileSearchExpanded(false); }}
+            map={mapRef.current}
+          />
+        )}
 
         {showInsight && focusedCounty && (
           <AiInsightCard
@@ -328,6 +356,7 @@ function MapPageInner() {
             onCompare={handleStartCompare}
             compareCountyName={compareCounty ?? undefined}
             compareData={comparePointData}
+            narrative={insightData?.narrative}
           />
         )}
         <Breadcrumb
@@ -336,12 +365,14 @@ function MapPageInner() {
           onDeselect={handleDeselect}
         />
         <ChoroplethLegendContainer
-          searchOpen={searchOpen}
           choroplethData={choroplethData}
           coordCoverage={coordCoverage}
           heatmapCrashes={heatmapEnabled ? heatmap.totalCrashes : null}
+          heatmapDisplayed={heatmapEnabled ? heatmap.points.length : null}
           heatmapLoading={heatmapEnabled && heatmap.isLoading}
           countyActive={!!focusedCounty}
+          countyTotalCrashes={inspectedData?.rawCount ?? null}
+          searchOpen={mobileSearchExpanded}
         />
       </section>
 
@@ -385,19 +416,23 @@ export default function MapPage() {
 }
 
 function ChoroplethLegendContainer({
-  searchOpen,
   choroplethData,
   coordCoverage,
   heatmapCrashes,
+  heatmapDisplayed,
   heatmapLoading,
   countyActive,
+  countyTotalCrashes,
+  searchOpen,
 }: {
-  searchOpen?: boolean;
   choroplethData: ChoroplethData;
   coordCoverage?: CoordCoverage | null;
   heatmapCrashes?: number | null;
+  heatmapDisplayed?: number | null;
   heatmapLoading?: boolean;
   countyActive?: boolean;
+  countyTotalCrashes?: number | null;
+  searchOpen?: boolean;
 }) {
   const queryClient = useQueryClient();
   return (
@@ -411,8 +446,139 @@ function ChoroplethLegendContainer({
       searchOpen={searchOpen}
       onRetry={() => queryClient.invalidateQueries({ queryKey: ["choropleth"] })}
       heatmapCrashes={heatmapCrashes}
+      heatmapDisplayed={heatmapDisplayed}
       heatmapLoading={heatmapLoading}
       countyActive={countyActive}
+      countyTotalCrashes={countyTotalCrashes}
     />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mobile search pill — inline at top center, expands to show results below
+// ---------------------------------------------------------------------------
+
+const MOBILE_COUNTY_NAMES = (CA_COUNTIES as unknown as string[]).slice().sort();
+
+function MobileSearchPill({
+  expanded,
+  onExpand,
+  onCollapse,
+  onSelect,
+  map,
+}: {
+  expanded: boolean;
+  onExpand: () => void;
+  onCollapse: () => void;
+  onSelect: (name: string) => void;
+  map: LeafletMap | null;
+}) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const results = query.trim()
+    ? MOBILE_COUNTY_NAMES.filter((n) =>
+        n.toLowerCase().includes(query.toLowerCase())
+      ).slice(0, 4)
+    : [];
+
+  useEffect(() => {
+    if (expanded && inputRef.current) inputRef.current.focus();
+  }, [expanded]);
+
+  // Collapse when map moves
+  useEffect(() => {
+    if (!map) return;
+    const collapse = () => { onCollapse(); setQuery(""); };
+    map.on("movestart", collapse);
+    return () => { map.off("movestart", collapse); };
+  }, [map, onCollapse]);
+
+  // Close on outside tap
+  useEffect(() => {
+    if (!expanded) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onCollapse();
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [expanded, onCollapse]);
+
+  const handleSelect = (name: string) => {
+    onSelect(name);
+    setQuery("");
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={expanded
+        ? "absolute top-3 left-3 right-3 z-20 md:hidden"
+        : "md:hidden"
+      }
+    >
+      <div
+        className={`
+          flex items-center gap-2
+          bg-surface-container-lowest/90 backdrop-blur-md
+          ghost-border shadow-lg
+          ${expanded ? "h-10 rounded-2xl px-3" : "h-10 rounded-full px-3 cursor-pointer"}
+        `}
+        onClick={() => !expanded && onExpand()}
+      >
+        <span className="material-symbols-outlined text-[18px] text-on-surface-variant shrink-0">
+          search
+        </span>
+        {expanded ? (
+          <>
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") { onCollapse(); setQuery(""); }
+                if (e.key === "Enter" && results.length > 0) handleSelect(results[0]);
+              }}
+              placeholder="Search counties…"
+              className="flex-1 bg-transparent text-sm text-on-surface placeholder:text-on-surface-variant/60 outline-none border-none min-w-0"
+            />
+            <button
+              onClick={(e) => { e.stopPropagation(); onCollapse(); setQuery(""); }}
+              className="p-0.5 rounded-full"
+            >
+              <span className="material-symbols-outlined text-[16px] text-on-surface-variant">close</span>
+            </button>
+          </>
+        ) : (
+          <span className="text-[11px] text-on-surface-variant font-medium">Counties</span>
+        )}
+      </div>
+
+      {expanded && results.length > 0 && (
+        <div className="mt-1.5 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg overflow-hidden">
+          {results.map((name) => (
+            <button
+              key={name}
+              onClick={() => handleSelect(name)}
+              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-on-surface text-left hover:bg-surface-container transition-colors"
+            >
+              <span className="material-symbols-outlined text-[14px] text-on-surface-variant">location_on</span>
+              <span>{name} County</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {expanded && query.trim() && results.length === 0 && (
+        <div className="mt-1.5 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg px-3 py-2.5">
+          <p className="text-xs text-on-surface-variant">No match for "{query}"</p>
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
  - Pre-computed per-county AI narratives via Groq ETL pipeline
  - /api/insights/{county_slug} endpoint + frontend insight card
  - Fatal crash overlay (red dots, palette-aware colors)
  - Fix heatmap drift on mobile pinch-to-zoom
  - Mobile search pill, cleaner measure box in county detail mode
  - Compare mode zooms out and restores choropleth
  - Red alert for missing census data on per-capita measures
  - Max zoom raised to 18 for county heatmap

## What does this PR do?

  - Pre-computed per-county AI narratives via Groq ETL pipeline
  - /api/insights/{county_slug} endpoint + frontend insight card
  - Fatal crash overlay (red dots, palette-aware colors)
  - Fix heatmap drift on mobile pinch-to-zoom
  - Mobile search pill, cleaner measure box in county detail mode
  - Compare mode zooms out and restores choropleth
  - Red alert for missing census data on per-capita measures
  - Max zoom raised to 18 for county heatmap

## How to test
  - [ ] Click a county → verify AI narrative appears in insight card
  - [ ] Drill into county → confirm fatal crashes show as red dots
  - [ ] Pinch-to-zoom on mobile → heatmap should not drift
  - [ ] Select a per-capita measure with 2025 → red "No census data" warning appears
  - [ ] Click Compare → map zooms out, choropleth shading returns
  - [ ] Select counties in filter panel → heatmap should NOT activate
  - [ ] Switch palettes → fatal dot colors change (warm=purple, colorblind=orange)

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
