### PR TITLE
Skeleton primitives + Stats loading/error states (partial #50, #51)

### DIFF
--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,31 @@
+interface EmptyStateProps {
+  /** Material Symbols name. Defaults to a generic empty-inbox glyph. */
+  icon?: string;
+  /** Optional headline above the description. */
+  title?: string;
+  /** Required muted explanation of why nothing is shown. */
+  description: string;
+  className?: string;
+}
+
+export function EmptyState({
+  icon = "inbox",
+  title,
+  description,
+  className = "",
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className={`flex flex-col items-center justify-center gap-2 text-center px-4 text-on-surface-variant ${className}`}
+    >
+      <span className="material-symbols-outlined text-[28px] opacity-40" aria-hidden="true">
+        {icon}
+      </span>
+      {title && (
+        <p className="font-headline font-bold text-sm text-on-surface">{title}</p>
+      )}
+      <p className="text-sm leading-relaxed max-w-xs">{description}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/ErrorState.tsx
+++ b/frontend/src/components/ui/ErrorState.tsx
@@ -1,0 +1,39 @@
+interface ErrorStateProps {
+  icon?: string;
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  icon = "error",
+  title = "Couldn't load data",
+  description = "Something went wrong. Please try again.",
+  onRetry,
+  className = "",
+}: ErrorStateProps) {
+  return (
+    <div
+      role="alert"
+      className={`flex flex-col items-center justify-center gap-3 text-center px-4 text-on-surface-variant ${className}`}
+    >
+      <span className="material-symbols-outlined text-[28px] opacity-40 text-error" aria-hidden="true">
+        {icon}
+      </span>
+      <div>
+        <p className="font-headline font-bold text-sm text-on-surface">{title}</p>
+        <p className="text-sm leading-relaxed mt-0.5">{description}</p>
+      </div>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="bg-primary-container text-on-primary-container px-4 py-1.5 rounded-md text-xs font-bold uppercase tracking-widest hover:opacity-90 transition-opacity"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,15 @@
+import { type HTMLAttributes } from "react";
+
+/**
+ * Pulsing placeholder block for loading states.
+ * Compose with Tailwind sizing classes (e.g. `h-48 w-full`).
+ */
+export function Skeleton({ className = "", ...rest }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`bg-surface-container-high animate-pulse rounded-md ${className}`}
+      {...rest}
+    />
+  );
+}

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -49,6 +49,7 @@ export interface UseStatsResult {
   data: StatsData | null;
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 type YearRow = { year: number; crash_count: number; total_killed: number; total_injured: number };
@@ -303,5 +304,6 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
     data,
     loading,
     error: rawError ? String(rawError) : null,
+    refetch: () => queries.forEach((q) => q.refetch()),
   };
 }

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -16,6 +16,9 @@ import {
 } from "recharts";
 import { useStats, type HourlyDataPoint, type YearlyDataPoint, type CauseDataPoint, type MonthlyDataPoint, type DayOfWeekDataPoint } from "../hooks/useStats";
 import { useDataQualityDisclaimer } from "../hooks/useDataQualityDisclaimer";
+import { Skeleton } from "../components/ui/Skeleton";
+import { EmptyState } from "../components/ui/EmptyState";
+import { ErrorState } from "../components/ui/ErrorState";
 
 function DataQualityNote({ text }: { text: string }) {
   return (
@@ -109,7 +112,7 @@ export default function StatsPage() {
     causes: [...filters.selectedCauses],
     counties: [...filters.selectedCounties].map((c) => c.toLowerCase().replace(/ /g, "-")),
   }), [filters.selectedYears, filters.selectedSeverities, filters.selectedCauses, filters.selectedCounties]);
-  const { data, loading, error } = useStats(statsFilters);
+  const { data, loading, error, refetch } = useStats(statsFilters);
   const dqDisclaimers = useDataQualityDisclaimer(
     [...filters.selectedYears],
     [...filters.selectedCounties],
@@ -321,9 +324,13 @@ export default function StatsPage() {
             Total Incidents
           </p>
           <div className="flex items-baseline gap-3">
-            <h2 className="text-4xl font-headline font-bold text-on-surface tracking-tight">
-              {totalIncidents != null ? totalIncidents.toLocaleString() : "—"}
-            </h2>
+            {loading ? (
+              <Skeleton className="h-10 w-40" />
+            ) : (
+              <h2 className="text-4xl font-headline font-bold text-on-surface tracking-tight">
+                {totalIncidents != null ? totalIncidents.toLocaleString() : "—"}
+              </h2>
+            )}
             {incidentYoYPct != null && (
               <span className={`text-sm font-bold flex items-center ${incidentUp ? "text-error" : "text-primary"}`}>
                 <span className="material-symbols-outlined text-[18px]">
@@ -343,9 +350,13 @@ export default function StatsPage() {
           <p className="text-on-surface-variant text-xs font-semibold uppercase tracking-widest mb-4">
             KSI Rate / 100K Pop.
           </p>
-          <h2 className="text-4xl font-headline font-bold text-on-surface tracking-tight">
-            {ksiRatePer100k != null ? ksiRatePer100k.toFixed(1) : "—"}
-          </h2>
+          {loading ? (
+            <Skeleton className="h-10 w-24" />
+          ) : (
+            <h2 className="text-4xl font-headline font-bold text-on-surface tracking-tight">
+              {ksiRatePer100k != null ? ksiRatePer100k.toFixed(1) : "—"}
+            </h2>
+          )}
           <p className="text-on-surface-variant text-[10px] mt-2 italic">
             Killed &amp; seriously injured per 100K residents
           </p>
@@ -357,11 +368,15 @@ export default function StatsPage() {
             YoY Fatality Change
           </p>
           <div className="flex items-baseline gap-3">
-            <h2 className="text-4xl font-headline font-bold text-on-surface tracking-tight">
-              {yoyFatalityChangePct != null
-                ? `${fatalityUp ? "+" : ""}${yoyFatalityChangePct}%`
-                : "—"}
-            </h2>
+            {loading ? (
+              <Skeleton className="h-10 w-32" />
+            ) : (
+              <h2 className="text-4xl font-headline font-bold text-on-surface tracking-tight">
+                {yoyFatalityChangePct != null
+                  ? `${fatalityUp ? "+" : ""}${yoyFatalityChangePct}%`
+                  : "—"}
+              </h2>
+            )}
             {yoyFatalityChangePct != null && (
               <span className={`text-sm font-bold flex items-center ${fatalityUp ? "text-error" : "text-primary"}`}>
                 <span className="material-symbols-outlined text-[18px]">
@@ -391,9 +406,9 @@ export default function StatsPage() {
             </div>
           </div>
           {loading ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-48 w-full" />
           ) : error ? (
-            <div className="h-48 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+            <ErrorState onRetry={refetch} className="h-48" />
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={hourlyData} barCategoryGap="10%" margin={{ top: 8, right: 20, left: 10, bottom: 0 }}>
@@ -445,9 +460,9 @@ export default function StatsPage() {
             Primary Cause
           </h3>
           {loading ? (
-            <div className="h-40 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-40 w-full" />
           ) : error ? (
-            <div className="h-40 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+            <ErrorState onRetry={refetch} className="h-40" />
           ) : causesWithPct.length <= 5 ? (
             <>
               <ResponsiveContainer width="100%" height={isMobile ? 200 : 160}>
@@ -520,9 +535,9 @@ export default function StatsPage() {
             </div>
           </div>
           {loading ? (
-            <div className="h-64 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-64 w-full" />
           ) : error ? (
-            <div className="h-64 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+            <ErrorState onRetry={refetch} className="h-64" />
           ) : yearlyData.length < 3 ? (
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {yearlyData.map((yr) => (
@@ -603,9 +618,9 @@ export default function StatsPage() {
             </div>
           </div>
           {loading ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-48 w-full" />
           ) : error ? (
-            <div className="h-48 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+            <ErrorState onRetry={refetch} className="h-48" />
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={monthlyData} barCategoryGap="10%" margin={{ top: 8, right: 20, left: 10, bottom: 0 }}>
@@ -654,9 +669,9 @@ export default function StatsPage() {
             Day of Week
           </h3>
           {loading ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-48 w-full" />
           ) : error ? (
-            <div className="h-48 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+            <ErrorState onRetry={refetch} className="h-48" />
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={dayOfWeekData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
@@ -686,9 +701,9 @@ export default function StatsPage() {
             Severity Breakdown
           </h3>
           {loading ? (
-            <div className="h-40 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-40 w-full" />
           ) : error ? (
-            <div className="h-40 flex items-center justify-center text-error text-sm">Failed to load data.</div>
+            <ErrorState onRetry={refetch} className="h-40" />
           ) : (
             <>
               <ResponsiveContainer width="100%" height={isMobile ? 200 : 160}>
@@ -743,12 +758,13 @@ export default function StatsPage() {
             <DataQualityNote text={`Gender recorded for ${Math.round(dqDisclaimers.genderPct)}% of parties. Chart may not be fully representative.`} />
           )}
           {loading ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-48 w-full" />
           ) : !genderData.length ? (
-            <div className="h-48 flex flex-col items-center justify-center gap-2 text-on-surface-variant text-sm text-center px-4">
-              <span className="material-symbols-outlined text-[28px] opacity-40">person_off</span>
-              <span>{dqDisclaimers.preDataOnly ? "Gender data requires 2016 or later (CCRS)." : "No gender data for the current filters."}</span>
-            </div>
+            <EmptyState
+              icon="person_off"
+              description={dqDisclaimers.preDataOnly ? "Gender data requires 2016 or later (CCRS)." : "No gender data for the current filters."}
+              className="h-48"
+            />
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={genderData} barCategoryGap="25%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
@@ -798,12 +814,13 @@ export default function StatsPage() {
             <DataQualityNote text={`Age recorded for ${Math.round(dqDisclaimers.agePct)}% of parties. Chart may not be fully representative.`} />
           )}
           {loading ? (
-            <div className="h-48 flex items-center justify-center text-on-surface-variant text-sm">Loading…</div>
+            <Skeleton className="h-48 w-full" />
           ) : !ageBracketData.length ? (
-            <div className="h-48 flex flex-col items-center justify-center gap-2 text-on-surface-variant text-sm text-center px-4">
-              <span className="material-symbols-outlined text-[28px] opacity-40">person_off</span>
-              <span>{dqDisclaimers.preDataOnly ? "Age data requires 2016 or later (CCRS)." : "No age data for the current filters."}</span>
-            </div>
+            <EmptyState
+              icon="person_off"
+              description={dqDisclaimers.preDataOnly ? "Age data requires 2016 or later (CCRS)." : "No age data for the current filters."}
+              className="h-48"
+            />
           ) : (
             <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
               <BarChart data={ageBracketData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>


### PR DESCRIPTION
…50, #51)

## What does this PR do?
 #50 — Loading skeletons (4/5 done)
  - ✅ Stats hero metrics skeleton
  - ✅ Stats chart area skeleton
  - ✅ Demographics panel skeleton (gender/age share the chart skeleton)
  - ✅ Use surface-container-high pulse animation
  - ⏳ AI insight card loading state — not touched yet

  #51 — Error/empty states (3/6 done)
  - ⏳ Map: "No data for selected filters" overlay
  - ⚠️ Stats: empty state for each chart section — only gender/age got the new EmptyState. The other six charts (Hourly,
   Cause, Yearly, Monthly, DoW, Severity) still render an empty Recharts frame when filters return zero rows. Easy to
  wire up — they just need a chartData.length === 0 ? <EmptyState /> : <chart> branch.
  - ✅ API error state with retry button
  - ⏳ Network offline indicator
  - ✅ Follow Digital Ledger aesthetic
  - ⏳ Pre-2009 ACS county messaging in demographics

## Dependencies
<!-- If this PR requires another PR to merge first, list it here. The bot will block merge until it's done. -->
<!-- Example: Depends on #143 -->


## How to test
 1. npm run dev
  2. Open /stats — on first load you should see grey pulsing blocks where the charts and hero numbers will land, then
  they pop in.
  3. Throttle the network in DevTools (or stop the backend) → reload → you should see the editorial error states with a
  Retry button. Clicking Retry should refetch all stats queries.
  4. Set a filter combo that returns no data (e.g. an obscure year + small county) → gender/age sections should show the
   new EmptyState design.

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
