### PR TITLE
ci: run alembic migrations on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build and restart backend
         run: docker compose -f docker-compose.prod.yml up --build -d
 
+      - name: Run database migrations
+        run: docker compose -f docker-compose.prod.yml exec -T backend alembic upgrade head
+
       - name: Verify backend is healthy
         run: |
           for i in 1 2 3 4 5; do


### PR DESCRIPTION
Adds alembic upgrade head step to deploy workflow so new migrations run automatically on push to main. This was missing — caused the map to break after merging #143 (new materialized views never got created on prod).