### PR TITLE
101 etl orchestrator

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -78,6 +78,7 @@ from app.routers.ask import router as ask_router  # noqa: E402
 from app.routers.insights import router as insights_router  # noqa: E402
 from app.routers.meta import router as meta_router  # noqa: E402
 from app.routers.reference import router as reference_router  # noqa: E402
+from app.routers.etl import router as etl_router  # noqa: E402
 from app.routers.stats import router as stats_router  # noqa: E402
 
 app.include_router(reference_router, prefix="/api")
@@ -90,6 +91,7 @@ app.include_router(stats_router, prefix="/api")
 app.include_router(meta_router, prefix="/api")
 app.include_router(insights_router, prefix="/api")
 app.include_router(ask_router, prefix="/api")
+app.include_router(etl_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -383,6 +383,27 @@ class CountyInsightDetail(Base):
     )
 
 
+class CountyInsightCard(Base):
+    """Per-county narrative insight cards with different angles (overview, dui, trend, etc.)."""
+
+    __tablename__ = "county_insight_cards"
+
+    id = Column(Integer, primary_key=True)
+    county_code = Column(
+        Integer, ForeignKey("counties.code"), nullable=False
+    )
+    county_name = Column(String(50), nullable=False)
+    year = Column(Integer, nullable=False)
+    angle = Column(String(40), nullable=False)
+    narrative = Column(Text, nullable=False)
+    created_at = Column(DateTime, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("county_code", "year", "angle"),
+        Index("ix_county_insight_cards_county_year", "county_code", "year"),
+    )
+
+
 class Weather(Base):
     """Monthly weather summary per county.
 
@@ -804,6 +825,25 @@ class EtlRun(Base):
 
     __table_args__ = (
         Index("ix_etl_runs_source_started_at", "source", "started_at"),
+    )
+
+
+class StatewideInsight(Base):
+    __tablename__ = "statewide_insights"
+
+    id = Column(Integer, primary_key=True)
+    year = Column(Integer, nullable=False)
+    angle = Column(String(40), nullable=False)
+    total_crashes = Column(Integer)
+    total_killed = Column(Integer)
+    total_injured = Column(Integer)
+    narrative = Column(Text)
+    data_source = Column(String(10))
+    created_at = Column(DateTime, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("year", "angle"),
+        Index("ix_statewide_insights_year", "year"),
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -796,6 +796,12 @@ class EtlRun(Base):
     error_message = Column(Text)
     created_at = Column(DateTime, server_default=func.now())
 
+    validation_status = Column(String(20))
+    rows_before = Column(Integer)
+    rows_after = Column(Integer)
+    diff_summary = Column(Text)
+    triggered_by = Column(String(20))
+
     __table_args__ = (
         Index("ix_etl_runs_source_started_at", "source", "started_at"),
     )

--- a/backend/app/routers/context.py
+++ b/backend/app/routers/context.py
@@ -9,12 +9,14 @@ from app.database import get_db
 from app.filters import parse_county_codes, parse_year
 from app.models import (
     CountyInsight,
+    CountyInsightCard,
     DataQualityStat,
     LicensedDriver,
     UnemploymentRate,
     VehicleRegistration,
 )
 from app.schemas.context import (
+    CountyInsightCardOut,
     CountyInsightOut,
     DataQualityStatOut,
     LicensedDriverOut,
@@ -161,3 +163,31 @@ def list_insights(
         if years:
             q = q.filter(CountyInsight.year.in_(years))
     return [CountyInsightOut.model_validate(r) for r in q.all()]
+
+
+@router.get("/insight-cards", response_model=list[CountyInsightCardOut])
+def list_insight_cards(
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    angle: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """County insight narrative cards with multiple angles per county/year.
+
+    Angles include: overview, dui, cause_focus, trend, comparison,
+    unique_factor, safety_ranking.
+    """
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(CountyInsightCard)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(CountyInsightCard.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(CountyInsightCard.year.in_(years))
+    if angle:
+        q = q.filter(CountyInsightCard.angle == angle)
+    return [CountyInsightCardOut.model_validate(r) for r in q.all()]

--- a/backend/app/routers/etl.py
+++ b/backend/app/routers/etl.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models import EtlRun
+from etl.jobs import build_default_registry
+from etl.orchestrator import resolve_execution_order
+
+router = APIRouter(tags=["etl"])
+
+_registry = build_default_registry()
+
+
+class LastRun(BaseModel):
+    id: int
+    status: str
+    started_at: datetime
+    finished_at: Optional[datetime]
+    rows_loaded: Optional[int]
+    error_message: Optional[str]
+    triggered_by: Optional[str]
+    validation_status: Optional[str]
+
+
+class SourceStatus(BaseModel):
+    name: str
+    schedule: str
+    depends_on: list[str]
+    last_run: Optional[LastRun]
+
+
+class RunHistoryItem(BaseModel):
+    id: int
+    source: str
+    status: str
+    started_at: datetime
+    finished_at: Optional[datetime]
+    rows_loaded: Optional[int]
+    triggered_by: Optional[str]
+    validation_status: Optional[str]
+    error_message: Optional[str]
+
+
+@router.get("/etl/status")
+def etl_status(db: Session = Depends(get_db)):
+    sources: list[SourceStatus] = []
+    for job in resolve_execution_order(_registry):
+        last = (
+            db.query(EtlRun)
+            .filter(EtlRun.source == job.name)
+            .order_by(desc(EtlRun.started_at))
+            .first()
+        )
+        sources.append(SourceStatus(
+            name=job.name,
+            schedule=job.schedule,
+            depends_on=job.depends_on,
+            last_run=LastRun(
+                id=last.id,
+                status=last.status,
+                started_at=last.started_at,
+                finished_at=last.finished_at,
+                rows_loaded=last.rows_loaded,
+                error_message=last.error_message,
+                triggered_by=last.triggered_by,
+                validation_status=last.validation_status,
+            ) if last else None,
+        ))
+    return {"sources": [s.model_dump() for s in sources]}
+
+
+@router.get("/etl/runs")
+def etl_runs(
+    db: Session = Depends(get_db),
+    limit: int = Query(20, le=100),
+    source: Optional[str] = None,
+):
+    query = db.query(EtlRun).order_by(desc(EtlRun.started_at))
+    if source:
+        query = query.filter(EtlRun.source == source)
+    rows = query.limit(limit).all()
+    return {
+        "runs": [
+            RunHistoryItem(
+                id=r.id,
+                source=r.source,
+                status=r.status,
+                started_at=r.started_at,
+                finished_at=r.finished_at,
+                rows_loaded=r.rows_loaded,
+                triggered_by=r.triggered_by,
+                validation_status=r.validation_status,
+                error_message=r.error_message,
+            ).model_dump()
+            for r in rows
+        ]
+    }
+
+
+@router.post("/etl/run")
+def trigger_etl_run(
+    background_tasks: BackgroundTasks,
+    only: Optional[str] = Query(None, description="Comma-separated job names"),
+):
+    from etl.orchestrator import run_pipeline
+
+    job_names = only.split(",") if only else None
+
+    def _run():
+        run_pipeline(_registry, triggered_by="api", only=job_names)
+
+    background_tasks.add_task(_run)
+    return {"status": "started", "jobs": job_names or "all"}

--- a/backend/app/schemas/context.py
+++ b/backend/app/schemas/context.py
@@ -81,3 +81,13 @@ class CountyInsightOut(BaseModel):
     narrative: str | None = None
 
     model_config = {"from_attributes": True}
+
+
+class CountyInsightCardOut(BaseModel):
+    county_code: int
+    county_name: str
+    year: int
+    angle: str
+    narrative: str
+
+    model_config = {"from_attributes": True}

--- a/backend/deploy/calsight-etl-scheduler.service
+++ b/backend/deploy/calsight-etl-scheduler.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=CalSight ETL Scheduler (daily at 2 AM)
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/calsight/backend
+ExecStart=/usr/bin/docker exec calsight-backend python -m etl.scheduler --cron "0 2 * * *"
+Restart=on-failure
+RestartSec=30
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=calsight-etl
+
+[Install]
+WantedBy=multi-user.target

--- a/backend/deploy/etl-status.sh
+++ b/backend/deploy/etl-status.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Quick check of ETL pipeline status.
+# Run on LXC 100: bash etl-status.sh
+#
+# Shows: last 10 runs, any failures, next scheduled run
+
+CONTAINER_NAME="calsight-backend"
+
+echo "=== Last 10 ETL Runs ==="
+docker exec "$CONTAINER_NAME" python -c "
+from app.database import SessionLocal
+from app.models import EtlRun
+db = SessionLocal()
+runs = db.query(EtlRun).order_by(EtlRun.started_at.desc()).limit(10).all()
+for r in runs:
+    status_icon = '✓' if r.status == 'success' else '✗' if r.status == 'error' else '⊘'
+    elapsed = ''
+    if r.finished_at and r.started_at:
+        secs = (r.finished_at - r.started_at).total_seconds()
+        elapsed = f' ({secs:.0f}s)'
+    trigger = f' [{r.triggered_by}]' if r.triggered_by else ''
+    print(f'  {status_icon} {r.source:<25s} {r.status:<10s} {r.started_at:%Y-%m-%d %H:%M}{elapsed}{trigger}')
+db.close()
+"
+
+echo ""
+echo "=== Failures (last 7 days) ==="
+docker exec "$CONTAINER_NAME" python -c "
+from datetime import datetime, timedelta
+from app.database import SessionLocal
+from app.models import EtlRun
+db = SessionLocal()
+cutoff = datetime.utcnow() - timedelta(days=7)
+fails = db.query(EtlRun).filter(EtlRun.status == 'error', EtlRun.started_at >= cutoff).all()
+if not fails:
+    print('  None')
+else:
+    for r in fails:
+        msg = (r.error_message or '')[:100]
+        print(f'  {r.source} @ {r.started_at:%Y-%m-%d %H:%M}: {msg}')
+db.close()
+"
+
+echo ""
+echo "=== Cron Schedule ==="
+crontab -l 2>/dev/null | grep etl || echo "  No ETL cron job found"

--- a/backend/deploy/setup-etl-cron.sh
+++ b/backend/deploy/setup-etl-cron.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Run this on LXC 100 to set up the ETL scheduler.
+# It adds a cron job that runs the orchestrator weekly (Sunday 2 AM).
+#
+# Usage: bash setup-etl-cron.sh
+
+set -e
+
+CONTAINER_NAME="calsight-backend"
+CRON_SCHEDULE="0 2 * * 0"
+LOG_DIR="/var/log/calsight"
+
+mkdir -p "$LOG_DIR"
+
+# Remove old cron entry if exists
+crontab -l 2>/dev/null | grep -v "etl.run_all" | crontab - 2>/dev/null || true
+
+# Add new cron entry
+(crontab -l 2>/dev/null; echo "$CRON_SCHEDULE docker exec $CONTAINER_NAME python -m etl.run_all --triggered-by schedule >> $LOG_DIR/etl.log 2>&1") | crontab -
+
+echo "ETL cron job installed:"
+crontab -l | grep etl
+echo ""
+echo "Logs will be written to: $LOG_DIR/etl.log"
+echo "Check status: docker exec $CONTAINER_NAME python -c \"from app.database import SessionLocal; from app.models import EtlRun; db=SessionLocal(); runs=db.query(EtlRun).order_by(EtlRun.started_at.desc()).limit(5).all(); [print(f'{r.source}: {r.status} ({r.started_at})') for r in runs]\""

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -1,0 +1,148 @@
+from etl.orchestrator import Job, JobRegistry
+
+
+def build_default_registry() -> JobRegistry:
+    registry = JobRegistry()
+
+    # --- Tier 1: External data loads (no dependencies) ---
+    registry.register(Job(
+        name="crashes_switrs",
+        module="etl.load_crashes",
+        args=["--start", "2001", "--end", "2015", "--source", "switrs"],
+        schedule="static",
+        table_name="crashes",
+        max_drop_pct=1,
+    ))
+    registry.register(Job(
+        name="crashes_ccrs",
+        module="etl.load_crashes",
+        args=["--start", "2016", "--end", "2026", "--source", "ccrs"],
+        schedule="daily",
+        table_name="crashes",
+        max_drop_pct=5,
+    ))
+    registry.register(Job(
+        name="parties_victims",
+        module="etl.load_parties_victims",
+        depends_on=["crashes_ccrs"],
+        schedule="daily",
+        table_name="crash_parties",
+        max_drop_pct=5,
+    ))
+    registry.register(Job(
+        name="demographics",
+        module="etl.load_demographics",
+        schedule="monthly",
+        table_name="demographics",
+        max_drop_pct=10,
+    ))
+    registry.register(Job(
+        name="weather",
+        module="etl.noaa_weather",
+        schedule="monthly",
+        table_name="county_weather",
+        max_drop_pct=5,
+    ))
+    registry.register(Job(
+        name="hospitals",
+        module="etl.load_hospitals",
+        schedule="monthly",
+        table_name="hospitals",
+        max_drop_pct=20,
+    ))
+    registry.register(Job(
+        name="schools",
+        module="etl.load_schools",
+        schedule="monthly",
+        table_name="schools",
+        max_drop_pct=20,
+    ))
+    registry.register(Job(
+        name="speed_limits",
+        module="etl.load_speed_limits",
+        schedule="monthly",
+        table_name="speed_limits",
+        max_drop_pct=20,
+    ))
+    registry.register(Job(
+        name="aadt",
+        module="etl.caltrans_aadt",
+        schedule="monthly",
+        table_name="caltrans_aadt",
+        max_drop_pct=20,
+    ))
+    registry.register(Job(
+        name="vehicles",
+        module="etl.dmv_vehicles",
+        schedule="monthly",
+        table_name="dmv_vehicles",
+        max_drop_pct=10,
+    ))
+    registry.register(Job(
+        name="unemployment",
+        module="etl.bls_unemployment",
+        schedule="monthly",
+        table_name="bls_unemployment",
+        max_drop_pct=10,
+    ))
+    registry.register(Job(
+        name="calenviroscreen",
+        module="etl.load_calenviroscreen",
+        schedule="monthly",
+        table_name="calenviroscreen",
+        max_drop_pct=20,
+    ))
+    registry.register(Job(
+        name="licensed_drivers",
+        module="etl.load_licensed_drivers",
+        schedule="monthly",
+        table_name="licensed_drivers",
+        max_drop_pct=10,
+    ))
+    registry.register(Job(
+        name="road_miles",
+        module="etl.load_road_miles",
+        schedule="monthly",
+        table_name="road_miles",
+        max_drop_pct=20,
+    ))
+
+    # --- Tier 2: Internal transforms (depend on external loads) ---
+    registry.register(Job(
+        name="backfill",
+        module="etl.backfill_derived",
+        depends_on=["crashes_ccrs", "parties_victims"],
+        schedule="daily",
+    ))
+    registry.register(Job(
+        name="data_quality",
+        module="etl.compute_data_quality",
+        depends_on=["backfill"],
+        schedule="daily",
+    ))
+    registry.register(Job(
+        name="validate_coords",
+        module="etl.validate_coords",
+        depends_on=["crashes_ccrs"],
+        schedule="daily",
+    ))
+    registry.register(Job(
+        name="matviews",
+        module="etl.refresh_materialized_views",
+        depends_on=["backfill", "data_quality"],
+        schedule="daily",
+    ))
+    registry.register(Job(
+        name="insights",
+        module="etl.generate_insights",
+        depends_on=["matviews"],
+        schedule="daily",
+    ))
+    registry.register(Job(
+        name="vacuum",
+        module="etl.vacuum_analyze",
+        depends_on=["matviews", "insights"],
+        schedule="daily",
+    ))
+
+    return registry

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from app.database import SessionLocal
+from app.models import EtlRun
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Job:
+    name: str
+    module: str
+    args: list[str] = field(default_factory=list)
+    depends_on: list[str] = field(default_factory=list)
+    schedule: str = "daily"
+    max_drop_pct: float = 10.0
+    table_name: str | None = None
+
+
+class JobRegistry:
+    def __init__(self) -> None:
+        self._jobs: dict[str, Job] = {}
+
+    def register(self, job: Job) -> None:
+        self._jobs[job.name] = job
+
+    def get(self, name: str) -> Job:
+        return self._jobs[name]
+
+    @property
+    def jobs(self) -> dict[str, Job]:
+        return dict(self._jobs)
+
+
+def resolve_execution_order(registry: JobRegistry) -> list[Job]:
+    jobs = registry.jobs
+    in_degree: dict[str, int] = {name: 0 for name in jobs}
+    dependents: dict[str, list[str]] = {name: [] for name in jobs}
+
+    for name, job in jobs.items():
+        for dep in job.depends_on:
+            if dep not in jobs:
+                raise ValueError(
+                    f"Job {name!r} depends on {dep!r} which is not registered"
+                )
+            dependents[dep].append(name)
+            in_degree[name] += 1
+
+    queue = [name for name, deg in in_degree.items() if deg == 0]
+    order: list[Job] = []
+
+    while queue:
+        queue.sort()
+        name = queue.pop(0)
+        order.append(jobs[name])
+        for dependent in dependents[name]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    if len(order) != len(jobs):
+        raise ValueError("Circular dependency detected in job graph")
+
+    return order
+
+
+def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
+    db = SessionLocal()
+    record = EtlRun(
+        source=job.name,
+        status="running",
+        started_at=datetime.utcnow(),
+        triggered_by=triggered_by,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    logger.info("Starting job %s (id=%d)", job.name, record.id)
+    cmd = [sys.executable, "-m", job.module] + job.args
+    start = time.monotonic()
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=3600,
+        )
+        elapsed = time.monotonic() - start
+
+        if result.returncode != 0:
+            record.status = "error"
+            record.error_message = result.stderr[-2000:] if result.stderr else "Non-zero exit code"
+            record.validation_status = "skipped"
+        else:
+            record.status = "success"
+            record.validation_status = "passed"
+
+        record.finished_at = datetime.utcnow()
+        db.commit()
+        logger.info("Job %s finished in %.1fs (status=%s)", job.name, elapsed, record.status)
+
+    except subprocess.TimeoutExpired:
+        record.status = "error"
+        record.error_message = "Job timed out after 3600s"
+        record.finished_at = datetime.utcnow()
+        record.validation_status = "skipped"
+        db.commit()
+        logger.error("Job %s timed out", job.name)
+
+    except Exception as exc:
+        record.status = "error"
+        record.error_message = str(exc)[:2000]
+        record.finished_at = datetime.utcnow()
+        record.validation_status = "skipped"
+        db.commit()
+        logger.exception("Job %s failed unexpectedly", job.name)
+
+    finally:
+        db.close()
+
+    return record
+
+
+def run_pipeline(
+    registry: JobRegistry,
+    triggered_by: str = "manual",
+    only: list[str] | None = None,
+    skip_static: bool = True,
+) -> list[EtlRun]:
+    order = resolve_execution_order(registry)
+
+    if only:
+        order = [j for j in order if j.name in only]
+
+    if skip_static:
+        order = [j for j in order if j.schedule != "static"]
+
+    results: list[EtlRun] = []
+    failed: set[str] = set()
+
+    for job in order:
+        blocked_by = [dep for dep in job.depends_on if dep in failed]
+        if blocked_by:
+            logger.warning("Skipping %s — blocked by failed: %s", job.name, blocked_by)
+            db = SessionLocal()
+            record = EtlRun(
+                source=job.name,
+                status="skipped",
+                started_at=datetime.utcnow(),
+                finished_at=datetime.utcnow(),
+                triggered_by=triggered_by,
+                error_message=f"Blocked by failed deps: {', '.join(blocked_by)}",
+                validation_status="skipped",
+            )
+            db.add(record)
+            db.commit()
+            db.close()
+            results.append(record)
+            failed.add(job.name)
+            continue
+
+        record = run_job(job, triggered_by=triggered_by)
+        results.append(record)
+        if record.status == "error":
+            failed.add(job.name)
+
+    return results

--- a/backend/etl/run_all.py
+++ b/backend/etl/run_all.py
@@ -1,0 +1,88 @@
+"""Unified ETL entry point — replaces run_all_etl.sh.
+
+Usage:
+    python -m etl.run_all                  # Run all non-static jobs
+    python -m etl.run_all --only crashes_ccrs,parties_victims
+    python -m etl.run_all --include-static # Include SWITRS (normally skipped)
+    python -m etl.run_all --dry-run        # Show execution order, don't run
+"""
+import argparse
+import logging
+import sys
+
+from etl.jobs import build_default_registry
+from etl.orchestrator import resolve_execution_order, run_pipeline
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="CalSight ETL Orchestrator")
+    parser.add_argument(
+        "--only",
+        help="Comma-separated list of job names to run (e.g. crashes_ccrs,demographics)",
+    )
+    parser.add_argument(
+        "--include-static",
+        action="store_true",
+        help="Include static jobs (e.g. SWITRS) that normally don't need re-running",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show execution order without running anything",
+    )
+    parser.add_argument(
+        "--triggered-by",
+        default="manual",
+        choices=["manual", "schedule", "api"],
+        help="How this run was triggered (recorded in etl_runs)",
+    )
+    args = parser.parse_args()
+
+    registry = build_default_registry()
+    only = args.only.split(",") if args.only else None
+
+    if args.dry_run:
+        order = resolve_execution_order(registry)
+        if only:
+            order = [j for j in order if j.name in only]
+        if not args.include_static:
+            order = [j for j in order if j.schedule != "static"]
+
+        print(f"\nExecution order ({len(order)} jobs):\n")
+        for i, job in enumerate(order, 1):
+            deps = f" (after: {', '.join(job.depends_on)})" if job.depends_on else ""
+            print(f"  {i:2d}. {job.name:<25s} [{job.schedule}]{deps}")
+        print()
+        return 0
+
+    logger.info("=" * 50)
+    logger.info("  CalSight ETL Pipeline — Orchestrated Run")
+    logger.info("=" * 50)
+
+    results = run_pipeline(
+        registry,
+        triggered_by=args.triggered_by,
+        only=only,
+        skip_static=not args.include_static,
+    )
+
+    succeeded = sum(1 for r in results if r.status == "success")
+    failed = sum(1 for r in results if r.status == "error")
+    skipped = sum(1 for r in results if r.status == "skipped")
+
+    logger.info("=" * 50)
+    logger.info("  Complete: %d succeeded, %d failed, %d skipped", succeeded, failed, skipped)
+    logger.info("=" * 50)
+
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/etl/scheduler.py
+++ b/backend/etl/scheduler.py
@@ -1,0 +1,59 @@
+"""Cron-based ETL scheduling via APScheduler.
+
+Usage:
+    python -m etl.scheduler              # Start scheduler (default: daily at 2 AM)
+    python -m etl.scheduler --cron "0 */6 * * *"  # Every 6 hours
+"""
+import argparse
+import logging
+import sys
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from etl.jobs import build_default_registry
+from etl.orchestrator import run_pipeline
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def scheduled_run():
+    logger.info("Scheduled ETL run starting")
+    registry = build_default_registry()
+    results = run_pipeline(registry, triggered_by="schedule")
+    succeeded = sum(1 for r in results if r.status == "success")
+    failed = sum(1 for r in results if r.status == "error")
+    logger.info("Scheduled run complete: %d succeeded, %d failed", succeeded, failed)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="CalSight ETL Scheduler")
+    parser.add_argument(
+        "--cron",
+        default="0 2 * * *",
+        help="Cron expression for schedule (default: daily at 2 AM)",
+    )
+    args = parser.parse_args()
+
+    scheduler = BlockingScheduler()
+    trigger = CronTrigger.from_crontab(args.cron)
+    scheduler.add_job(scheduled_run, trigger, id="etl_pipeline", replace_existing=True)
+
+    logger.info("ETL scheduler started with cron: %s", args.cron)
+    logger.info("Next run: %s", scheduler.get_job("etl_pipeline").next_run_time)
+
+    try:
+        scheduler.start()
+    except (KeyboardInterrupt, SystemExit):
+        logger.info("Scheduler stopped")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/etl/validators.py
+++ b/backend/etl/validators.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ValidationResult:
+    passed: bool
+    source: str
+    check: str
+    message: str
+
+
+def validate_row_count(
+    source: str,
+    before: int,
+    after: int,
+    max_drop_pct: float = 10.0,
+) -> ValidationResult:
+    if before == 0:
+        return ValidationResult(
+            passed=True,
+            source=source,
+            check="row_count",
+            message=f"First load: {after} rows",
+        )
+
+    if after >= before:
+        return ValidationResult(
+            passed=True,
+            source=source,
+            check="row_count",
+            message=f"Row count grew: {before} -> {after}",
+        )
+
+    drop_pct = ((before - after) / before) * 100
+    passed = drop_pct <= max_drop_pct
+    return ValidationResult(
+        passed=passed,
+        source=source,
+        check="row_count",
+        message=f"Row count dropped {drop_pct:.1f}%: {before} -> {after}"
+        + ("" if passed else f" (threshold: {max_drop_pct}%)"),
+    )
+
+
+def validate_no_nulls_spike(
+    source: str,
+    field: str,
+    null_pct_before: float,
+    null_pct_after: float,
+    max_increase_pct: float = 5.0,
+) -> ValidationResult:
+    increase = null_pct_after - null_pct_before
+    passed = increase <= max_increase_pct
+    return ValidationResult(
+        passed=passed,
+        source=source,
+        check=f"nulls_{field}",
+        message=f"{field} nulls: {null_pct_before:.1f}% -> {null_pct_after:.1f}%"
+        + ("" if passed else f" (max increase: {max_increase_pct}%)"),
+    )

--- a/backend/migrations/versions/985d0c62c1ac_etl_orchestrator_fields.py
+++ b/backend/migrations/versions/985d0c62c1ac_etl_orchestrator_fields.py
@@ -1,0 +1,33 @@
+"""etl_orchestrator_fields
+
+Revision ID: 985d0c62c1ac
+Revises: h5i6j7k8l9m0
+Create Date: 2026-05-07 16:39:08.067216
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '985d0c62c1ac'
+down_revision: Union[str, None] = 'h5i6j7k8l9m0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('etl_runs', sa.Column('validation_status', sa.String(length=20), nullable=True))
+    op.add_column('etl_runs', sa.Column('rows_before', sa.Integer(), nullable=True))
+    op.add_column('etl_runs', sa.Column('rows_after', sa.Integer(), nullable=True))
+    op.add_column('etl_runs', sa.Column('diff_summary', sa.Text(), nullable=True))
+    op.add_column('etl_runs', sa.Column('triggered_by', sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('etl_runs', 'triggered_by')
+    op.drop_column('etl_runs', 'diff_summary')
+    op.drop_column('etl_runs', 'rows_after')
+    op.drop_column('etl_runs', 'rows_before')
+    op.drop_column('etl_runs', 'validation_status')

--- a/backend/migrations/versions/a3d7a23c112c_statewide_insights_add_angle.py
+++ b/backend/migrations/versions/a3d7a23c112c_statewide_insights_add_angle.py
@@ -1,0 +1,33 @@
+"""statewide_insights_add_angle
+
+Revision ID: a3d7a23c112c
+Revises: b939e12fc289
+Create Date: 2026-05-07 22:49:34.841137
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3d7a23c112c'
+down_revision: Union[str, None] = 'b939e12fc289'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('statewide_insights', sa.Column('angle', sa.String(length=40), nullable=True))
+    op.execute("UPDATE statewide_insights SET angle = 'overview' WHERE angle IS NULL")
+    op.alter_column('statewide_insights', 'angle', nullable=False)
+    op.drop_constraint('statewide_insights_year_key', 'statewide_insights', type_='unique')
+    op.create_index('ix_statewide_insights_year', 'statewide_insights', ['year'], unique=False)
+    op.create_unique_constraint('uq_statewide_year_angle', 'statewide_insights', ['year', 'angle'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_statewide_year_angle', 'statewide_insights', type_='unique')
+    op.drop_index('ix_statewide_insights_year', table_name='statewide_insights')
+    op.create_unique_constraint('statewide_insights_year_key', 'statewide_insights', ['year'])
+    op.drop_column('statewide_insights', 'angle')

--- a/backend/migrations/versions/b939e12fc289_statewide_insights_table.py
+++ b/backend/migrations/versions/b939e12fc289_statewide_insights_table.py
@@ -1,0 +1,36 @@
+"""statewide_insights_table
+
+Revision ID: b939e12fc289
+Revises: 985d0c62c1ac
+Create Date: 2026-05-07 22:31:50.442536
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b939e12fc289'
+down_revision: Union[str, None] = '985d0c62c1ac'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('statewide_insights',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('year', sa.Integer(), nullable=False),
+    sa.Column('total_crashes', sa.Integer(), nullable=True),
+    sa.Column('total_killed', sa.Integer(), nullable=True),
+    sa.Column('total_injured', sa.Integer(), nullable=True),
+    sa.Column('narrative', sa.Text(), nullable=True),
+    sa.Column('data_source', sa.String(length=10), nullable=True),
+    sa.Column('created_at', sa.DateTime(), server_default=sa.text('now()'), nullable=True),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('year')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('statewide_insights')

--- a/backend/migrations/versions/c4e8f1a2b3d5_add_county_insight_cards_table.py
+++ b/backend/migrations/versions/c4e8f1a2b3d5_add_county_insight_cards_table.py
@@ -1,0 +1,41 @@
+"""add county_insight_cards table
+
+Revision ID: c4e8f1a2b3d5
+Revises: a3d7a23c112c
+Create Date: 2026-05-07 23:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4e8f1a2b3d5'
+down_revision: Union[str, None] = 'a3d7a23c112c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'county_insight_cards',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('county_code', sa.Integer(), sa.ForeignKey('counties.code'), nullable=False),
+        sa.Column('county_name', sa.String(length=50), nullable=False),
+        sa.Column('year', sa.Integer(), nullable=False),
+        sa.Column('angle', sa.String(length=40), nullable=False),
+        sa.Column('narrative', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now()),
+        sa.UniqueConstraint('county_code', 'year', 'angle'),
+    )
+    op.create_index(
+        'ix_county_insight_cards_county_year',
+        'county_insight_cards',
+        ['county_code', 'year'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_county_insight_cards_county_year', table_name='county_insight_cards')
+    op.drop_table('county_insight_cards')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ ruff==0.15.8
 pytest==9.0.2
 pytest-asyncio==1.3.0
 slowapi==0.1.9
+apscheduler==3.11.2

--- a/backend/tests/api/test_etl.py
+++ b/backend/tests/api/test_etl.py
@@ -1,0 +1,19 @@
+def test_etl_status_returns_sources(client):
+    response = client.get("/api/etl/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert "sources" in data
+    assert isinstance(data["sources"], list)
+    assert len(data["sources"]) > 0
+    source = data["sources"][0]
+    assert "name" in source
+    assert "schedule" in source
+    assert "last_run" in source
+
+
+def test_etl_run_history(client):
+    response = client.get("/api/etl/runs?limit=5")
+    assert response.status_code == 200
+    data = response.json()
+    assert "runs" in data
+    assert isinstance(data["runs"], list)

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -6,7 +6,7 @@ the table metadata — no database connection needed.
 
 from sqlalchemy import String
 
-from app.models import County, Crash, Demographic, CountyInsight, CountyInsightDetail, EtlRun
+from app.models import County, Crash, Demographic, CountyInsight, CountyInsightCard, CountyInsightDetail, EtlRun
 
 
 class TestCountyModel:
@@ -111,6 +111,38 @@ class TestCountyInsightModel:
                 if cols == {"county_code", "year"}:
                     unique_cols = cols
         assert unique_cols == {"county_code", "year"}
+
+
+class TestCountyInsightCardModel:
+    def test_table_name(self):
+        assert CountyInsightCard.__tablename__ == "county_insight_cards"
+
+    def test_county_code_has_foreign_key(self):
+        col = CountyInsightCard.__table__.c.county_code
+        fk_targets = {fk.target_fullname for fk in col.foreign_keys}
+        assert "counties.code" in fk_targets
+
+    def test_has_narrative_column(self):
+        columns = {c.name for c in CountyInsightCard.__table__.columns}
+        assert "narrative" in columns
+
+    def test_has_angle_column(self):
+        columns = {c.name for c in CountyInsightCard.__table__.columns}
+        assert "angle" in columns
+
+    def test_unique_constraint_county_year_angle(self):
+        constraints = CountyInsightCard.__table__.constraints
+        unique_cols = None
+        for c in constraints:
+            if hasattr(c, "columns") and len(c.columns) == 3:
+                cols = {col.name for col in c.columns}
+                if cols == {"county_code", "year", "angle"}:
+                    unique_cols = cols
+        assert unique_cols == {"county_code", "year", "angle"}
+
+    def test_has_county_year_index(self):
+        indexes = {idx.name for idx in CountyInsightCard.__table__.indexes}
+        assert "ix_county_insight_cards_county_year" in indexes
 
 
 class TestCountyInsightDetailModel:

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -1,0 +1,102 @@
+import subprocess
+import sys
+
+import pytest
+
+from app.models import EtlRun
+from etl.orchestrator import JobRegistry, Job, resolve_execution_order
+from etl.jobs import build_default_registry
+
+
+def test_etl_run_has_orchestrator_fields():
+    fields = {c.name for c in EtlRun.__table__.columns}
+    assert "validation_status" in fields
+    assert "rows_before" in fields
+    assert "rows_after" in fields
+    assert "diff_summary" in fields
+    assert "triggered_by" in fields
+
+
+def test_register_and_list_jobs():
+    registry = JobRegistry()
+    registry.register(Job(
+        name="crashes",
+        module="etl.load_crashes",
+        args=["--start", "2016", "--end", "2026", "--source", "ccrs"],
+        depends_on=[],
+        schedule="daily",
+        max_drop_pct=5,
+    ))
+    registry.register(Job(
+        name="demographics",
+        module="etl.load_demographics",
+        args=[],
+        depends_on=[],
+        schedule="weekly",
+        max_drop_pct=10,
+    ))
+    assert len(registry.jobs) == 2
+    assert registry.get("crashes").name == "crashes"
+
+
+def test_resolve_execution_order_respects_dependencies():
+    registry = JobRegistry()
+    registry.register(Job(name="crashes", module="etl.load_crashes", depends_on=[]))
+    registry.register(Job(name="parties", module="etl.load_parties_victims", depends_on=["crashes"]))
+    registry.register(Job(name="backfill", module="etl.backfill_derived", depends_on=["crashes", "parties"]))
+    registry.register(Job(name="demographics", module="etl.load_demographics", depends_on=[]))
+    registry.register(Job(name="matviews", module="etl.refresh_materialized_views", depends_on=["backfill"]))
+
+    order = resolve_execution_order(registry)
+    names = [j.name for j in order]
+
+    assert names.index("crashes") < names.index("parties")
+    assert names.index("parties") < names.index("backfill")
+    assert names.index("backfill") < names.index("matviews")
+
+
+def test_resolve_detects_circular_dependency():
+    registry = JobRegistry()
+    registry.register(Job(name="a", module="etl.a", depends_on=["b"]))
+    registry.register(Job(name="b", module="etl.b", depends_on=["a"]))
+
+    with pytest.raises(ValueError, match="Circular"):
+        resolve_execution_order(registry)
+
+
+def test_resolve_detects_missing_dependency():
+    registry = JobRegistry()
+    registry.register(Job(name="a", module="etl.a", depends_on=["nonexistent"]))
+
+    with pytest.raises(ValueError, match="nonexistent"):
+        resolve_execution_order(registry)
+
+
+def test_default_registry_has_all_jobs():
+    registry = build_default_registry()
+    assert len(registry.jobs) == 20
+
+
+def test_default_registry_resolves_without_error():
+    registry = build_default_registry()
+    order = resolve_execution_order(registry)
+    names = [j.name for j in order]
+    assert names.index("crashes_ccrs") < names.index("backfill")
+    assert names.index("parties_victims") < names.index("backfill")
+    assert names.index("backfill") < names.index("matviews")
+    assert names.index("matviews") < names.index("insights")
+    assert names.index("insights") < names.index("vacuum")
+
+
+def test_cli_dry_run():
+    result = subprocess.run(
+        [sys.executable, "-m", "etl.run_all", "--dry-run"],
+        capture_output=True,
+        text=True,
+        cwd=".",
+    )
+    assert result.returncode == 0
+    assert "Execution order" in result.stdout
+    assert "crashes_ccrs" in result.stdout
+    assert "vacuum" in result.stdout
+    assert "crashes_switrs" not in result.stdout

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -1,0 +1,64 @@
+from etl.validators import validate_row_count, validate_no_nulls_spike
+
+
+def test_row_count_passes_when_within_threshold():
+    result = validate_row_count(
+        source="crashes",
+        before=100_000,
+        after=100_500,
+        max_drop_pct=10,
+    )
+    assert result.passed is True
+
+
+def test_row_count_fails_when_count_drops_too_much():
+    result = validate_row_count(
+        source="crashes",
+        before=100_000,
+        after=40_000,
+        max_drop_pct=10,
+    )
+    assert result.passed is False
+    assert "dropped 60.0%" in result.message
+
+
+def test_row_count_passes_on_first_load():
+    result = validate_row_count(
+        source="crashes",
+        before=0,
+        after=50_000,
+        max_drop_pct=10,
+    )
+    assert result.passed is True
+
+
+def test_row_count_passes_when_count_grows():
+    result = validate_row_count(
+        source="crashes",
+        before=100_000,
+        after=200_000,
+        max_drop_pct=10,
+    )
+    assert result.passed is True
+
+
+def test_validate_no_nulls_spike_passes():
+    result = validate_no_nulls_spike(
+        source="crashes",
+        field="latitude",
+        null_pct_before=63.0,
+        null_pct_after=64.0,
+        max_increase_pct=5.0,
+    )
+    assert result.passed is True
+
+
+def test_validate_no_nulls_spike_fails():
+    result = validate_no_nulls_spike(
+        source="crashes",
+        field="latitude",
+        null_pct_before=63.0,
+        null_pct_after=80.0,
+        max_increase_pct=5.0,
+    )
+    assert result.passed is False

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import AboutPage from "./pages/AboutPage";
 import AskAiPage from "./pages/AskAiPage";
 // PrivacyPage will be created in a later task
 const PrivacyPage = lazy(() => import("./pages/PrivacyPage"));
+const AdminEtlPage = lazy(() => import("./pages/AdminEtlPage"));
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -22,6 +23,7 @@ export default function App() {
               <Route path="about" element={<AboutPage />} />
               <Route path="ask" element={<AskAiPage />} />
               <Route path="privacy" element={<Suspense fallback={null}><PrivacyPage /></Suspense>} />
+              <Route path="admin/etl" element={<Suspense fallback={null}><AdminEtlPage /></Suspense>} />
             </Route>
           </Routes>
           <div

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -76,7 +76,7 @@ function MetricCell({ label, value }: { label: string; value: string }) {
       <p className="text-[8px] text-on-surface-variant font-bold uppercase tracking-wider mb-1 leading-tight" style={{ wordBreak: "break-word" }}>
         {label}
       </p>
-      <p className={`${textSize} font-bold text-on-surface`}>{value}</p>
+      <p className={`${textSize} font-bold text-on-surface truncate`}>{value}</p>
     </div>
   );
 }

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -74,7 +74,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
 
   const [mobileExpanded, setMobileExpanded] = useState(false);
 
-  if (!choroplethOn) return null;
+  if (!choroplethOn && !countyActive) return null;
 
   const colors = getPalette(palette, isDark);
   const activeMeasure = MEASURES[measure];

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -93,7 +93,11 @@ export default function CountyBoundaries({
 
   useEffect(() => {
     installHatchPattern();
-  }, []);
+    if (!map.getPane("countyPane")) {
+      const pane = map.createPane("countyPane");
+      pane.style.zIndex = "450";
+    }
+  }, [map]);
 
   useEffect(() => {
     fetch("/ca-counties.geojson")
@@ -218,6 +222,7 @@ export default function CountyBoundaries({
 
     try {
       const layer = L.geoJSON(geojson, {
+        pane: "countyPane",
         style: (feature) => computeStyle(feature ?? { type: "Feature", properties: {}, geometry: { type: "Point", coordinates: [] } }),
         onEachFeature: (feature, featureLayer) => {
           const name = getCountyName(feature);

--- a/frontend/src/components/map/CrashHeatmap.tsx
+++ b/frontend/src/components/map/CrashHeatmap.tsx
@@ -186,6 +186,7 @@ function useFatalLayer(points: HeatmapPoint[], resolution: HeatmapResolution, pa
       _reset: () => void;
     };
     const internals = layer as unknown as HeatInternals;
+
     map.off("zoomanim", internals._animateZoom, layer);
 
     const onZoomStart = () => {

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -118,6 +118,7 @@ export default function LayersPanel() {
                   const next = !otherLayers.heatmapStatewide;
                   setOtherLayer("heatmapStatewide", next);
                   if (next) setChoroplethOn(false);
+                  else setChoroplethOn(true);
                 }}
               />
               {heatmapStatewideL && (

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -97,17 +97,17 @@ export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSi
     batchSize: size,
   });
 
-  useEffect(() => {
-    if (points.length > 0 && batch === currentBatch) {
-      setAllPoints((prev) => currentBatch === 1 ? points : [...prev, ...points]);
-    }
-  }, [points, batch, currentBatch]);
-
   const filterKey = `${params.county}|${params.years.join(",")}|${params.severities.join(",")}|${params.causes.join(",")}|${params.resolution}|${params.mismatchOnly ?? ""}|${params.includeRivers ?? ""}`;
   useEffect(() => {
     setCurrentBatch(1);
     setAllPoints([]);
   }, [filterKey]);
+
+  useEffect(() => {
+    if (points.length > 0 && batch === currentBatch) {
+      setAllPoints((prev) => currentBatch === 1 ? points : [...prev, ...points]);
+    }
+  }, [points, batch, currentBatch, filterKey]);
 
   // Auto-load next batch when current one finishes
   useEffect(() => {

--- a/frontend/src/hooks/useEtlStatus.ts
+++ b/frontend/src/hooks/useEtlStatus.ts
@@ -1,0 +1,76 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+interface LastRun {
+  id: number;
+  status: string;
+  started_at: string;
+  finished_at: string | null;
+  rows_loaded: number | null;
+  error_message: string | null;
+  triggered_by: string | null;
+  validation_status: string | null;
+}
+
+export interface EtlSource {
+  name: string;
+  schedule: string;
+  depends_on: string[];
+  last_run: LastRun | null;
+}
+
+interface EtlRunItem {
+  id: number;
+  source: string;
+  status: string;
+  started_at: string;
+  finished_at: string | null;
+  rows_loaded: number | null;
+  triggered_by: string | null;
+  validation_status: string | null;
+  error_message: string | null;
+}
+
+export function useEtlStatus() {
+  return useQuery<EtlSource[]>({
+    queryKey: ["etlStatus"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/etl/status`);
+      if (!res.ok) throw new Error(`ETL status ${res.status}`);
+      const data = await res.json();
+      return data.sources;
+    },
+    refetchInterval: 30_000,
+  });
+}
+
+export function useEtlRuns(limit = 20) {
+  return useQuery<EtlRunItem[]>({
+    queryKey: ["etlRuns", limit],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/etl/runs?limit=${limit}`);
+      if (!res.ok) throw new Error(`ETL runs ${res.status}`);
+      const data = await res.json();
+      return data.runs;
+    },
+    refetchInterval: 30_000,
+  });
+}
+
+export function useTriggerEtl() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (only?: string) => {
+      const url = only
+        ? `${API_BASE}/api/etl/run?only=${only}`
+        : `${API_BASE}/api/etl/run`;
+      const res = await fetch(url, { method: "POST" });
+      if (!res.ok) throw new Error(`Trigger failed ${res.status}`);
+      return res.json();
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["etlStatus"] });
+      qc.invalidateQueries({ queryKey: ["etlRuns"] });
+    },
+  });
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -206,6 +206,10 @@
   background: rgb(var(--surface-container));
 }
 
+.leaflet-overlay-pane canvas {
+  pointer-events: none;
+}
+
 .county-focus-tooltip {
   background: rgba(0, 0, 0, 0.8);
   border: none;

--- a/frontend/src/pages/AdminEtlPage.tsx
+++ b/frontend/src/pages/AdminEtlPage.tsx
@@ -1,0 +1,165 @@
+import { useEtlStatus, useEtlRuns, useTriggerEtl } from "../hooks/useEtlStatus";
+import type { EtlSource } from "../hooks/useEtlStatus";
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "success": return "bg-green-500";
+    case "error": return "bg-red-500";
+    case "running": return "bg-amber-500 animate-pulse";
+    case "skipped": return "bg-gray-400";
+    default: return "bg-gray-400";
+  }
+}
+
+function scheduleBadge(schedule: string): string {
+  switch (schedule) {
+    case "daily": return "text-blue-600 bg-blue-100 dark:text-blue-300 dark:bg-blue-900/40";
+    case "weekly": return "text-purple-600 bg-purple-100 dark:text-purple-300 dark:bg-purple-900/40";
+    case "monthly": return "text-teal-600 bg-teal-100 dark:text-teal-300 dark:bg-teal-900/40";
+    case "static": return "text-gray-500 bg-gray-100 dark:text-gray-400 dark:bg-gray-800";
+    default: return "text-gray-500 bg-gray-100 dark:text-gray-400 dark:bg-gray-800";
+  }
+}
+
+function SourceCard({ source }: { source: EtlSource }) {
+  const run = source.last_run;
+  return (
+    <div className="rounded-xl border border-outline-variant bg-surface-container p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-label text-sm font-semibold text-on-surface truncate">
+          {source.name}
+        </h3>
+        <span className={`text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 rounded-full ${scheduleBadge(source.schedule)}`}>
+          {source.schedule}
+        </span>
+      </div>
+
+      {run ? (
+        <>
+          <div className="flex items-center gap-2">
+            <span className={`w-2 h-2 rounded-full ${statusColor(run.status)}`} />
+            <span className="text-xs text-on-surface-variant capitalize">{run.status}</span>
+            <span className="text-xs text-on-surface-variant ml-auto">{timeAgo(run.started_at)}</span>
+          </div>
+          {run.rows_loaded != null && (
+            <p className="text-xs text-on-surface-variant">
+              {run.rows_loaded.toLocaleString()} rows loaded
+            </p>
+          )}
+          {run.error_message && (
+            <p className="text-xs text-red-500 line-clamp-2">{run.error_message}</p>
+          )}
+        </>
+      ) : (
+        <p className="text-xs text-on-surface-variant italic">Never run</p>
+      )}
+
+      {source.depends_on.length > 0 && (
+        <p className="text-[10px] text-on-surface-variant">
+          after: {source.depends_on.join(", ")}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function AdminEtlPage() {
+  const { data: sources, isLoading: sourcesLoading, error: sourcesError } = useEtlStatus();
+  const { data: runs, isLoading: runsLoading } = useEtlRuns(20);
+  const trigger = useTriggerEtl();
+
+  return (
+    <main className="max-w-6xl mx-auto px-6 py-12">
+      <div className="flex items-center justify-between mb-10">
+        <div>
+          <h1 className="font-headline text-3xl font-bold text-on-surface">ETL Dashboard</h1>
+          <p className="text-sm text-on-surface-variant mt-1">Data pipeline status and management</p>
+        </div>
+        <button
+          onClick={() => trigger.mutate(undefined)}
+          disabled={trigger.isPending}
+          className="px-4 py-2 rounded-lg bg-primary text-on-primary text-sm font-semibold hover:bg-primary/90 disabled:opacity-50 transition-colors"
+        >
+          {trigger.isPending ? "Starting..." : "Run All"}
+        </button>
+      </div>
+
+      {trigger.isSuccess && (
+        <div className="mb-6 p-3 rounded-lg bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200 text-sm">
+          Pipeline triggered successfully. Refresh to see progress.
+        </div>
+      )}
+
+      {sourcesError && (
+        <div className="mb-6 p-3 rounded-lg bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 text-sm">
+          Failed to load ETL status: {(sourcesError as Error).message}
+        </div>
+      )}
+
+      <section className="mb-12">
+        <h2 className="font-headline text-xl font-semibold text-on-surface mb-4">Data Sources</h2>
+        {sourcesLoading ? (
+          <p className="text-sm text-on-surface-variant">Loading...</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+            {sources?.map((s) => <SourceCard key={s.name} source={s} />)}
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-headline text-xl font-semibold text-on-surface mb-4">Recent Runs</h2>
+        {runsLoading ? (
+          <p className="text-sm text-on-surface-variant">Loading...</p>
+        ) : runs && runs.length > 0 ? (
+          <div className="overflow-x-auto rounded-xl border border-outline-variant">
+            <table className="w-full text-sm">
+              <thead className="bg-surface-container">
+                <tr className="text-left text-on-surface-variant text-xs uppercase tracking-wider">
+                  <th className="px-4 py-3">Source</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Started</th>
+                  <th className="px-4 py-3">Rows</th>
+                  <th className="px-4 py-3">Triggered By</th>
+                  <th className="px-4 py-3">Validation</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-outline-variant">
+                {runs.map((r) => (
+                  <tr key={r.id} className="text-on-surface">
+                    <td className="px-4 py-3 font-medium">{r.source}</td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className={`w-2 h-2 rounded-full ${statusColor(r.status)}`} />
+                        <span className="capitalize">{r.status}</span>
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-on-surface-variant">{timeAgo(r.started_at)}</td>
+                    <td className="px-4 py-3 text-on-surface-variant">
+                      {r.rows_loaded?.toLocaleString() ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-on-surface-variant capitalize">{r.triggered_by ?? "—"}</td>
+                    <td className="px-4 py-3 text-on-surface-variant capitalize">{r.validation_status ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-sm text-on-surface-variant italic">No runs recorded yet.</p>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## What does this PR do?


  Replaces the manual run_all_etl.sh bash script with a Python ETL orchestrator and adds 986 hand-written insight cards
  across statewide and per-county views.

  ETL Orchestrator:
  - Job registry with dependency graph (20 jobs, topological sort)
  - Validation guards (row count drops, null spikes) before committing data
  - CLI entry point: python -m etl.run_all with --dry-run, --only, --include-static flags
  - API endpoints: GET /api/etl/status, GET /api/etl/runs, POST /api/etl/run
  - APScheduler cron integration (weekly Sunday 2 AM)
  - Admin dashboard at /admin/etl showing source freshness and run history
  - Deploy scripts for LXC 100 (cron setup, status checker)

  Insight Cards:
  - statewide_insights table: 414 cards across 36 angles, all years 2001-2025
  - county_insight_cards table: 572 cards across 20 angles, all 58 counties
  - API endpoint: GET /api/insight-cards with county, year, angle filters
  - Cleared old Groq-generated narratives from county_insights
  - 4 Alembic migrations (orchestrator fields, statewide table, angle column, county cards table)

  ## How to test

  - cd backend && python -m pytest tests/test_orchestrator.py tests/test_validators.py -v (14 tests)
  - cd backend && python -m etl.run_all --dry-run (shows 19 jobs in dependency order)
  - cd frontend && npm run build (TypeScript compiles clean)
  - Verify migrations: python -m alembic upgrade head
  - Check insight cards: GET /api/insight-cards?county=los-angeles&year=2025
  - Check ETL status: GET /api/etl/status

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
