### PR TITLE
Add statewide heat map card (#165)

### DIFF
--- a/frontend/src/components/map/StatewideHeatmapCard.tsx
+++ b/frontend/src/components/map/StatewideHeatmapCard.tsx
@@ -1,0 +1,77 @@
+import { useLayersState, type HeatmapResolution } from "../../hooks/useLayersState";
+import { getPalette } from "../../lib/choropleth/palettes";
+import { useIsDark } from "../../context/ThemeContext";
+
+type Props = {
+  totalCrashes: number | null;
+  displayed: number | null;
+  isLoading: boolean;
+  searchOpen?: boolean;
+};
+
+const RESOLUTION_LABEL: Record<HeatmapResolution, string> = {
+  raw: "Raw",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+};
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString();
+}
+
+export default function StatewideHeatmapCard({ totalCrashes, displayed, isLoading, searchOpen }: Props) {
+  const { palette, heatmapResolution } = useLayersState();
+  const isDark = useIsDark();
+  const colors = getPalette(palette, isDark);
+
+  const sampled = totalCrashes != null && displayed != null && displayed < totalCrashes;
+
+  return (
+    <div
+      data-testid="statewide-heatmap-card"
+      className={`absolute z-20 bg-surface-container-lowest/95 backdrop-blur-md rounded-xl p-2 md:p-3 w-[200px] md:w-[250px] ghost-border transition-all duration-300 top-3 left-2 md:top-2 md:left-auto md:right-4 ${searchOpen ? "hidden md:block" : ""}`}
+    >
+      <span className="text-[9px] md:text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
+        Statewide Heatmap
+      </span>
+
+      <div className={`flex h-3 rounded-sm overflow-hidden ${isLoading ? "animate-pulse opacity-40" : ""}`}>
+        {colors.map((c, i) => (
+          <div key={i} className="flex-1" style={{ backgroundColor: c }} />
+        ))}
+      </div>
+      <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
+        <span>Low</span>
+        <span>High</span>
+      </div>
+
+      <div className="text-[10px] text-on-surface-variant mt-2 leading-snug">
+        {isLoading ? (
+          <span className="italic">Loading heatmap…</span>
+        ) : totalCrashes == null || totalCrashes === 0 ? (
+          <span className="italic">No crashes for current filters</span>
+        ) : sampled ? (
+          <>
+            <span className="font-mono font-semibold">{formatCount(displayed!)}</span>
+            {" of "}
+            <span className="font-mono font-semibold">{formatCount(totalCrashes)}</span>
+            {" mapped"}
+          </>
+        ) : (
+          <>
+            <span className="font-mono font-semibold">{formatCount(totalCrashes)}</span>
+            {" mapped"}
+          </>
+        )}
+      </div>
+
+      <div className="text-[10px] text-on-surface-variant mt-1">
+        Resolution:{" "}
+        <span className="font-semibold text-on-surface">{RESOLUTION_LABEL[heatmapResolution]}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -23,6 +23,7 @@ import DataExportPanel, {
 import MapCanvas from "../components/map/MapCanvas";
 import AiInsightCard from "../components/map/AiInsightCard";
 import Breadcrumb from "../components/map/Breadcrumb";
+import StatewideHeatmapCard from "../components/map/StatewideHeatmapCard";
 import { EmptyState } from "../components/ui/EmptyState";
 import { useCrashHeatmap, useBatchedHeatmap } from "../hooks/useCrashHeatmap";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
@@ -103,7 +104,7 @@ function MapPageInner() {
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
 
-  const { measure, otherLayers, heatmapResolution, palette } = useLayersState();
+  const { measure, otherLayers, heatmapResolution, palette, choroplethOn } = useLayersState();
 
   const useCountyDetail = !!focusedCounty && otherLayers.heatmapCounty && (!compareMode || !!compareCounty);
 
@@ -444,6 +445,14 @@ function MapPageInner() {
           searchOpen={mobileSearchExpanded}
           mismatchCount={otherLayers.coordMismatches ? mismatchHeatmap.totalCrashes : null}
         />
+        {otherLayers.heatmapStatewide && !focusedCounty && !choroplethOn && (
+          <StatewideHeatmapCard
+            totalCrashes={statewideHeatmap.totalCrashes}
+            displayed={statewideHeatmap.points.length}
+            isLoading={statewideHeatmap.isLoading}
+            searchOpen={mobileSearchExpanded}
+          />
+        )}
         {heatmapEnabled && heatmap.isLoading && (
           <HeatmapLoadingPill />
         )}


### PR DESCRIPTION
What does this PR do?

  Closes #165. Adds a compact StatewideHeatmapCard that appears when the statewide heatmap is on but the choropleth is
  off and no county is selected — the case where the existing ChoroplethLegend short-circuits and leaves the user with
  no legend or stats. Card shows the heatmap color gradient, total/mapped crash counts, and the active resolution.
  Hidden automatically once choropleth is re-enabled (legend takes over) or a county is clicked (AI insight card takes
  over).

  Dependencies

  None.

  How to test

  - cd frontend && npm install && npm run dev, open the map.
  - Open the Layers panel, turn Choropleth off and Statewide Heatmap on. New card appears top-right (desktop) / top-left
   (mobile) with caption, gradient, "Low / High" labels, mapped count, and "Resolution: …".
  - Switch palettes (default / warm / cool / colorblind) — gradient swatches update and match the dots painted on the
  map.
  - Switch resolutions (Low / Medium / High / Raw) — Resolution label updates.
  - Click any county → card disappears (AI insight card takes over).
  - Turn Choropleth back on → card disappears (existing legend takes over).
  - Apply filters that yield zero crashes → card shows "No crashes for current filters" (alongside the existing centered
   no-data overlay; both visible by design, neither blocks).
  - Toggle dark mode → card surfaces, gradient swatches, and text colors flip cleanly.


## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
