### PR TITLE
142-frontend-update-filters-statspage-charts-and-about-page-for-enric…

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1,26 +1,30 @@
 """Aggregate crash stats, dispatched to the right materialized view."""
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy import Column, Integer, MetaData, SmallInteger, String, Table, func, select
+from sqlalchemy import Column, Float, Integer, MetaData, SmallInteger, String, Table, func, select
 from sqlalchemy.orm import Session
 
 from app.county_slug_map import get_slug_map
 from app.database import get_db
 from app.filters import (
     FilterError,
+    build_crash_predicates,
     parse_cause,
     parse_county_codes,
     parse_severity,
     parse_year,
 )
-from app.models import County
+from app.models import County, Crash
 from app.schemas.stats import (
     AgeBracketRow,
     CauseRow,
     CountyRow,
+    DayOfWeekRow,
     GenderRow,
     GrandTotal,
     HourRow,
+    MonthRow,
+    RateRow,
     SeverityRow,
     YearRow,
 )
@@ -80,9 +84,39 @@ mv_victims = Table(
 )
 
 
+mv_month = Table(
+    "mv_crashes_by_month", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("crash_month", SmallInteger),
+    Column("severity", String),
+    Column("canonical_cause", String),
+    Column("crash_count", Integer),
+    Column("total_killed", Integer),
+    Column("total_injured", Integer),
+)
+
+mv_rates = Table(
+    "mv_crash_rates", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("total_crashes", Integer),
+    Column("total_killed", Integer),
+    Column("total_injured", Integer),
+    Column("per_100k_population", Float),
+    Column("per_10k_licensed_drivers", Float),
+    Column("per_100_road_miles", Float),
+    Column("per_100k_aadt", Float),
+    Column("per_10k_vehicles", Float),
+)
+
+
 def _pick_view(group_by: str | None, has_cause_filter: bool):
     if group_by == "hour":
         return mv_hour
+    if group_by == "month":
+        return mv_month
     if group_by == "cause" or has_cause_filter:
         return mv_cause
     return mv_year
@@ -111,7 +145,7 @@ def stats(
     distracted: str | None = Query(None),
     group_by: str | None = Query(
         None,
-        pattern="^(county|year|cause|hour|severity|gender|age_bracket)$",
+        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|rate)$",
     ),
     db: Session = Depends(get_db),
 ):
