### PR TITLE
fix: re-apply crash detail card + canvas pointer-events after linter …

### DIFF
--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -22,11 +22,21 @@ def build_default_registry() -> JobRegistry:
         max_drop_pct=5,
     ))
     registry.register(Job(
-        name="parties_victims",
+        name="parties",
         module="etl.load_parties_victims",
+        args=["--table", "parties"],
         depends_on=["crashes_ccrs"],
         schedule="daily",
         table_name="crash_parties",
+        max_drop_pct=5,
+    ))
+    registry.register(Job(
+        name="victims",
+        module="etl.load_parties_victims",
+        args=["--table", "victims"],
+        depends_on=["crashes_ccrs"],
+        schedule="daily",
+        table_name="crash_victims",
         max_drop_pct=5,
     ))
     registry.register(Job(
@@ -111,7 +121,7 @@ def build_default_registry() -> JobRegistry:
     registry.register(Job(
         name="backfill",
         module="etl.backfill_derived",
-        depends_on=["crashes_ccrs", "parties_victims"],
+        depends_on=["crashes_ccrs", "parties", "victims"],
         schedule="daily",
     ))
     registry.register(Job(

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -125,6 +125,7 @@ def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
         logger.exception("Job %s failed unexpectedly", job.name)
 
     finally:
+        db.expunge(record)
         db.close()
 
     return record

--- a/backend/etl/run_all.py
+++ b/backend/etl/run_all.py
@@ -2,7 +2,7 @@
 
 Usage:
     python -m etl.run_all                  # Run all non-static jobs
-    python -m etl.run_all --only crashes_ccrs,parties_victims
+    python -m etl.run_all --only crashes_ccrs,parties,victims
     python -m etl.run_all --include-static # Include SWITRS (normally skipped)
     python -m etl.run_all --dry-run        # Show execution order, don't run
 """

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -74,7 +74,7 @@ def test_resolve_detects_missing_dependency():
 
 def test_default_registry_has_all_jobs():
     registry = build_default_registry()
-    assert len(registry.jobs) == 20
+    assert len(registry.jobs) == 21
 
 
 def test_default_registry_resolves_without_error():
@@ -82,7 +82,8 @@ def test_default_registry_resolves_without_error():
     order = resolve_execution_order(registry)
     names = [j.name for j in order]
     assert names.index("crashes_ccrs") < names.index("backfill")
-    assert names.index("parties_victims") < names.index("backfill")
+    assert names.index("parties") < names.index("backfill")
+    assert names.index("victims") < names.index("backfill")
     assert names.index("backfill") < names.index("matviews")
     assert names.index("matviews") < names.index("insights")
     assert names.index("insights") < names.index("vacuum")


### PR DESCRIPTION
## What does this PR do?

fix/etl-orchestrator-timeout-detached


## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
