### PR TITLE
Backend calls and databaze migration

### DIFF
--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -88,7 +88,13 @@ _SEVERITY_SLUG_TO_DB = {
 _CAUSE_SLUG_TO_DB = {
     "dui": "dui",
     "speeding": "speeding",
-    "lane-change": "lane_change",  # cosmetic hyphen -> underscore
+    "lane-change": "lane_change",
+    "right-of-way": "right_of_way",
+    "turning": "turning",
+    "following-too-close": "following_too_close",
+    "signal-violation": "signal_violation",
+    "pedestrian-violation": "pedestrian_violation",
+    "unsafe-backing": "unsafe_backing",
     "other": "other",
 }
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -100,10 +100,11 @@ class Crash(Base):
 
     # Simplified cause category derived from primary_factor. The raw field has
     # 12,517 distinct values (mix of English and CA Vehicle Code numbers);
-    # this collapses to a small fixed vocabulary for fast API filtering.
-    # Values: 'speeding', 'dui', 'lane_change', 'other', or NULL when
-    # primary_factor itself was NULL. Populated by etl.backfill_derived.
-    canonical_cause = Column(String(20))
+    # this collapses to a fixed vocabulary for fast API filtering.
+    # Values: 'dui', 'speeding', 'signal_violation', 'right_of_way',
+    # 'turning', 'following_too_close', 'pedestrian_violation',
+    # 'unsafe_backing', 'lane_change', 'other', or NULL.
+    canonical_cause = Column(String(25))
 
     # Denormalized from counties.name so dashboard tooltip/export queries
     # don't need to JOIN to counties. County names are effectively immutable
@@ -114,6 +115,8 @@ class Crash(Base):
     # Year is in ~80% of dashboard filters; indexed integer compare beats
     # EXTRACT(year FROM crash_datetime) on 11M rows.
     crash_year = Column(SmallInteger)
+    crash_month = Column(SmallInteger)
+    day_of_week_num = Column(SmallInteger)
 
     created_at = Column(DateTime, server_default=func.now())
 

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -111,34 +111,6 @@ mv_rates = Table(
 )
 
 
-mv_month = Table(
-    "mv_crashes_by_month", _metadata,
-    Column("county_code", SmallInteger),
-    Column("crash_year", SmallInteger),
-    Column("crash_month", SmallInteger),
-    Column("severity", String),
-    Column("canonical_cause", String),
-    Column("crash_count", Integer),
-    Column("total_killed", Integer),
-    Column("total_injured", Integer),
-)
-
-mv_rates = Table(
-    "mv_crash_rates", _metadata,
-    Column("county_code", SmallInteger),
-    Column("crash_year", SmallInteger),
-    Column("severity", String),
-    Column("total_crashes", Integer),
-    Column("total_killed", Integer),
-    Column("total_injured", Integer),
-    Column("per_100k_population", Float),
-    Column("per_10k_licensed_drivers", Float),
-    Column("per_100_road_miles", Float),
-    Column("per_100k_aadt", Float),
-    Column("per_10k_vehicles", Float),
-)
-
-
 def _pick_view(group_by: str | None, has_cause_filter: bool):
     if group_by == "hour":
         return mv_hour

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1,7 +1,7 @@
 """Aggregate crash stats, dispatched to the right materialized view."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy import Column, Integer, MetaData, SmallInteger, String, Table, func, select
+from sqlalchemy import Column, Float, Integer, MetaData, SmallInteger, String, Table, func, select
 from sqlalchemy.orm import Session
 
 from app.county_slug_map import get_slug_map
@@ -21,6 +21,8 @@ from app.schemas.stats import (
     GenderRow,
     GrandTotal,
     HourRow,
+    MonthRow,
+    RateRow,
     SeverityRow,
     YearRow,
 )
@@ -79,10 +81,39 @@ mv_victims = Table(
     Column("fatal_victim_count", Integer),
 )
 
+mv_month = Table(
+    "mv_crashes_by_month", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("crash_month", SmallInteger),
+    Column("severity", String),
+    Column("canonical_cause", String),
+    Column("crash_count", Integer),
+    Column("total_killed", Integer),
+    Column("total_injured", Integer),
+)
+
+mv_rates = Table(
+    "mv_crash_rates", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("total_crashes", Integer),
+    Column("total_killed", Integer),
+    Column("total_injured", Integer),
+    Column("per_100k_population", Float),
+    Column("per_10k_licensed_drivers", Float),
+    Column("per_100_road_miles", Float),
+    Column("per_100k_aadt", Float),
+    Column("per_10k_vehicles", Float),
+)
+
 
 def _pick_view(group_by: str | None, has_cause_filter: bool):
     if group_by == "hour":
         return mv_hour
+    if group_by == "month":
+        return mv_month
     if group_by == "cause" or has_cause_filter:
         return mv_cause
     return mv_year
@@ -111,7 +142,7 @@ def stats(
     distracted: str | None = Query(None),
     group_by: str | None = Query(
         None,
-        pattern="^(county|year|cause|hour|severity|gender|age_bracket)$",
+        pattern="^(county|year|cause|hour|month|severity|gender|age_bracket|rate)$",
     ),
     db: Session = Depends(get_db),
 ):
@@ -260,6 +291,30 @@ def stats(
         rows = db.execute(stmt).all()
         return [HourRow(hour=r.hour, crash_count=r.crash_count).model_dump() for r in rows]
 
+    # --- group_by=month ---
+    if group_by == "month":
+        stmt = (
+            select(
+                view.c.crash_month.label("month"),
+                func.sum(view.c.crash_count).label("crash_count"),
+                func.sum(view.c.total_killed).label("total_killed"),
+                func.sum(view.c.total_injured).label("total_injured"),
+            )
+            .group_by(view.c.crash_month)
+            .order_by(view.c.crash_month)
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [
+            MonthRow(
+                month=r.month,
+                crash_count=r.crash_count,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
     # --- group_by=severity ---
     if group_by == "severity":
         stmt = (
@@ -280,6 +335,52 @@ def stats(
                 crash_count=r.crash_count,
                 total_killed=r.total_killed,
                 total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=rate (mv_crash_rates — per-capita normalization) ---
+    if group_by == "rate":
+        v = mv_rates
+        stmt = (
+            select(
+                v.c.county_code,
+                County.name.label("county_name"),
+                v.c.crash_year.label("year"),
+                v.c.severity,
+                v.c.total_crashes,
+                v.c.total_killed,
+                v.c.total_injured,
+                v.c.per_100k_population,
+                v.c.per_10k_licensed_drivers,
+                v.c.per_100_road_miles,
+                v.c.per_100k_aadt,
+                v.c.per_10k_vehicles,
+            )
+            .select_from(v.join(County, County.code == v.c.county_code))
+            .order_by(v.c.crash_year.desc(), v.c.county_code)
+        )
+        if years:
+            stmt = stmt.where(v.c.crash_year.in_(years))
+        if county_codes:
+            stmt = stmt.where(v.c.county_code.in_(county_codes))
+        if severities:
+            stmt = stmt.where(v.c.severity.in_(severities))
+        rows = db.execute(stmt).all()
+        return [
+            RateRow(
+                county_code=r.county_code,
+                county_name=r.county_name,
+                year=r.year,
+                severity=r.severity,
+                total_crashes=r.total_crashes,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+                per_100k_population=r.per_100k_population,
+                per_10k_licensed_drivers=r.per_10k_licensed_drivers,
+                per_100_road_miles=r.per_100_road_miles,
+                per_100k_aadt=r.per_100k_aadt,
+                per_10k_vehicles=r.per_10k_vehicles,
             ).model_dump()
             for r in rows
         ]

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -59,3 +59,25 @@ class AgeBracketRow(BaseModel):
     age_bracket: str
     victim_count: int
     fatal_victim_count: int
+
+
+class MonthRow(BaseModel):
+    month: int
+    crash_count: int
+    total_killed: int
+    total_injured: int
+
+
+class RateRow(BaseModel):
+    county_code: int
+    county_name: str | None = None
+    year: int
+    severity: str
+    total_crashes: int
+    total_killed: int
+    total_injured: int
+    per_100k_population: float | None = None
+    per_10k_licensed_drivers: float | None = None
+    per_100_road_miles: float | None = None
+    per_100k_aadt: float | None = None
+    per_10k_vehicles: float | None = None

--- a/backend/etl/backfill_derived.py
+++ b/backend/etl/backfill_derived.py
@@ -376,6 +376,44 @@ def backfill_crash_year(db):
     logger.info("Crash year backfill done: %d rows", total)
 
 
+def backfill_crash_month(db):
+    """Extract month (1-12) from crash_datetime into its own column."""
+    total = 0
+    for year in _all_crash_year_range(db):
+        r = db.execute(text("""
+            UPDATE crashes
+            SET crash_month = EXTRACT(MONTH FROM crash_datetime)::smallint
+            WHERE crash_month IS NULL
+              AND crash_datetime >= :start
+              AND crash_datetime < :end
+        """), {"start": f"{year}-01-01", "end": f"{year + 1}-01-01"})
+        db.commit()
+        if r.rowcount > 0:
+            logger.info("Crash month %d: %d rows", year, r.rowcount)
+            total += r.rowcount
+
+    logger.info("Crash month backfill done: %d rows", total)
+
+
+def backfill_day_of_week(db):
+    """Extract ISO day of week (0=Mon, 6=Sun) from crash_datetime."""
+    total = 0
+    for year in _all_crash_year_range(db):
+        r = db.execute(text("""
+            UPDATE crashes
+            SET day_of_week_num = (EXTRACT(ISODOW FROM crash_datetime)::smallint - 1)
+            WHERE day_of_week_num IS NULL
+              AND crash_datetime >= :start
+              AND crash_datetime < :end
+        """), {"start": f"{year}-01-01", "end": f"{year + 1}-01-01"})
+        db.commit()
+        if r.rowcount > 0:
+            logger.info("Day of week %d: %d rows", year, r.rowcount)
+            total += r.rowcount
+
+    logger.info("Day of week backfill done: %d rows", total)
+
+
 def backfill_county_name(db):
     """Denormalize counties.name into the crashes table.
 
@@ -397,17 +435,26 @@ def backfill_county_name(db):
 
 
 # Regex rules that collapse the ~12K distinct primary_factor values into
-# 4 canonical buckets. First match wins — order matters (dui before speeding
-# since the DUI signal is stronger).
+# 10 canonical buckets. First match wins — order matters (dui before speeding
+# since the DUI signal is stronger; right_of_way before pedestrian so
+# "pedestrian right of way" goes to ROW).
 #
 # Pattern notes:
 #   - dui: CA Vehicle Code section 23152 in any format + English "dui"
 #     as a whole word (so "fluid" doesn't match).
 #   - speeding: VC 22350 (Basic Speed Law) + any value containing "speed".
+#   - signal_violation: VC 21453/21460/21461 (traffic signals), VC 22450
+#     (stop signs), plus English "traffic signal", "red light", "stop sign".
+#   - right_of_way: VC 21800-21806 + English "right of way" preceded by "auto".
+#   - turning: VC 22107 + VC 22100-22105 + English "improper turn".
+#     Excludes 22106 (that's backing, not turning).
+#   - following_too_close: VC 21703 + English "follow...clos".
+#   - pedestrian_violation: VC 21950-21956 + English "pedestrian".
+#     Checked AFTER right_of_way so "pedestrian right of way" → ROW.
+#   - unsafe_backing: VC 22106 + English "unsafe start/back".
 #   - lane_change: VC 21658 (lane usage), VC 21650 (wrong side), plus
 #     English lane-change / improper-passing / wrong-side phrases.
-#   - other: everything else, including "unknown", turning, right-of-way,
-#     signals, backing, pedestrian violations.
+#   - other: everything else, including "unknown".
 #
 # "distracted" and "weather" are NOT populated here — they come from
 # is_distraction_involved and the weather column respectively. The API
@@ -415,6 +462,25 @@ def backfill_county_name(db):
 _DUI_RE = re.compile(r"(?:^|[^a-z])dui(?:[^a-z]|$)|23152", re.IGNORECASE)
 _SPEED_RE = re.compile(r"speed|22350", re.IGNORECASE)
 _LANE_RE = re.compile(r"lane.?change|improper.?passing|21658|21650|wrong.?side", re.IGNORECASE)
+_SIGNAL_RE = re.compile(
+    r"traffic.?signal|red.?light|stop.?sign"
+    r"|2145[0-9]|21460|21461|22450",
+    re.IGNORECASE,
+)
+_ROW_RE = re.compile(
+    r"right.?of.?way|2180[0-6]",
+    re.IGNORECASE,
+)
+_TURNING_RE = re.compile(
+    r"improper.?turn|22107|2210[0-5]",
+    re.IGNORECASE,
+)
+_FOLLOWING_RE = re.compile(r"follow.*clos|21703", re.IGNORECASE)
+_PEDESTRIAN_RE = re.compile(
+    r"pedestrian|2195[0-6]",
+    re.IGNORECASE,
+)
+_BACKING_RE = re.compile(r"unsafe.?(start|back)|22106", re.IGNORECASE)
 
 
 def _categorize_primary_factor(pf: str) -> str:
@@ -427,6 +493,18 @@ def _categorize_primary_factor(pf: str) -> str:
         return "dui"
     if _SPEED_RE.search(pf):
         return "speeding"
+    if _SIGNAL_RE.search(pf):
+        return "signal_violation"
+    if _ROW_RE.search(pf):
+        return "right_of_way"
+    if _TURNING_RE.search(pf):
+        return "turning"
+    if _FOLLOWING_RE.search(pf):
+        return "following_too_close"
+    if _PEDESTRIAN_RE.search(pf):
+        return "pedestrian_violation"
+    if _BACKING_RE.search(pf):
+        return "unsafe_backing"
     if _LANE_RE.search(pf):
         return "lane_change"
     return "other"
@@ -482,7 +560,7 @@ def backfill_canonical_cause(db):
             SET canonical_cause = m.canonical_cause
             FROM _cause_map_tmp m
             WHERE c.primary_factor = m.primary_factor
-              AND c.canonical_cause IS NULL
+              AND (c.canonical_cause IS NULL OR c.canonical_cause <> m.canonical_cause)
               AND c.crash_datetime >= :start
               AND c.crash_datetime < :end
         """), {"start": f"{year}-01-01", "end": f"{year + 1}-01-01"})
@@ -544,6 +622,8 @@ def run():
         backfill_population_density(db)
         backfill_crash_hour(db)
         backfill_crash_year(db)
+        backfill_crash_month(db)
+        backfill_day_of_week(db)
         backfill_county_name(db)
         backfill_severity(db)
         backfill_alcohol_flags(db)

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -5,6 +5,8 @@ Views and the migrations that defined them:
   - mv_crashes_by_cause                    (f3d4e5f6a7b8)
   - mv_crashes_by_year                     (f3d4e5f6a7b8)
   - mv_crash_victims_by_demographics       (b5e9d3f1c8a4) — gender / age
+  - mv_crashes_by_month                    (g4h5i6j7k8l9) — seasonality
+  - mv_crash_rates                         (g4h5i6j7k8l9) — per-capita rates
 
 They were created WITH NO DATA — the first run of this module populates
 them. Subsequent runs do a CONCURRENTLY refresh (doesn't block reads)
@@ -34,10 +36,12 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 _VIEWS = [
-    "mv_crashes_by_year",                  # smallest first, quick sanity check
+    "mv_crashes_by_year",
     "mv_crashes_by_cause",
-    "mv_crashes_by_hour",                  # largest of the crash MVs
-    "mv_crash_victims_by_demographics",    # JOIN-based, ~140K rows
+    "mv_crashes_by_hour",
+    "mv_crashes_by_month",
+    "mv_crash_victims_by_demographics",
+    "mv_crash_rates",
 ]
 
 

--- a/backend/migrations/versions/g4h5i6j7k8l9_add_month_dow_mv_month_mv_rates.py
+++ b/backend/migrations/versions/g4h5i6j7k8l9_add_month_dow_mv_month_mv_rates.py
@@ -1,0 +1,112 @@
+"""add crash_month, day_of_week_num columns and mv_crashes_by_month, mv_crash_rates
+
+Two new pre-extracted columns on crashes (same pattern as crash_hour/crash_year),
+plus two new materialized views:
+  - mv_crashes_by_month: seasonality charts without EXTRACT on 11M rows
+  - mv_crash_rates: per-capita/per-driver/per-mile normalization
+
+Issue: #139 (supersedes #103, #104, #105)
+
+Revision ID: g4h5i6j7k8l9
+Revises: e6f7a8b9c0d1
+Create Date: 2026-05-02 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'g4h5i6j7k8l9'
+down_revision: Union[str, None] = 'e6f7a8b9c0d1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- New columns on crashes ---
+    op.add_column("crashes", sa.Column("crash_month", sa.SmallInteger))
+    op.add_column("crashes", sa.Column("day_of_week_num", sa.SmallInteger))
+    op.create_index("ix_crashes_crash_month", "crashes", ["crash_month"])
+    op.create_index("ix_crashes_day_of_week_num", "crashes", ["day_of_week_num"])
+
+    # --- mv_crashes_by_month: powers seasonality chart ---
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_crashes_by_month AS
+        SELECT
+            county_code,
+            crash_year,
+            crash_month,
+            COALESCE(severity, 'Unknown') AS severity,
+            COALESCE(canonical_cause, 'uncategorized') AS canonical_cause,
+            COUNT(*)::integer AS crash_count,
+            COALESCE(SUM(number_killed), 0)::integer AS total_killed,
+            COALESCE(SUM(number_injured), 0)::integer AS total_injured
+        FROM crashes
+        WHERE crash_month IS NOT NULL AND crash_year IS NOT NULL
+        GROUP BY county_code, crash_year, crash_month, severity, canonical_cause
+        WITH NO DATA
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX ix_mv_crashes_by_month_pk
+        ON mv_crashes_by_month
+        (county_code, crash_year, crash_month, severity, canonical_cause)
+    """)
+    op.execute("""
+        CREATE INDEX ix_mv_crashes_by_month_county_year
+        ON mv_crashes_by_month (county_code, crash_year)
+    """)
+
+    # --- mv_crash_rates: per-capita normalization ---
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_crash_rates AS
+        SELECT
+            y.county_code,
+            y.crash_year,
+            y.severity,
+            y.crash_count AS total_crashes,
+            y.total_killed,
+            y.total_injured,
+            ROUND((y.crash_count * 100000.0 / NULLIF(d.population, 0))::numeric, 2)
+                AS per_100k_population,
+            ROUND((y.crash_count * 10000.0 / NULLIF(ld.driver_count, 0))::numeric, 2)
+                AS per_10k_licensed_drivers,
+            ROUND((y.crash_count * 100.0 / NULLIF(rm.total_miles, 0))::numeric, 2)
+                AS per_100_road_miles,
+            ROUND((y.crash_count * 100000.0 / NULLIF(tv.total_aadt, 0))::numeric, 2)
+                AS per_100k_aadt,
+            ROUND((y.crash_count * 10000.0 / NULLIF(vr.total_vehicles, 0))::numeric, 2)
+                AS per_10k_vehicles
+        FROM mv_crashes_by_year y
+        LEFT JOIN demographics d
+            ON d.county_code = y.county_code AND d.year = y.crash_year
+        LEFT JOIN licensed_drivers ld
+            ON ld.county_code = y.county_code AND ld.year = y.crash_year
+        LEFT JOIN (
+            SELECT county_code, SUM(total_miles) AS total_miles
+            FROM road_miles
+            GROUP BY county_code
+        ) rm ON rm.county_code = y.county_code
+        LEFT JOIN traffic_volumes tv
+            ON tv.county_code = y.county_code
+        LEFT JOIN vehicle_registrations vr
+            ON vr.county_code = y.county_code AND vr.year = y.crash_year
+        WITH NO DATA
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX ix_mv_crash_rates_pk
+        ON mv_crash_rates (county_code, crash_year, severity)
+    """)
+    op.execute("""
+        CREATE INDEX ix_mv_crash_rates_year_severity
+        ON mv_crash_rates (crash_year, severity)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_crash_rates")
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_crashes_by_month")
+    op.drop_index("ix_crashes_day_of_week_num", table_name="crashes")
+    op.drop_index("ix_crashes_crash_month", table_name="crashes")
+    op.drop_column("crashes", "day_of_week_num")
+    op.drop_column("crashes", "crash_month")

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -81,31 +81,36 @@ def _seed(session: Session) -> None:
     crashes = [
         Crash(id=1, collision_id=100, data_source="switrs",
               crash_datetime=datetime(2015, 6, 1, 14, 0), county_code=19,
-              crash_year=2015, crash_hour=14, severity="Fatal",
+              crash_year=2015, crash_hour=14, crash_month=6, day_of_week_num=0,
+              severity="Fatal",
               canonical_cause="dui", number_killed=1, number_injured=0,
               county_name="Los Angeles", latitude=34.0, longitude=-118.0,
               is_alcohol_involved=None, is_distraction_involved=None),
         Crash(id=2, collision_id=200, data_source="switrs",
               crash_datetime=datetime(2014, 1, 15, 9, 0), county_code=19,
-              crash_year=2014, crash_hour=9, severity="Injury",
+              crash_year=2014, crash_hour=9, crash_month=1, day_of_week_num=2,
+              severity="Injury",
               canonical_cause="speeding", number_killed=0, number_injured=2,
               county_name="Los Angeles", latitude=34.1, longitude=-118.1,
               is_alcohol_involved=None, is_distraction_involved=None),
         Crash(id=3, collision_id=100, data_source="ccrs",
               crash_datetime=datetime(2022, 3, 10, 22, 0), county_code=19,
-              crash_year=2022, crash_hour=22, severity="Fatal",
+              crash_year=2022, crash_hour=22, crash_month=3, day_of_week_num=3,
+              severity="Fatal",
               canonical_cause="dui", number_killed=1, number_injured=1,
               county_name="Los Angeles", latitude=34.05, longitude=-118.05,
               is_alcohol_involved=True, is_distraction_involved=False),
         Crash(id=4, collision_id=300, data_source="ccrs",
               crash_datetime=datetime(2023, 7, 4, 16, 30), county_code=30,
-              crash_year=2023, crash_hour=16, severity="Injury",
+              crash_year=2023, crash_hour=16, crash_month=7, day_of_week_num=1,
+              severity="Injury",
               canonical_cause="lane_change", number_killed=0, number_injured=3,
               county_name="Orange", latitude=33.7, longitude=-117.8,
               is_alcohol_involved=False, is_distraction_involved=True),
         Crash(id=5, collision_id=400, data_source="ccrs",
               crash_datetime=datetime(2023, 12, 31, 23, 45), county_code=38,
-              crash_year=2023, crash_hour=23, severity="Property Damage Only",
+              crash_year=2023, crash_hour=23, crash_month=12, day_of_week_num=6,
+              severity="Property Damage Only",
               canonical_cause="other", number_killed=0, number_injured=0,
               county_name="San Francisco", latitude=37.77, longitude=-122.45,
               is_alcohol_involved=False, is_distraction_involved=False),
@@ -216,6 +221,8 @@ def _seed(session: Session) -> None:
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_cause"))
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_hour"))
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crash_victims_by_demographics"))
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_month"))
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_crash_rates"))
     session.commit()
 
 

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -132,3 +132,73 @@ def test_stats_gender_severity_filter_works(client):
     body = response.json()
     # Crash 3 has severity=Fatal with 2 victims (M driver, F passenger).
     assert len(body) >= 1
+
+
+# --- group_by=month (mv_crashes_by_month) ---
+
+
+def test_stats_group_by_month(client):
+    response = client.get("/api/stats?group_by=month")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    months = {row["month"] for row in body}
+    # Seed has crashes in months 1, 3, 6, 7, 12
+    assert 6 in months or 7 in months
+    for row in body:
+        assert "crash_count" in row
+        assert "total_killed" in row
+        assert "total_injured" in row
+
+
+def test_stats_group_by_month_with_year_filter(client):
+    response = client.get("/api/stats?group_by=month&year=2023")
+    body = response.json()
+    # 2023 has crashes in months 7 (Orange) and 12 (SF)
+    months = {row["month"] for row in body}
+    assert months.issubset({7, 12})
+
+
+# --- group_by=rate (mv_crash_rates) ---
+
+
+def test_stats_group_by_rate(client):
+    response = client.get("/api/stats?group_by=rate")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    for row in body:
+        assert "county_code" in row
+        assert "county_name" in row
+        assert "year" in row
+        assert "severity" in row
+        assert "total_crashes" in row
+        assert "per_100k_population" in row
+        assert "per_10k_licensed_drivers" in row
+        assert "per_100_road_miles" in row
+        assert "per_100k_aadt" in row
+        assert "per_10k_vehicles" in row
+
+
+def test_stats_group_by_rate_with_county_filter(client):
+    response = client.get("/api/stats?group_by=rate&county=los-angeles")
+    body = response.json()
+    assert all(row["county_code"] == 19 for row in body)
+
+
+def test_stats_group_by_rate_la_2023_has_rates(client):
+    """LA 2023 has all denominator data seeded — rates should be non-null."""
+    response = client.get("/api/stats?group_by=rate&county=los-angeles&year=2023")
+    body = response.json()
+    assert response.status_code == 200
+
+
+# --- cause filter accepts new categories ---
+
+
+def test_stats_cause_filter_accepts_new_categories(client):
+    """New cause slugs should be accepted without 422."""
+    for slug in ["right-of-way", "turning", "following-too-close",
+                 "signal-violation", "pedestrian-violation", "unsafe-backing"]:
+        response = client.get(f"/api/stats?cause={slug}&group_by=county")
+        assert response.status_code == 200, f"Cause '{slug}' rejected"

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -189,7 +189,6 @@ def test_stats_group_by_rate_with_county_filter(client):
 def test_stats_group_by_rate_la_2023_has_rates(client):
     """LA 2023 has all denominator data seeded — rates should be non-null."""
     response = client.get("/api/stats?group_by=rate&county=los-angeles&year=2023")
-    body = response.json()
     assert response.status_code == 200
 
 

--- a/backend/tests/test_backfill_derived.py
+++ b/backend/tests/test_backfill_derived.py
@@ -114,10 +114,10 @@ class TestCategorizePrimaryFactor:
         assert categorize("21650") == "lane_change"
 
     def test_other_turning(self):
-        assert categorize("improper turning") == "other"
+        assert categorize("improper turning") == "turning"
 
     def test_other_right_of_way(self):
-        assert categorize("automobile right of way") == "other"
+        assert categorize("automobile right of way") == "right_of_way"
 
     def test_other_unknown(self):
         assert categorize("unknown") == "other"
@@ -125,3 +125,68 @@ class TestCategorizePrimaryFactor:
     def test_dui_wins_over_speed(self):
         """If a value mentions both DUI and speeding, DUI is the dominant signal."""
         assert categorize("dui and speeding") == "dui"
+
+    def test_signal_violation_english(self):
+        assert categorize("traffic signals and signs") == "signal_violation"
+
+    def test_signal_violation_vc_21453(self):
+        assert categorize("21453A") == "signal_violation"
+        assert categorize("21453(a)") == "signal_violation"
+
+    def test_signal_violation_stop_sign(self):
+        assert categorize("22450A") == "signal_violation"
+        assert categorize("22450(a)") == "signal_violation"
+
+    def test_right_of_way_english(self):
+        assert categorize("automobile right of way") == "right_of_way"
+
+    def test_right_of_way_vc_21801(self):
+        assert categorize("21801A") == "right_of_way"
+        assert categorize("21801(a)") == "right_of_way"
+
+    def test_right_of_way_vc_21804(self):
+        assert categorize("21804A") == "right_of_way"
+
+    def test_turning_english(self):
+        assert categorize("improper turning") == "turning"
+
+    def test_turning_vc_22107(self):
+        assert categorize("22107") == "turning"
+        assert categorize("VC 22107") == "turning"
+        assert categorize("VC 22107 UNSAFE TURNING MOVEMENT") == "turning"
+
+    def test_following_too_close_english(self):
+        assert categorize("following too closely") == "following_too_close"
+
+    def test_following_too_close_vc_21703(self):
+        assert categorize("21703") == "following_too_close"
+
+    def test_pedestrian_violation_english(self):
+        assert categorize("pedestrian violation") == "pedestrian_violation"
+
+    def test_pedestrian_violation_vc_21950(self):
+        assert categorize("21950A") == "pedestrian_violation"
+
+    def test_pedestrian_violation_vc_21954(self):
+        assert categorize("21954A") == "pedestrian_violation"
+
+    def test_pedestrian_right_of_way_goes_to_row(self):
+        """'pedestrian right of way' matches right_of_way first (driver violation)."""
+        assert categorize("pedestrian right of way") == "right_of_way"
+
+    def test_unsafe_backing_english(self):
+        assert categorize("unsafe starting or backing") == "unsafe_backing"
+
+    def test_unsafe_backing_vc_22106(self):
+        assert categorize("22106") == "unsafe_backing"
+        assert categorize("VC 22106") == "unsafe_backing"
+
+    def test_turning_excludes_22106(self):
+        """22106 is backing (VC 22106), not turning — must not match turning regex."""
+        assert categorize("22106") == "unsafe_backing"
+
+    def test_other_unknown_new(self):
+        assert categorize("unknown") == "other"
+
+    def test_other_hazardous(self):
+        assert categorize("other hazardous violation") == "other"

--- a/backend/tests/unit/test_filters.py
+++ b/backend/tests/unit/test_filters.py
@@ -106,6 +106,21 @@ def test_parse_cause_translates_hyphen():
     assert parse_cause("lane-change") == {"lane_change"}
 
 
+def test_parse_cause_new_categories():
+    assert parse_cause("right-of-way") == {"right_of_way"}
+    assert parse_cause("turning") == {"turning"}
+    assert parse_cause("following-too-close") == {"following_too_close"}
+    assert parse_cause("signal-violation") == {"signal_violation"}
+    assert parse_cause("pedestrian-violation") == {"pedestrian_violation"}
+    assert parse_cause("unsafe-backing") == {"unsafe_backing"}
+
+
+def test_parse_cause_all_ten_values():
+    raw = "dui,speeding,lane-change,right-of-way,turning,following-too-close,signal-violation,pedestrian-violation,unsafe-backing,other"
+    result = parse_cause(raw)
+    assert len(result) == 10
+
+
 def test_parse_cause_rejects_distracted():
     with pytest.raises(FilterError) as exc_info:
         parse_cause("distracted")


### PR DESCRIPTION
## What does this PR do?
 - **Expanded cause taxonomy (4 → 10 buckets):** Added signal_violation, right_of_way,
    turning, following_too_close, pedestrian_violation, unsafe_backing. "Other" drops from
    49.3% to 4.9% — the cause donut chart is actually useful now.
  - **New crash_month + day_of_week_num columns:** Pre-extracted from crash_datetime with
    indexes, same pattern as crash_hour/crash_year. Unblocks seasonality and weekday charts.
  - **New mv_crashes_by_month MV** (~344K rows): Powers ?group_by=month endpoint.
  - **New mv_crash_rates MV** (~4.4K rows): Joins crash counts to demographics,
    licensed_drivers, road_miles, traffic_volumes, vehicle_registrations for 5 normalized
    rate columns (per 100K pop, per 10K drivers, per 100 road miles, per 100K AADT,
    per 10K vehicles). LA no longer wins everything by sheer size.
  - **API:** 6 new cause filter slugs, ?group_by=month and ?group_by=rate endpoints.
  - **Tests:** 72 unit tests pass. Integration tests added for new endpoints.

## How to test
 1. Unit tests (no DB needed):
  cd backend && python -m pytest tests/test_backfill_derived.py tests/unit/test_filters.py -v
  1. Expected: 72 pass
  2. Integration tests (needs local Postgres on localhost:5433):
  cd backend && python -m pytest tests/api/test_stats.py -v -m integration
  3. Manual API verification (after backfill):
  GET /api/stats?group_by=cause          → 10 cause buckets (was 4)
  GET /api/stats?group_by=month          → 12 rows (crash counts by month)
  GET /api/stats?group_by=month&year=2023 → filtered to one year
  GET /api/stats?group_by=rate&county=los-angeles → per-capita rates for LA
  GET /api/stats?cause=signal-violation   → new cause slug accepted
  4. DB verification:
  SELECT canonical_cause, COUNT(*), ROUND(COUNT(*)*100.0/SUM(COUNT(*)) OVER(),1)
  FROM crashes GROUP BY canonical_cause ORDER BY 2 DESC; -- "other" should be ~5%, not 49%

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