@@ -260,6 +294,58 @@ def stats(
         rows = db.execute(stmt).all()
         return [HourRow(hour=r.hour, crash_count=r.crash_count).model_dump() for r in rows]
 
+    # --- group_by=month ---
+    if group_by == "month":
+        stmt = (
+            select(
+                view.c.crash_month.label("month"),
+                func.sum(view.c.crash_count).label("crash_count"),
+                func.sum(view.c.total_killed).label("total_killed"),
+                func.sum(view.c.total_injured).label("total_injured"),
+            )
+            .group_by(view.c.crash_month)
+            .order_by(view.c.crash_month)
+        )
+        stmt = _apply_filters(stmt, view, years, county_codes, severities, causes)
+        rows = db.execute(stmt).all()
+        return [
+            MonthRow(
+                month=r.month,
+                crash_count=r.crash_count,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=day_of_week (queries crashes table directly, indexed column) ---
+    if group_by == "day_of_week":
+        stmt = (
+            select(
+                Crash.day_of_week_num.label("day_of_week"),
+                func.count().label("crash_count"),
+            )
+            .where(Crash.day_of_week_num.isnot(None))
+            .group_by(Crash.day_of_week_num)
+            .order_by(Crash.day_of_week_num)
+        )
+        preds = build_crash_predicates(
+            years=years,
+            county_codes=county_codes,
+            severities=severities,
+            causes=causes,
+        )
+        for pred in preds:
+            stmt = stmt.where(pred)
+        rows = db.execute(stmt).all()
+        return [
+            DayOfWeekRow(
+                day_of_week=r.day_of_week,
+                crash_count=r.crash_count,
+            ).model_dump()
+            for r in rows
+        ]
+
     # --- group_by=severity ---
     if group_by == "severity":
         stmt = (
@@ -280,6 +366,52 @@ def stats(
                 crash_count=r.crash_count,
                 total_killed=r.total_killed,
                 total_injured=r.total_injured,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=rate (mv_crash_rates — per-capita normalization) ---
+    if group_by == "rate":
+        v = mv_rates
+        stmt = (
+            select(
+                v.c.county_code,
+                County.name.label("county_name"),
+                v.c.crash_year.label("year"),
+                v.c.severity,
+                v.c.total_crashes,
+                v.c.total_killed,
+                v.c.total_injured,
+                v.c.per_100k_population,
+                v.c.per_10k_licensed_drivers,
+                v.c.per_100_road_miles,
+                v.c.per_100k_aadt,
+                v.c.per_10k_vehicles,
+            )
+            .select_from(v.join(County, County.code == v.c.county_code))
+            .order_by(v.c.crash_year.desc(), v.c.county_code)
+        )
+        if years:
+            stmt = stmt.where(v.c.crash_year.in_(years))
+        if county_codes:
+            stmt = stmt.where(v.c.county_code.in_(county_codes))
+        if severities:
+            stmt = stmt.where(v.c.severity.in_(severities))
+        rows = db.execute(stmt).all()
+        return [
+            RateRow(
+                county_code=r.county_code,
+                county_name=r.county_name,
+                year=r.year,
+                severity=r.severity,
+                total_crashes=r.total_crashes,
+                total_killed=r.total_killed,
+                total_injured=r.total_injured,
+                per_100k_population=r.per_100k_population,
+                per_10k_licensed_drivers=r.per_10k_licensed_drivers,
+                per_100_road_miles=r.per_100_road_miles,
+                per_100k_aadt=r.per_100k_aadt,
+                per_10k_vehicles=r.per_10k_vehicles,
             ).model_dump()
             for r in rows
         ]

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -59,3 +59,31 @@ class AgeBracketRow(BaseModel):
     age_bracket: str
     victim_count: int
     fatal_victim_count: int
+
+
+
+class MonthRow(BaseModel):
+    month: int
+    crash_count: int
+    total_killed: int
+    total_injured: int
+
+
+class DayOfWeekRow(BaseModel):
+    day_of_week: int
+    crash_count: int
+
+
+class RateRow(BaseModel):
+    county_code: int
+    county_name: str | None = None
+    year: int
+    severity: str
+    total_crashes: int
+    total_killed: int
+    total_injured: int
+    per_100k_population: float | None = None
+    per_10k_licensed_drivers: float | None = None
+    per_100_road_miles: float | None = None
+    per_100k_aadt: float | None = None
+    per_10k_vehicles: float | None = None

--- a/frontend/src/components/map/AiInsightCard.test.tsx
+++ b/frontend/src/components/map/AiInsightCard.test.tsx
@@ -1,7 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeAll } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import AiInsightCard from "./AiInsightCard";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 import type { ChoroplethPoint } from "../../hooks/useChoroplethData";
 
 const POINT_A: ChoroplethPoint = {

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -49,11 +49,11 @@ function MetricGrid({ data, measureLabel }: { data: ChoroplethPoint; measureLabe
 
 function MetricCell({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-surface-container-low/50 p-2 rounded-lg">
-      <p className="text-[8px] text-on-surface-variant font-bold uppercase tracking-widest mb-0.5">
+    <div className="bg-surface-container-low/50 p-2.5 rounded-lg">
+      <p className="text-[9px] text-on-surface-variant font-bold uppercase tracking-widest mb-1">
         {label}
       </p>
-      <p className="text-sm font-bold text-on-surface">{value}</p>
+      <p className="text-base font-bold text-on-surface">{value}</p>
     </div>
   );
 }
@@ -89,7 +89,9 @@ export default function AiInsightCard({
   compareData,
   narrative,
 }: AiInsightCardProps) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(
+    () => window.matchMedia("(min-width: 768px)").matches,
+  );
   const isComparing = compareMode && compareCountyName && compareData;
 
   return (
@@ -97,28 +99,28 @@ export default function AiInsightCard({
       <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden">
         {/* Collapsed bar — always visible */}
         <div
-          className="flex items-center justify-between px-4 py-2.5 cursor-pointer select-none"
+          className="flex items-center justify-between px-4 py-3 cursor-pointer select-none"
           onClick={() => setExpanded((v) => !v)}
         >
-          <div className="flex items-center gap-3 min-w-0">
-            <h3 className="font-headline text-sm font-bold text-on-surface tracking-tight truncate">
+          <div className="min-w-0">
+            <h3 className="font-headline text-base font-bold text-on-surface tracking-tight truncate">
               {isComparing ? `${countyName} vs ${compareCountyName}` : `${countyName} County`}
             </h3>
             {data && !expanded && (
-              <span className="text-xs text-on-surface-variant hidden sm:inline">
+              <p className="text-[11px] text-on-surface-variant mt-0.5">
                 {fmt(data.rawCount)} crashes · {fmt(data.totalKilled)} killed
-              </span>
+              </p>
             )}
           </div>
-          <div className="flex items-center gap-1 shrink-0">
-            <span className="material-symbols-outlined text-[18px] text-on-surface-variant transition-transform" style={{ transform: expanded ? "rotate(180deg)" : undefined }}>
+          <div className="flex items-center gap-3 shrink-0">
+            <span className="material-symbols-outlined text-[20px] text-on-surface-variant transition-transform p-1" style={{ transform: expanded ? "rotate(180deg)" : undefined }}>
               expand_less
             </span>
             <button
               onClick={(e) => { e.stopPropagation(); onClose(); }}
-              className="p-1 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
+              className="p-2 -mr-1 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
             >
-              <span className="material-symbols-outlined text-[16px]">close</span>
+              <span className="material-symbols-outlined text-[18px]">close</span>
             </button>
           </div>
         </div>

--- a/frontend/src/hooks/useFilterParams.test.ts
+++ b/frontend/src/hooks/useFilterParams.test.ts
@@ -37,8 +37,12 @@ describe("SEVERITIES", () => {
 });
 
 describe("CAUSES", () => {
-  it("has exactly the 4 DB-truthful values", () => {
-    expect(CAUSES.map((c) => c.value)).toEqual(["dui", "speeding", "lane-change", "other"]);
+  it("has exactly the 10 DB-truthful values", () => {
+    expect(CAUSES.map((c) => c.value)).toEqual([
+      "dui", "speeding", "lane-change", "right-of-way", "turning",
+      "following-too-close", "signal-violation", "pedestrian-violation",
+      "unsafe-backing", "other",
+    ]);
   });
 
   it("does not include distracted or weather", () => {

--- a/frontend/src/hooks/useFilterParams.ts
+++ b/frontend/src/hooks/useFilterParams.ts
@@ -36,14 +36,19 @@ export const CA_COUNTIES = [
   "Tehama", "Trinity", "Tulare", "Tuolumne", "Ventura", "Yolo", "Yuba",
 ] as const;
 
-// DB truth: canonical_cause has exactly 4 values (dui | speeding | lane_change | other).
-// "distracted" and "weather" were removed — they don't exist in the DB and
-// caused 422s. The backend maps URL slug "lane-change" → DB "lane_change"
-// (filters.py line 91). Restore distracted/weather when issue #103 expands the taxonomy.
+// DB truth: canonical_cause has 10 values after issue #139 expanded the taxonomy.
+// "distracted" and "weather" are cross-cutting filter facets, not cause buckets.
+// The backend maps URL slugs (hyphens) → DB values (underscores) in filters.py.
 export const CAUSES = [
   { value: "dui", label: "DUI", icon: "local_bar" },
   { value: "speeding", label: "Speeding", icon: "speed" },
   { value: "lane-change", label: "Lane Change", icon: "swap_horiz" },
+  { value: "right-of-way", label: "Right of Way", icon: "priority_high" },
+  { value: "turning", label: "Improper Turn", icon: "turn_right" },
+  { value: "following-too-close", label: "Tailgating", icon: "car_crash" },
+  { value: "signal-violation", label: "Signal Violation", icon: "traffic" },
+  { value: "pedestrian-violation", label: "Pedestrian", icon: "directions_walk" },
+  { value: "unsafe-backing", label: "Unsafe Backing", icon: "keyboard_return" },
   { value: "other", label: "Other", icon: "more_horiz" },
 ] as const;
 

--- a/frontend/src/hooks/useStats.test.tsx
+++ b/frontend/src/hooks/useStats.test.tsx
@@ -73,7 +73,7 @@ describe("useStats", () => {
     });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(spy).toHaveBeenCalledTimes(7);
+    expect(spy).toHaveBeenCalledTimes(10);
     const urls = spy.mock.calls.map((c) => String(c[0]));
     expect(urls.some((u) => u.includes("group_by=year") && u.includes("year=2022%2C2023"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=hour") && u.includes("year=2022%2C2023"))).toBe(true);
@@ -82,6 +82,9 @@ describe("useStats", () => {
     expect(urls.some((u) => u.includes("group_by=severity"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=gender"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=age_bracket"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=month"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=day_of_week"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=rate"))).toBe(true);
   });
 
   it("maps API responses to chart data shapes", async () => {
@@ -96,7 +99,7 @@ describe("useStats", () => {
     expect(data.hourlyData[0]).toEqual({ hour: 0, count: 1000 });
 
     expect(data.yearlyData).toHaveLength(2);
-    expect(data.yearlyData[0]).toEqual({ year: 2022, count: 400_000 });
+    expect(data.yearlyData[0]).toEqual({ year: 2022, count: 400_000, killed: 3800, injured: 120_000 });
 
     expect(data.causesData).toHaveLength(4);
     expect(data.causesData[0]).toEqual({ label: "Speeding", count: 5000 });

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -11,7 +11,7 @@ export type StatsFilters = {
 };
 
 export interface HourlyDataPoint { hour: number; count: number }
-export interface YearlyDataPoint { year: number; count: number }
+export interface YearlyDataPoint { year: number; count: number; killed: number; injured: number }
 export interface CauseDataPoint { label: string; count: number }
 export interface SeverityDataPoint { label: string; count: number }
 export interface GenderDataPoint { label: string; count: number }
@@ -22,6 +22,15 @@ export interface HeroMetrics {
   ksiRatePer100k?: number;
   yoyFatalityChangePct?: number;
 }
+export interface MonthlyDataPoint { month: number; label: string; count: number; killed: number; injured: number }
+export interface DayOfWeekDataPoint { day: number; label: string; count: number }
+export interface RateDataPoint {
+  county_code: number; county_name: string; year: number; severity: string;
+  total_crashes: number; total_killed: number; total_injured: number;
+  per_100k_population: number | null; per_10k_licensed_drivers: number | null;
+  per_100_road_miles: number | null; per_100k_aadt: number | null;
+  per_10k_vehicles: number | null;
+}
 
 export interface StatsData {
   hourlyData: HourlyDataPoint[];
@@ -30,6 +39,9 @@ export interface StatsData {
   severityData: SeverityDataPoint[];
   genderData: GenderDataPoint[];
   ageBracketData: AgeBracketDataPoint[];
+  monthlyData: MonthlyDataPoint[];
+  dayOfWeekData: DayOfWeekDataPoint[];
+  rateData: RateDataPoint[];
   heroMetrics: HeroMetrics;
 }
 
@@ -46,11 +58,25 @@ type SeverityRow = { severity: string; crash_count: number; total_killed: number
 type GenderRow = { gender: string; victim_count: number; fatal_victim_count: number };
 type AgeBracketRow = { age_bracket: string; victim_count: number; fatal_victim_count: number };
 type DemoRow = { county_code: number; year: number; population: number | null };
+type MonthRow = { month: number; crash_count: number; total_killed: number; total_injured: number };
+type DayOfWeekRow = { day_of_week: number; crash_count: number };
+type RateRow = {
+  county_code: number; county_name: string | null; year: number; severity: string;
+  total_crashes: number; total_killed: number; total_injured: number;
+  per_100k_population: number | null; per_10k_licensed_drivers: number | null;
+  per_100_road_miles: number | null; per_100k_aadt: number | null; per_10k_vehicles: number | null;
+};
 
 const CAUSE_LABEL: Record<string, string> = {
   dui: "DUI",
   speeding: "Speeding",
   lane_change: "Lane Change",
+  right_of_way: "Right of Way",
+  turning: "Improper Turn",
+  following_too_close: "Tailgating",
+  signal_violation: "Signal Violation",
+  pedestrian_violation: "Pedestrian",
+  unsafe_backing: "Unsafe Backing",
   other: "Other",
   uncategorized: "Uncategorized",
 };
@@ -65,6 +91,9 @@ const AGE_LABEL: Record<string, string> = {
 };
 
 const AGE_ORDER = ["under_18", "18_24", "25_44", "45_64", "over_65", "unknown"];
+
+const MONTH_LABEL = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DOW_LABEL = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 function severityToSlug(s: string): string {
   return s.toLowerCase().replace(/ /g, "-");
@@ -174,10 +203,22 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
         queryKey: ["stats", "age_bracket", { years: filters.years, severities: filters.severities, counties: filters.counties }],
         queryFn: () => fetchJson<AgeBracketRow[]>(buildVictimUrl("age_bracket", filters)),
       },
+      {
+        queryKey: ["stats", "month", filters],
+        queryFn: () => fetchJson<MonthRow[]>(buildUrl("month", filters)),
+      },
+      {
+        queryKey: ["stats", "day_of_week", filters],
+        queryFn: () => fetchJson<DayOfWeekRow[]>(buildUrl("day_of_week", filters)),
+      },
+      {
+        queryKey: ["stats", "rate", { years: filters.years, counties: filters.counties, severities: filters.severities }],
+        queryFn: () => fetchJson<RateRow[]>(buildUrl("rate", filters)),
+      },
     ],
   });
 
-  const [yearQ, hourQ, causeQ, demoQ, severityQ, genderQ, ageQ] = queries;
+  const [yearQ, hourQ, causeQ, demoQ, severityQ, genderQ, ageQ, monthQ, dowQ, rateQ] = queries;
   const loading = yearQ.isLoading || hourQ.isLoading || causeQ.isLoading;
   const rawError = yearQ.error ?? hourQ.error ?? causeQ.error;
 
@@ -187,6 +228,8 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
     const yearlyData: YearlyDataPoint[] = yearQ.data.map((r) => ({
       year: r.year,
       count: r.crash_count,
+      killed: r.total_killed,
+      injured: r.total_injured,
     }));
 
     const hourlyData: HourlyDataPoint[] = hourQ.data.map((r) => ({
@@ -219,13 +262,42 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
         count: r.victim_count,
       }));
 
+    const monthlyData: MonthlyDataPoint[] = (monthQ.data ?? []).map((r) => ({
+      month: r.month,
+      label: MONTH_LABEL[r.month - 1] ?? String(r.month),
+      count: r.crash_count,
+      killed: r.total_killed,
+      injured: r.total_injured,
+    }));
+
+    const dayOfWeekData: DayOfWeekDataPoint[] = (dowQ.data ?? []).map((r) => ({
+      day: r.day_of_week,
+      label: DOW_LABEL[r.day_of_week] ?? String(r.day_of_week),
+      count: r.crash_count,
+    }));
+
+    const rateData: RateDataPoint[] = (rateQ.data ?? []).map((r) => ({
+      county_code: r.county_code,
+      county_name: r.county_name ?? "Unknown",
+      year: r.year,
+      severity: r.severity,
+      total_crashes: r.total_crashes,
+      total_killed: r.total_killed,
+      total_injured: r.total_injured,
+      per_100k_population: r.per_100k_population,
+      per_10k_licensed_drivers: r.per_10k_licensed_drivers,
+      per_100_road_miles: r.per_100_road_miles,
+      per_100k_aadt: r.per_100k_aadt,
+      per_10k_vehicles: r.per_10k_vehicles,
+    }));
+
     const population = demoQ.data
       ? demoQ.data.reduce((s, r) => s + (r.population ?? 0), 0)
       : null;
     const heroMetrics = computeHeroMetrics(yearQ.data, population);
 
-    return { hourlyData, yearlyData, causesData, severityData, genderData, ageBracketData, heroMetrics };
-  }, [yearQ.data, hourQ.data, causeQ.data, demoQ.data, severityQ.data, genderQ.data, ageQ.data]);
+    return { hourlyData, yearlyData, causesData, severityData, genderData, ageBracketData, monthlyData, dayOfWeekData, rateData, heroMetrics };
+  }, [yearQ.data, hourQ.data, causeQ.data, demoQ.data, severityQ.data, genderQ.data, ageQ.data, monthQ.data, dowQ.data, rateQ.data]);
 
   return {
     data,

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -6,6 +6,7 @@ import {
   BarChart,
   Bar,
   XAxis,
+  YAxis,
   Tooltip,
   ResponsiveContainer,
   Cell,
@@ -13,7 +14,7 @@ import {
   Pie,
   LabelList,
 } from "recharts";
-import { useStats, type HourlyDataPoint, type YearlyDataPoint, type CauseDataPoint } from "../hooks/useStats";
+import { useStats, type HourlyDataPoint, type YearlyDataPoint, type CauseDataPoint, type MonthlyDataPoint, type DayOfWeekDataPoint } from "../hooks/useStats";
 import { useDataQualityDisclaimer } from "../hooks/useDataQualityDisclaimer";
 
 function DataQualityNote({ text }: { text: string }) {
@@ -68,6 +69,29 @@ function CauseTooltip({ active, payload }: { active?: boolean; payload?: { paylo
   );
 }
 
+function MonthTooltip({ active, payload }: { active?: boolean; payload?: { payload: MonthlyDataPoint }[] }) {
+  if (!active || !payload?.length) return null;
+  const { label, count, killed, injured } = payload[0].payload;
+  return (
+    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
+      <p className="font-headline font-bold text-on-surface">{label}</p>
+      <p className="text-on-surface-variant mt-0.5">{count.toLocaleString()} incidents</p>
+      <p className="text-on-surface-variant">{killed.toLocaleString()} killed · {injured.toLocaleString()} injured</p>
+    </div>
+  );
+}
+
+function DowTooltip({ active, payload }: { active?: boolean; payload?: { payload: DayOfWeekDataPoint }[] }) {
+  if (!active || !payload?.length) return null;
+  const { label, count } = payload[0].payload;
+  return (
+    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
+      <p className="font-headline font-bold text-on-surface">{label}</p>
+      <p className="text-on-surface-variant mt-0.5">{count.toLocaleString()} incidents</p>
+    </div>
+  );
+}
+
 export default function StatsPage() {
   const [isMobile, setIsMobile] = useState(() => window.matchMedia("(max-width: 768px)").matches);
   useEffect(() => {
@@ -108,8 +132,18 @@ export default function StatsPage() {
   const clrTertiary          = token("--tertiary");
 
   const causeColorMap: Record<string, string> = isDark
-    ? { "Other": "#8b8b9a", "Speeding": "#c27862", "Lane Change": "#6b8fa3", "DUI": "#a368a0", "Uncategorized": "#5c7b5c" }
-    : { "Other": "#78716c", "Speeding": "#b45309", "Lane Change": "#4a7a8c", "DUI": "#7e3794", "Uncategorized": "#4a7a52" };
+    ? {
+        "DUI": "#a368a0", "Speeding": "#c27862", "Lane Change": "#6b8fa3",
+        "Right of Way": "#7ba088", "Improper Turn": "#b89a6b", "Tailgating": "#8e7cc3",
+        "Signal Violation": "#c28a8a", "Pedestrian": "#6baab5", "Unsafe Backing": "#a0a06b",
+        "Other": "#8b8b9a", "Uncategorized": "#5c7b5c",
+      }
+    : {
+        "DUI": "#7e3794", "Speeding": "#b45309", "Lane Change": "#4a7a8c",
+        "Right of Way": "#3d7a5c", "Improper Turn": "#8a6d3b", "Tailgating": "#5b4fa0",
+        "Signal Violation": "#994444", "Pedestrian": "#2d7d8a", "Unsafe Backing": "#6b6b2e",
+        "Other": "#78716c", "Uncategorized": "#4a7a52",
+      };
 
   const severityColorMap: Record<string, string> = isDark
     ? { "Fatal": "#c25560", "Injury": "#b0a050", "Property Damage Only": "#6b8fa3" }
@@ -129,18 +163,24 @@ export default function StatsPage() {
   }
 
   // Build typed chips so each one knows how to remove itself.
-  // Collapse "all selected" into a single summary chip.
+  // "All X" chips open the filter panel instead of removing — they have no onRemove.
   const sortedYears = [...years].sort((a, b) => a - b);
-  type Chip = { label: string; onRemove: () => void };
+  type Chip = { label: string; onRemove?: () => void; onOpen?: () => void };
 
-  const yearChips: Chip[] = years.size === YEARS.length
-    ? [{ label: "All Years", onRemove: () => filters.clearYears() }]
+  const openFilters = () => setShowMobileFilters(true);
+
+  const countyChips: Chip[] = counties.size === 0
+    ? [{ label: "All Counties", onOpen: openFilters }]
+    : [...counties].sort().map((c) => ({ label: c, onRemove: () => filters.toggleCounty(c) }));
+
+  const yearChips: Chip[] = years.size === 0 || years.size === YEARS.length
+    ? [{ label: years.size === 0 ? "All Years" : "All Years", onOpen: openFilters }]
     : sortedYears.length >= 3 && sortedYears.every((y, i) => i === 0 || y === sortedYears[i - 1] + 1)
       ? [{ label: `${sortedYears[0]}–${sortedYears[sortedYears.length - 1]}`, onRemove: () => filters.clearYears() }]
       : sortedYears.map((y) => ({ label: String(y), onRemove: () => filters.toggleYear(y) }));
 
-  const severityChips: Chip[] = severities.size === SEVERITIES.length
-    ? [{ label: "All Severities", onRemove: () => filters.clearSeverities() }]
+  const severityChips: Chip[] = severities.size === 0 || severities.size === SEVERITIES.length
+    ? [{ label: "All Severities", onOpen: openFilters }]
     : [...severities].map((s) => ({ label: s, onRemove: () => filters.toggleSeverity(s) }));
 
   // Display label lookup for cause values (URL slug → human label)
@@ -148,11 +188,17 @@ export default function StatsPage() {
     "dui": "DUI",
     "speeding": "Speeding",
     "lane-change": "Lane Change",
+    "right-of-way": "Right of Way",
+    "turning": "Improper Turn",
+    "following-too-close": "Tailgating",
+    "signal-violation": "Signal Violation",
+    "pedestrian-violation": "Pedestrian",
+    "unsafe-backing": "Unsafe Backing",
     "other": "Other",
   };
 
-  const causeChips: Chip[] = causes.size === CAUSE_OPTIONS.length
-    ? [{ label: "All Causes", onRemove: () => filters.clearCauses() }]
+  const causeChips: Chip[] = causes.size === 0 || causes.size === CAUSE_OPTIONS.length
+    ? [{ label: "All Causes", onOpen: openFilters }]
     : [...causes].sort().map((c) => ({ label: CAUSE_LABEL[c] ?? c, onRemove: () => filters.toggleCause(c) }));
 
   const involvementChips: Chip[] = [
@@ -161,7 +207,7 @@ export default function StatsPage() {
   ];
 
   const chips: Chip[] = [
-    ...[...counties].sort().map((c) => ({ label: c, onRemove: () => filters.toggleCounty(c) })),
+    ...countyChips,
     ...yearChips,
     ...causeChips,
     ...severityChips,
@@ -174,6 +220,9 @@ export default function StatsPage() {
   const severityData   = data?.severityData   ?? [];
   const genderData     = data?.genderData     ?? [];
   const ageBracketData = data?.ageBracketData ?? [];
+  const monthlyData    = data?.monthlyData    ?? [];
+  const dayOfWeekData  = data?.dayOfWeekData  ?? [];
+  const rateData       = data?.rateData       ?? [];
   const heroMetrics    = data?.heroMetrics    ?? {};
 
   const { totalIncidents, incidentYoYPct, ksiRatePer100k, yoyFatalityChangePct } = heroMetrics;
@@ -189,6 +238,22 @@ export default function StatsPage() {
     ...d,
     pct: causeTotal > 0 ? Math.round((d.count / causeTotal) * 100) : 0,
   }));
+
+  const peakMonthIndex = monthlyData.length
+    ? monthlyData.reduce((maxIdx, d, i, arr) => (d.count > arr[maxIdx].count ? i : maxIdx), 0)
+    : 0;
+  const peakDowIndex = dayOfWeekData.length
+    ? dayOfWeekData.reduce((maxIdx, d, i, arr) => (d.count > arr[maxIdx].count ? i : maxIdx), 0)
+    : 0;
+
+  const sortedRateData = useMemo(() => {
+    if (!rateData.length) return [];
+    return [...rateData].sort((a, b) => {
+      if (a.county_name !== b.county_name) return a.county_name.localeCompare(b.county_name);
+      if (a.year !== b.year) return b.year - a.year;
+      return a.severity.localeCompare(b.severity);
+    });
+  }, [rateData]);
 
   const sevTotal    = severityData.reduce((sum, d) => sum + d.count, 0);
   const sevWithPct  = severityData.map((d) => ({
@@ -209,20 +274,32 @@ export default function StatsPage() {
           </span>
           <div className="flex items-center gap-2 flex-shrink-0">
             {chips.map((chip) => (
-              <span
-                key={chip.label}
-                className="inline-flex items-center gap-1 bg-surface-container-highest px-3 py-1 rounded-full text-xs font-medium text-on-surface whitespace-nowrap"
-              >
-                {chip.label}
-                <button
-                  type="button"
-                  aria-label={`Remove ${chip.label} filter`}
-                  onClick={chip.onRemove}
-                  className="hover:text-error transition-colors"
+              chip.onRemove ? (
+                <span
+                  key={chip.label}
+                  className="inline-flex items-center gap-1 bg-surface-container-highest px-3 py-1 rounded-full text-xs font-medium text-on-surface whitespace-nowrap"
                 >
-                  <span className="material-symbols-outlined text-[16px]">close</span>
+                  {chip.label}
+                  <button
+                    type="button"
+                    aria-label={`Remove ${chip.label} filter`}
+                    onClick={chip.onRemove}
+                    className="hover:text-error transition-colors"
+                  >
+                    <span className="material-symbols-outlined text-[16px]">close</span>
+                  </button>
+                </span>
+              ) : (
+                <button
+                  key={chip.label}
+                  type="button"
+                  onClick={chip.onOpen}
+                  className="inline-flex items-center gap-1 bg-surface-container-high px-3 py-1 rounded-full text-xs font-medium text-on-surface-variant whitespace-nowrap hover:text-on-surface transition-colors"
+                >
+                  {chip.label}
+                  <span className="material-symbols-outlined text-[14px]">tune</span>
                 </button>
-              </span>
+              )
             ))}
           </div>
         </div>
@@ -371,7 +448,7 @@ export default function StatsPage() {
             <div className="h-40 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
           ) : error ? (
             <div className="h-40 flex items-center justify-center text-error text-sm">Failed to load data.</div>
-          ) : (
+          ) : causesWithPct.length <= 5 ? (
             <>
               <ResponsiveContainer width="100%" height={isMobile ? 200 : 160}>
                 <PieChart>
@@ -407,6 +484,26 @@ export default function StatsPage() {
                 ))}
               </div>
             </>
+          ) : (
+            <ResponsiveContainer width="100%" height={Math.max(200, causesWithPct.length * 32)}>
+              <BarChart data={[...causesWithPct].sort((a, b) => b.count - a.count)} layout="vertical" margin={{ top: 0, right: 20, left: 0, bottom: 0 }}>
+                <XAxis type="number" hide />
+                <YAxis
+                  type="category"
+                  dataKey="label"
+                  width={100}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
+                />
+                <Tooltip content={<CauseTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
+                <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={18}>
+                  {[...causesWithPct].sort((a, b) => b.count - a.count).map((c) => (
+                    <Cell key={c.label} fill={causeColor(c.label)} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
           )}
         </div>
 
@@ -415,10 +512,10 @@ export default function StatsPage() {
           <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 gap-4">
             <div>
               <h3 className="text-on-surface font-headline font-bold text-xl leading-tight">
-                Incidents by Year ({yearlyData[0]?.year}-{yearlyData[yearlyData.length - 1]?.year})
+                Incidents by Year{yearlyData.length >= 2 ? ` (${yearlyData[0]?.year}–${yearlyData[yearlyData.length - 1]?.year})` : ""}
               </h3>
               <p className="text-on-surface-variant text-sm">
-                Longitudinal dataset showing historical trends
+                {yearlyData.length < 3 ? "Year-over-year summary" : "Longitudinal dataset showing historical trends"}
               </p>
             </div>
           </div>
@@ -426,6 +523,18 @@ export default function StatsPage() {
             <div className="h-64 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
           ) : error ? (
             <div className="h-64 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+          ) : yearlyData.length < 3 ? (
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {yearlyData.map((yr) => (
+                <div key={yr.year} className="bg-surface-container-low rounded-lg p-5">
+                  <p className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-3">{yr.year}</p>
+                  <p className="text-3xl font-headline font-bold text-on-surface tracking-tight">{yr.count.toLocaleString()}</p>
+                  <p className="text-[10px] text-on-surface-variant uppercase tracking-widest font-semibold mt-2">
+                    {yr.killed.toLocaleString()} killed · {yr.injured.toLocaleString()} injured
+                  </p>
+                </div>
+              ))}
+            </div>
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 200 : 256}>
               <BarChart data={yearlyData} barCategoryGap="15%" margin={{ top: 24, right: 0, left: 0, bottom: 0 }}>
@@ -469,11 +578,103 @@ export default function StatsPage() {
               </BarChart>
             </ResponsiveContainer>
           )}
-          <p className="mt-6 text-[10px] text-on-surface-variant italic leading-relaxed">
-            * Note: 2018 data represents a statistically significant anomaly due
-            to regional reporting calibration. Data accuracy remains within 99.4%
-            confidence interval.
-          </p>
+          {yearlyData.length >= 3 && (
+            <p className="mt-6 text-[10px] text-on-surface-variant italic leading-relaxed">
+              * Note: 2018 data represents a statistically significant anomaly due
+              to regional reporting calibration. Data accuracy remains within 99.4%
+              confidence interval.
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* Temporal Patterns Grid */}
+      <section className="grid grid-cols-12 gap-4 md:gap-6">
+        {/* Monthly Seasonality */}
+        <div className="col-span-12 md:col-span-8 bg-surface-container-lowest rounded-lg p-5 md:p-8 ambient-shadow">
+          <div className="flex justify-between items-start mb-6">
+            <div>
+              <h3 className="text-on-surface font-headline font-bold text-lg leading-tight">
+                Crashes by Month
+              </h3>
+              <p className="text-on-surface-variant text-xs font-medium">
+                Seasonal distribution across calendar year
+              </p>
+            </div>
+          </div>
+          {loading ? (
+            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+          ) : error ? (
+            <div className="h-48 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
+              <BarChart data={monthlyData} barCategoryGap="10%" margin={{ top: 8, right: 20, left: 10, bottom: 0 }}>
+                <XAxis
+                  dataKey="label"
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
+                />
+                <Tooltip content={<MonthTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
+                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
+                  {monthlyData.map((_, i) => (
+                    <Cell key={i} fill={i === peakMonthIndex ? clrPrimary : clrPrimaryContainer} />
+                  ))}
+                  <LabelList
+                    dataKey="count"
+                    position="top"
+                    content={(props) => {
+                      const { x, y, width, index } = props as { x: number; y: number; width: number; index: number };
+                      if (index !== peakMonthIndex) return null;
+                      return (
+                        <text
+                          x={Number(x) + Number(width) / 2}
+                          y={Number(y) - 4}
+                          textAnchor="middle"
+                          fill={clrPrimary}
+                          fontSize={8}
+                          fontWeight={700}
+                          fontFamily="Inter, sans-serif"
+                          letterSpacing={1}
+                        >
+                          PEAK
+                        </text>
+                      );
+                    }}
+                  />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* Day of Week */}
+        <div className="col-span-12 md:col-span-4 bg-surface-container-lowest rounded-lg p-5 md:p-8 ambient-shadow">
+          <h3 className="text-on-surface font-headline font-bold text-lg mb-4 leading-tight">
+            Day of Week
+          </h3>
+          {loading ? (
+            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+          ) : error ? (
+            <div className="h-48 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
+              <BarChart data={dayOfWeekData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                <XAxis
+                  dataKey="label"
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
+                />
+                <Tooltip content={<DowTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
+                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
+                  {dayOfWeekData.map((_, i) => (
+                    <Cell key={i} fill={i === peakDowIndex ? clrPrimary : clrPrimaryContainer} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </div>
       </section>
 
@@ -561,10 +762,12 @@ export default function StatsPage() {
                   content={({ active, payload }) => {
                     if (!active || !payload?.length) return null;
                     const d = payload[0].payload as { label: string; count: number };
+                    const total = genderData.reduce((s, g) => s + g.count, 0);
+                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
                     return (
                       <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
                         <p className="font-headline font-bold text-on-surface">{d.label}</p>
-                        <p className="text-on-surface-variant mt-0.5">{d.count.toLocaleString()} victims</p>
+                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} victims</p>
                       </div>
                     );
                   }}
@@ -614,10 +817,12 @@ export default function StatsPage() {
                   content={({ active, payload }) => {
                     if (!active || !payload?.length) return null;
                     const d = payload[0].payload as { label: string; count: number };
+                    const total = ageBracketData.reduce((s, a) => s + a.count, 0);
+                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
                     return (
                       <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
                         <p className="font-headline font-bold text-on-surface">{d.label}</p>
-                        <p className="text-on-surface-variant mt-0.5">{d.count.toLocaleString()} victims</p>
+                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} victims</p>
                       </div>
                     );
                   }}
@@ -629,6 +834,73 @@ export default function StatsPage() {
           )}
         </div>
       </section>
+
+      {/* Per-Capita Rates Table */}
+      {rateData.length > 0 && (
+        <section className="bg-surface-container-lowest rounded-lg p-5 md:p-8 ambient-shadow">
+          <div className="mb-6">
+            <h3 className="text-on-surface font-headline font-bold text-xl leading-tight">
+              Per-Capita Crash Rates
+            </h3>
+            <p className="text-on-surface-variant text-sm mt-1">
+              Normalized rates for cross-county comparison
+            </p>
+          </div>
+          <div className="space-y-1">
+            {Object.entries(
+              sortedRateData.reduce<Record<string, typeof sortedRateData>>((acc, r) => {
+                (acc[r.county_name] ??= []).push(r);
+                return acc;
+              }, {}),
+            ).map(([county, rows]) => (
+              <details key={county} className="group">
+                <summary className="flex items-center gap-2 px-3 py-2.5 cursor-pointer select-none hover:bg-surface-container-low/40 rounded transition-colors">
+                  <span className="material-symbols-outlined text-[16px] text-on-surface-variant transition-transform group-open:rotate-90">
+                    chevron_right
+                  </span>
+                  <span className="font-headline font-bold text-sm text-on-surface">{county}</span>
+                  <span className="text-[10px] text-on-surface-variant uppercase tracking-widest font-semibold">
+                    {rows.length} {rows.length === 1 ? "row" : "rows"}
+                  </span>
+                </summary>
+                <div className="overflow-x-auto ml-6 mb-2">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="text-left text-on-surface-variant uppercase tracking-widest font-semibold">
+                        <th className="px-3 py-1.5">Year</th>
+                        <th className="px-3 py-1.5">Severity</th>
+                        <th className="px-3 py-1.5">Crashes</th>
+                        <th className="px-3 py-1.5">Per 100K Pop</th>
+                        <th className="px-3 py-1.5">Per 10K Drivers</th>
+                        <th className="px-3 py-1.5">Per 100 Mi</th>
+                        <th className="px-3 py-1.5">Per 100K AADT</th>
+                        <th className="px-3 py-1.5">Per 10K Vehicles</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rows.map((r, i) => (
+                        <tr
+                          key={`${r.year}-${r.severity}`}
+                          className={i % 2 === 0 ? "bg-surface-container-lowest" : "bg-surface-container-low/40"}
+                        >
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.year}</td>
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.severity}</td>
+                          <td className="px-3 py-1.5 text-on-surface font-bold">{r.total_crashes.toLocaleString()}</td>
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.per_100k_population?.toFixed(1) ?? "—"}</td>
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.per_10k_licensed_drivers?.toFixed(1) ?? "—"}</td>
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.per_100_road_miles?.toFixed(1) ?? "—"}</td>
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.per_100k_aadt?.toFixed(1) ?? "—"}</td>
+                          <td className="px-3 py-1.5 text-on-surface-variant">{r.per_10k_vehicles?.toFixed(1) ?? "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </details>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Methodology Footer */}
       <section className="border-t border-outline-variant/15 pt-12 pb-16 opacity-60 hover:opacity-100 transition-opacity">


### PR DESCRIPTION
  ## What does this PR do?

  - Expands cause filter panel from 4 → 10 categories with Material Symbols icons (right-of-way, turning, tailgating,
  signal violation, pedestrian, unsafe backing)
  - Adds monthly seasonality bar chart (12 bars, peak highlighted)
  - Adds day-of-week bar chart (Mon-Sun) + new backend `?group_by=day_of_week` endpoint
  - Adds collapsible per-capita crash rates table grouped by county (per 100K pop, per 10K drivers, per 100 road miles,
  per 100K AADT, per 10K vehicles)
  - Cause chart dynamically switches between donut (≤5 causes selected) and horizontal bar (6+)
  - Filter chips now always show "All Counties" / "All Causes" / "All Severities" in default state — clicking opens
  filter panel
  - AiInsightCard: larger touch targets for expand/close on mobile, stacked layout for county name + stats, auto-expands
   on desktop
  - Victims by Gender and Victims by Age tooltips now show percentage
  - Incidents by Year shows summary cards instead of chart when <3 years selected

  Depends on: PR #143 (backend enrichment)

  How to test:

  ## How to test
  - [ ] Open StatsPage — verify 10 cause chips in filter panel with correct icons
  - [ ] With no filters applied, verify "All Counties", "All Years", "All Causes", "All Severities" chips appear —
  clicking opens filter panel
  - [ ] Select ≤5 causes → donut chart; select 6+ → horizontal bar chart
  - [ ] Verify monthly chart shows 12 bars (Jan-Dec) with peak labeled
  - [ ] Verify day-of-week chart shows 7 bars (Mon-Sun)
  - [ ] Scroll to Per-Capita Crash Rates — click county to expand, verify all 5 rate columns
  - [ ] Select only 1-2 years → verify Incidents by Year shows summary cards instead of chart
  - [ ] Toggle dark mode — verify all chart colors update
  - [ ] On mobile: tap a county on map → verify expand/close buttons are easy to tap separately
  - [ ] On mobile: verify collapsed card shows crash totals below county name
  - [ ] Hover on Gender/Age chart bars → tooltip shows percentage

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
