### PR TITLE
fix(#161): statewide heatmap click-through, metric overflow, and rela…

### DIFF
--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -76,7 +76,7 @@ function MetricCell({ label, value }: { label: string; value: string }) {
       <p className="text-[8px] text-on-surface-variant font-bold uppercase tracking-wider mb-1 leading-tight" style={{ wordBreak: "break-word" }}>
         {label}
       </p>
-      <p className={`${textSize} font-bold text-on-surface`}>{value}</p>
+      <p className={`${textSize} font-bold text-on-surface truncate`}>{value}</p>
     </div>
   );
 }

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -74,7 +74,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
 
   const [mobileExpanded, setMobileExpanded] = useState(false);
 
-  if (!choroplethOn) return null;
+  if (!choroplethOn && !countyActive) return null;
 
   const colors = getPalette(palette, isDark);
   const activeMeasure = MEASURES[measure];

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -93,7 +93,11 @@ export default function CountyBoundaries({
 
   useEffect(() => {
     installHatchPattern();
-  }, []);
+    if (!map.getPane("countyPane")) {
+      const pane = map.createPane("countyPane");
+      pane.style.zIndex = "450";
+    }
+  }, [map]);
 
   useEffect(() => {
     fetch("/ca-counties.geojson")
@@ -218,6 +222,7 @@ export default function CountyBoundaries({
 
     try {
       const layer = L.geoJSON(geojson, {
+        pane: "countyPane",
         style: (feature) => computeStyle(feature ?? { type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [] } }),
         onEachFeature: (feature, featureLayer) => {
           const name = getCountyName(feature);

--- a/frontend/src/components/map/CrashHeatmap.tsx
+++ b/frontend/src/components/map/CrashHeatmap.tsx
@@ -186,6 +186,7 @@ function useFatalLayer(points: HeatmapPoint[], resolution: HeatmapResolution, pa
       _reset: () => void;
     };
     const internals = layer as unknown as HeatInternals;
+
     map.off("zoomanim", internals._animateZoom, layer);
 
     const onZoomStart = () => {

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -118,6 +118,7 @@ export default function LayersPanel() {
                   const next = !otherLayers.heatmapStatewide;
                   setOtherLayer("heatmapStatewide", next);
                   if (next) setChoroplethOn(false);
+                  else setChoroplethOn(true);
                 }}
               />
               {heatmapStatewideL && (

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -97,17 +97,17 @@ export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSi
     batchSize: size,
   });
 
-  useEffect(() => {
-    if (points.length > 0 && batch === currentBatch) {
-      setAllPoints((prev) => currentBatch === 1 ? points : [...prev, ...points]);
-    }
-  }, [points, batch, currentBatch]);
-
   const filterKey = `${params.county}|${params.years.join(",")}|${params.severities.join(",")}|${params.causes.join(",")}|${params.resolution}|${params.mismatchOnly ?? ""}|${params.includeRivers ?? ""}`;
   useEffect(() => {
     setCurrentBatch(1);
     setAllPoints([]);
   }, [filterKey]);
+
+  useEffect(() => {
+    if (points.length > 0 && batch === currentBatch) {
+      setAllPoints((prev) => currentBatch === 1 ? points : [...prev, ...points]);
+    }
+  }, [points, batch, currentBatch, filterKey]);
 
   // Auto-load next batch when current one finishes
   useEffect(() => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -206,6 +206,10 @@
   background: rgb(var(--surface-container));
 }
 
+.leaflet-overlay-pane canvas {
+  pointer-events: none;
+}
+
 .county-focus-tooltip {
   background: rgba(0, 0, 0, 0.8);
   border: none;


### PR DESCRIPTION
## What does this PR do?

  Fixes multiple bugs that surface when using the statewide heatmap view:

  1. Heatmap canvas blocked county clicks — County boundaries now render in a dedicated Leaflet pane (z-index 450) above
   the heatmap canvas, with CSS pointer-events: none on overlay canvases as a fallback. Clicking a county with statewide
   heatmap active now works.
  2. Metric number overflow — Large values in the AI insight card (e.g. "1,234,567") now truncate cleanly instead of
  spilling past the card edge.
  3. Layer toggle UX — Turning off statewide heatmap automatically re-enables shade by measure, instead of leaving both
  off.
  4. Crash detail card hidden — The crash detail legend card now stays visible when a county is selected, even when
  choropleth is off (statewide heatmap mode).
  5. Same-county heatmap reload — Clicking a county, deselecting, then re-clicking the same county now correctly reloads
   the heatmap. React-query returned cached data with the same reference, so the accumulation effect never re-fired.

  Closes #161, #158. Related to #152, #157, #164 (already closed).

  ## Dependencies

  None

  ## How to test

  - Toggle statewide heatmap on, click a county — AI insight card and crash detail card should both appear
  - Click LA County with a wide year range — metric numbers should truncate, not overflow the card
  - Toggle statewide heatmap off — shade by measure should re-enable automatically
  - Click a county, click empty space, click the same county — heatmap should reload
  - Verify county detail heatmap + shade by measure still works as before

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
