### PR TITLE
(#165) Date range filter (month/year)

### DIFF
--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -12,7 +12,8 @@ error envelope documented in the spec.
 
 from __future__ import annotations
 
-from datetime import date
+from calendar import monthrange
+from datetime import date, datetime, time
 
 from sqlalchemy import ColumnElement
 
@@ -55,6 +56,87 @@ def parse_year(raw: str | None) -> set[int] | None:
             )
         out.add(y)
     return out or None
+
+
+# Date range — month-resolution start/end (?start=2020-01&end=2023-12).
+DateRange = tuple[date | None, date | None]
+
+
+def _parse_year_month(raw: str, filter_name: str) -> tuple[int, int]:
+    parts = raw.split("-")
+    if len(parts) != 2 or len(parts[0]) != 4 or len(parts[1]) != 2:
+        raise FilterError(
+            filter_name,
+            f"{filter_name} must be in YYYY-MM format; got '{raw}'.",
+        )
+    try:
+        y = int(parts[0])
+        m = int(parts[1])
+    except ValueError:
+        raise FilterError(
+            filter_name,
+            f"{filter_name} must be in YYYY-MM format; got '{raw}'.",
+        ) from None
+    current_year = date.today().year
+    if y < _FIRST_YEAR or y > current_year:
+        raise FilterError(
+            filter_name,
+            f"Year {y} is outside the supported range "
+            f"({_FIRST_YEAR}-{current_year}).",
+        )
+    if m < 1 or m > 12:
+        raise FilterError(
+            filter_name,
+            f"Month must be 1-12; got {m}.",
+        )
+    return y, m
+
+
+def parse_date_range(start: str | None, end: str | None) -> DateRange | None:
+    """Parse ?start=YYYY-MM&end=YYYY-MM into a (start_date, end_date) tuple.
+
+    `start` becomes the first day of the start month; `end` becomes the
+    last day of the end month (inclusive). Either side may be omitted.
+    Returns None when both inputs are empty/missing.
+    """
+    has_start = start is not None and start != ""
+    has_end = end is not None and end != ""
+    if not has_start and not has_end:
+        return None
+
+    start_d: date | None = None
+    end_d: date | None = None
+
+    if has_start:
+        sy, sm = _parse_year_month(start, "start")  # type: ignore[arg-type]
+        start_d = date(sy, sm, 1)
+    if has_end:
+        ey, em = _parse_year_month(end, "end")  # type: ignore[arg-type]
+        end_d = date(ey, em, monthrange(ey, em)[1])
+
+    if start_d and end_d and start_d > end_d:
+        raise FilterError(
+            "end",
+            f"end ({end}) must be on or after start ({start}).",
+        )
+
+    return start_d, end_d
+
+
+def years_from_date_range(date_range: DateRange | None) -> set[int] | None:
+    """Convert a date range into the set of years it spans.
+
+    Used for endpoints that aggregate against year-resolution materialized
+    views; month-level precision is rounded outward.
+    """
+    if date_range is None:
+        return None
+    start_d, end_d = date_range
+    start_y = start_d.year if start_d else _FIRST_YEAR
+    end_y = end_d.year if end_d else date.today().year
+    if start_y > end_y:
+        return set()
+    return set(range(start_y, end_y + 1))
 
 
 def parse_county_codes(
@@ -158,15 +240,26 @@ def parse_bool_flag(raw: str | None, name: str) -> bool | None:
 def build_crash_predicates(
     *,
     years: set[int] | None = None,
+    date_range: DateRange | None = None,
     county_codes: set[int] | None = None,
     severities: set[str] | None = None,
     causes: set[str] | None = None,
     alcohol: bool | None = None,
     distracted: bool | None = None,
 ) -> list[ColumnElement]:
-    """Build SQLAlchemy WHERE predicates for the crashes table."""
+    """Build SQLAlchemy WHERE predicates for the crashes table.
+
+    `date_range` filters on `crash_datetime` at month resolution and takes
+    precedence over `years` when both are supplied.
+    """
     preds: list[ColumnElement] = []
-    if years:
+    if date_range is not None:
+        start_d, end_d = date_range
+        if start_d:
+            preds.append(Crash.crash_datetime >= datetime.combine(start_d, time.min))
+        if end_d:
+            preds.append(Crash.crash_datetime <= datetime.combine(end_d, time.max))
+    elif years:
         preds.append(Crash.crash_year.in_(years))
     if county_codes:
         preds.append(Crash.county_code.in_(county_codes))

--- a/backend/app/routers/crash_people.py
+++ b/backend/app/routers/crash_people.py
@@ -19,7 +19,9 @@ from app.database import get_db
 from app.filters import (
     FilterError,
     parse_county_codes,
+    parse_date_range,
     parse_year,
+    years_from_date_range,
 )
 from app.models import Crash, CrashParty, CrashVictim
 from app.schemas.common import PaginatedResponse
@@ -127,6 +129,8 @@ def list_parties(
     data_source: str | None = Query(None, pattern="^(ccrs|switrs)$"),
     county: str | None = Query(None),
     year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
     gender: str | None = Query(None),
     age_min: int | None = Query(None, ge=0, le=130),
     age_max: int | None = Query(None, ge=0, le=130),
@@ -161,7 +165,8 @@ def list_parties(
     if data_source is not None:
         q = q.filter(CrashParty.data_source == data_source)
 
-    needs_join = bool(county) or bool(year)
+    date_range = parse_date_range(start, end)
+    needs_join = bool(county) or bool(year) or date_range is not None
     if needs_join:
         q = q.join(
             Crash,
@@ -172,7 +177,11 @@ def list_parties(
             codes = parse_county_codes(county, get_slug_map(db))
             if codes:
                 q = q.filter(Crash.county_code.in_(codes))
-        if year:
+        if date_range is not None:
+            years = years_from_date_range(date_range)
+            if years:
+                q = q.filter(Crash.crash_year.in_(years))
+        elif year:
             years = parse_year(year)
             if years:
                 q = q.filter(Crash.crash_year.in_(years))
@@ -204,6 +213,8 @@ def list_victims(
     data_source: str | None = Query(None, pattern="^(ccrs|switrs)$"),
     county: str | None = Query(None),
     year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
     gender: str | None = Query(None),
     age_min: int | None = Query(None, ge=0, le=130),
     age_max: int | None = Query(None, ge=0, le=130),
@@ -234,7 +245,8 @@ def list_victims(
     if data_source is not None:
         q = q.filter(CrashVictim.data_source == data_source)
 
-    needs_join = bool(county) or bool(year)
+    date_range = parse_date_range(start, end)
+    needs_join = bool(county) or bool(year) or date_range is not None
     if needs_join:
         q = q.join(
             Crash,
@@ -245,7 +257,11 @@ def list_victims(
             codes = parse_county_codes(county, get_slug_map(db))
             if codes:
                 q = q.filter(Crash.county_code.in_(codes))
-        if year:
+        if date_range is not None:
+            years = years_from_date_range(date_range)
+            if years:
+                q = q.filter(Crash.crash_year.in_(years))
+        elif year:
             years = parse_year(year)
             if years:
                 q = q.filter(Crash.crash_year.in_(years))

--- a/backend/app/routers/crashes.py
+++ b/backend/app/routers/crashes.py
@@ -15,6 +15,7 @@ from app.filters import (
     parse_bool_flag,
     parse_cause,
     parse_county_codes,
+    parse_date_range,
     parse_severity,
     parse_year,
 )
@@ -41,6 +42,8 @@ COUNT_STATEMENT_TIMEOUT_MS = 5000
 def list_crashes(
     response: Response,
     year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
     county: str | None = Query(None),
     severity: str | None = Query(None),
     cause: str | None = Query(None),
@@ -54,7 +57,9 @@ def list_crashes(
     """Paginated crash detail records.
 
     Filters (all multi-value, comma-separated):
-      - `year=2020,2023`
+      - `start=2020-01&end=2023-12` (month-resolution date range; either
+        side may be omitted)
+      - `year=2020,2023` (legacy; ignored when `start` or `end` is set)
       - `county=los-angeles,orange` (slugified county names)
       - `severity=fatal,injury,property-damage-only`
       - `cause=dui,speeding,lane-change,other`
@@ -68,7 +73,8 @@ def list_crashes(
     """
     response.headers["Cache-Control"] = "public, max-age=300"
 
-    years = parse_year(year)
+    date_range = parse_date_range(start, end)
+    years = parse_year(year) if date_range is None else None
     county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
     severities = parse_severity(severity)
     causes = parse_cause(cause)
@@ -76,18 +82,20 @@ def list_crashes(
     distracted_v = parse_bool_flag(distracted, "distracted")
 
     if include_total and not any([
-        years, county_codes, severities, causes,
+        date_range is not None, years, county_codes, severities, causes,
         alcohol_v is not None, distracted_v is not None,
     ]):
         raise FilterError(
             "include_total",
-            "include_total=true requires at least one filter (year, county, "
-            "severity, cause, alcohol, distracted). Unbounded COUNT(*) over "
-            "11M crashes is too slow. For aggregate totals, use /api/stats.",
+            "include_total=true requires at least one filter (start/end, "
+            "year, county, severity, cause, alcohol, distracted). Unbounded "
+            "COUNT(*) over 11M crashes is too slow. For aggregate totals, "
+            "use /api/stats.",
         )
 
     preds = build_crash_predicates(
         years=years,
+        date_range=date_range,
         county_codes=county_codes,
         severities=severities,
         causes=causes,

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -15,6 +15,7 @@ from app.filters import (
     parse_bool_flag,
     parse_cause,
     parse_county_codes,
+    parse_date_range,
     parse_severity,
     parse_year,
 )
@@ -51,6 +52,8 @@ _DECIMALS = {
 def crash_heatmap(
     response: Response,
     year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
     county: str | None = Query(None),
     severity: str | None = Query(None),
     cause: str | None = Query(None),
@@ -73,7 +76,8 @@ def crash_heatmap(
     """
     response.headers["Cache-Control"] = "public, max-age=300"
 
-    years = parse_year(year)
+    date_range = parse_date_range(start, end)
+    years = parse_year(year) if date_range is None else None
     county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
     severities = parse_severity(severity)
     causes = parse_cause(cause)
@@ -91,6 +95,7 @@ def crash_heatmap(
 
     preds = build_crash_predicates(
         years=years,
+        date_range=date_range,
         county_codes=county_codes,
         severities=severities,
         causes=causes,

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -11,8 +11,10 @@ from app.filters import (
     build_crash_predicates,
     parse_cause,
     parse_county_codes,
+    parse_date_range,
     parse_severity,
     parse_year,
+    years_from_date_range,
 )
 from app.models import County, Crash
 from app.schemas.stats import (
@@ -137,6 +139,8 @@ def _apply_filters(stmt, view, years, county_codes, severities, causes):
 def stats(
     response: Response,
     year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
     county: str | None = Query(None),
     severity: str | None = Query(None),
     cause: str | None = Query(None),
@@ -161,6 +165,11 @@ def stats(
     those columns). Use `/api/crashes` with those filters for drill-down.
     `cause` filter is incompatible with `group_by=gender|age_bracket`
     because the victim-demographics view doesn't carry canonical_cause.
+
+    `start`/`end` (YYYY-MM) are accepted but rounded outward to year
+    boundaries here, since the underlying materialized views aggregate by
+    year. For month-precise filtering, use `/api/crashes` or
+    `/api/crashes/heatmap`.
     """
     response.headers["Cache-Control"] = "public, max-age=300"
 
@@ -175,7 +184,8 @@ def stats(
             "Distracted filter is not supported on /api/stats. Use /api/crashes?distracted=true.",
         )
 
-    years = parse_year(year)
+    date_range = parse_date_range(start, end)
+    years = years_from_date_range(date_range) if date_range is not None else parse_year(year)
     county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
     severities = parse_severity(severity)
     causes = parse_cause(cause)

--- a/backend/tests/unit/test_filters.py
+++ b/backend/tests/unit/test_filters.py
@@ -1,5 +1,7 @@
 """Unit tests for URL-param parsers and predicate builder in app.filters."""
 
+from datetime import date
+
 import pytest
 
 from app.filters import (
@@ -8,8 +10,10 @@ from app.filters import (
     parse_bool_flag,
     parse_cause,
     parse_county_codes,
+    parse_date_range,
     parse_severity,
     parse_year,
+    years_from_date_range,
 )
 
 
@@ -173,3 +177,99 @@ def test_build_crash_predicates_combined():
         years={2023}, county_codes={19}, severities={"Fatal"}
     )
     assert len(preds) == 3
+
+
+# --- date range ---
+
+def test_parse_date_range_both_none_returns_none():
+    assert parse_date_range(None, None) is None
+
+
+def test_parse_date_range_both_empty_returns_none():
+    assert parse_date_range("", "") is None
+
+
+def test_parse_date_range_full_range():
+    start, end = parse_date_range("2020-03", "2022-08")
+    assert start == date(2020, 3, 1)
+    # end is the last day of the end month, inclusive.
+    assert end == date(2022, 8, 31)
+
+
+def test_parse_date_range_open_start():
+    result = parse_date_range(None, "2023-06")
+    assert result is not None
+    start, end = result
+    assert start is None
+    assert end == date(2023, 6, 30)
+
+
+def test_parse_date_range_open_end():
+    result = parse_date_range("2023-01", None)
+    assert result is not None
+    start, end = result
+    assert start == date(2023, 1, 1)
+    assert end is None
+
+
+def test_parse_date_range_february_leap_year():
+    _, end = parse_date_range("2020-02", "2020-02")
+    assert end == date(2020, 2, 29)
+
+
+def test_parse_date_range_rejects_bad_format():
+    with pytest.raises(FilterError) as exc_info:
+        parse_date_range("2020", None)
+    assert exc_info.value.filter == "start"
+
+
+def test_parse_date_range_rejects_bad_month():
+    with pytest.raises(FilterError) as exc_info:
+        parse_date_range("2020-13", None)
+    assert exc_info.value.filter == "start"
+
+
+def test_parse_date_range_rejects_out_of_range_year():
+    with pytest.raises(FilterError) as exc_info:
+        parse_date_range("1990-06", None)
+    assert exc_info.value.filter == "start"
+
+
+def test_parse_date_range_rejects_inverted_range():
+    with pytest.raises(FilterError) as exc_info:
+        parse_date_range("2023-06", "2020-01")
+    assert exc_info.value.filter == "end"
+
+
+def test_years_from_date_range_full():
+    dr = parse_date_range("2020-03", "2022-08")
+    assert years_from_date_range(dr) == {2020, 2021, 2022}
+
+
+def test_years_from_date_range_single_month():
+    dr = parse_date_range("2023-06", "2023-06")
+    assert years_from_date_range(dr) == {2023}
+
+
+def test_years_from_date_range_none():
+    assert years_from_date_range(None) is None
+
+
+def test_build_crash_predicates_uses_date_range_over_years():
+    dr = parse_date_range("2023-01", "2023-12")
+    preds = build_crash_predicates(years={2020}, date_range=dr)
+    # Both bounds (>= start, <= end) — no crash_year predicate.
+    assert len(preds) == 2
+    compiled = " ".join(
+        str(p.compile(compile_kwargs={"literal_binds": True})) for p in preds
+    )
+    assert "crashes.crash_datetime" in compiled
+    assert "crash_year" not in compiled
+
+
+def test_build_crash_predicates_open_ended_date_range():
+    dr = parse_date_range("2023-01", None)
+    preds = build_crash_predicates(date_range=dr)
+    assert len(preds) == 1
+    compiled = str(preds[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "crashes.crash_datetime >=" in compiled

--- a/frontend/src/components/map/CountyBoundaries.tsx
+++ b/frontend/src/components/map/CountyBoundaries.tsx
@@ -43,7 +43,7 @@ export default function CountyBoundaries({
   onSelectCounty,
 }: CountyBoundariesProps) {
   const map = useMap();
-  const { selectedYears, selectedSeverities, selectedCauses, selectedCounties } = useFilterParams();
+  const { selectedDateRange, selectedSeverities, selectedCauses, selectedCounties } = useFilterParams();
   const { choroplethOn, measure, palette, setBucketEdges, otherLayers } = useLayersState();
   const isDark = useIsDark();
 
@@ -57,11 +57,11 @@ export default function CountyBoundaries({
   // params (MVs don't carry them). See stats.py lines 134-143.
   const filters = useMemo(
     () => ({
-      years: [...selectedYears].sort((a, b) => a - b),
+      dateRange: selectedDateRange,
       severities: [...selectedSeverities],
       causes: [...selectedCauses],
     }),
-    [selectedYears, selectedSeverities, selectedCauses],
+    [selectedDateRange, selectedSeverities, selectedCauses],
   );
   const { byCountyCode } = useChoroplethData(measure, filters);
 

--- a/frontend/src/components/map/FiltersPanel.tsx
+++ b/frontend/src/components/map/FiltersPanel.tsx
@@ -1,9 +1,14 @@
 import { useState } from "react";
-import { YEARS, CA_COUNTIES, CAUSES, SEVERITIES } from "../../hooks/useFilterParams";
+import {
+  YEARS,
+  CA_COUNTIES,
+  CAUSES,
+  SEVERITIES,
+  formatYearMonth,
+  type DateRangeFilter,
+  type YearMonth,
+} from "../../hooks/useFilterParams";
 import SearchableMultiSelect from "../ui/SearchableMultiSelect";
-
-const DISPLAY_YEAR_COUNT = 6;
-const displayYears = YEARS.slice(-DISPLAY_YEAR_COUNT);
 
 const PILL_ACTIVE = "px-3 py-1.5 rounded-full text-xs font-semibold bg-primary text-on-primary transition-all";
 const PILL_INACTIVE = "px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-all";
@@ -16,18 +21,22 @@ const countyOptions = [
 /** Stable reference — avoids creating a new Set on every render. */
 const ALL_COUNTIES_SET = new Set(["__all__"]);
 
+const MONTHS: { value: number; label: string }[] = [
+  { value: 1, label: "Jan" }, { value: 2, label: "Feb" }, { value: 3, label: "Mar" },
+  { value: 4, label: "Apr" }, { value: 5, label: "May" }, { value: 6, label: "Jun" },
+  { value: 7, label: "Jul" }, { value: 8, label: "Aug" }, { value: 9, label: "Sep" },
+  { value: 10, label: "Oct" }, { value: 11, label: "Nov" }, { value: 12, label: "Dec" },
+];
+
 interface FiltersPanelProps {
-  selectedYears: Set<number>;
+  selectedDateRange: DateRangeFilter | null;
   selectedSeverities: Set<string>;
   selectedCounties: Set<string>;
   selectedCauses: Set<string>;
   selectedAlcohol: boolean;
   selectedDistracted: boolean;
-  onToggleYear: (year: number) => void;
-  onSetYearRange: (from: number, to: number) => void;
-  onSetYears?: (years: Set<number>) => void;
-  onClearYears: () => void;
-  onSetAllYears?: () => void;
+  onSetDateRange: (start: YearMonth | null, end: YearMonth | null) => void;
+  onClearDateRange: () => void;
   onToggleSeverity: (severity: string) => void;
   onSetSeverities?: (severities: Set<string>) => void;
   onSetAllSeverities?: () => void;
@@ -44,15 +53,12 @@ interface FiltersPanelProps {
 }
 
 export default function FiltersPanel({
-  selectedYears,
+  selectedDateRange,
   selectedSeverities,
   selectedCounties,
   selectedCauses,
-  onToggleYear,
-  onSetYearRange,
-  onSetYears,
-  onClearYears,
-  onSetAllYears,
+  onSetDateRange,
+  onClearDateRange,
   onToggleSeverity,
   onSetSeverities,
   onSetAllSeverities,
@@ -65,18 +71,10 @@ export default function FiltersPanel({
   onClearCauses,
   resetKey = 0,
 }: FiltersPanelProps) {
-  // "range" = from–to input, "custom" = single year input, null = default pill view
-  const [inputMode, setInputMode] = useState<"range" | "custom" | null>(null);
-  const [rangeFrom, setRangeFrom] = useState("");
-  const [rangeTo, setRangeTo] = useState("");
-  const [customInput, setCustomInput] = useState("");
-
   // Stash previous selections so "All" toggle can restore them
-  const [prevYears, setPrevYears] = useState<Set<number> | null>(null);
   const [prevCauses, setPrevCauses] = useState<Set<string> | null>(null);
   const [prevSeverities, setPrevSeverities] = useState<Set<string> | null>(null);
 
-  const allYearsSelected = selectedYears.size === YEARS.length;
   const allCausesSelected = selectedCauses.size === CAUSES.length;
   const allSeveritiesSelected = selectedSeverities.size === SEVERITIES.length;
 
@@ -104,25 +102,17 @@ export default function FiltersPanel({
     };
   }
 
-  const sortedYears = [...selectedYears].sort((a, b) => a - b);
-  const displaySet = new Set(displayYears);
-  const customYears = sortedYears.filter((y) => !displaySet.has(y));
+  // Date range — derive partial values so changing year/month either side
+  // independently still produces a valid range.
+  const start = selectedDateRange?.start ?? null;
+  const end = selectedDateRange?.end ?? null;
+  const dateRangeActive = start !== null || end !== null;
 
-  function handleRangeSubmit() {
-    const a = parseInt(rangeFrom, 10);
-    const b = parseInt(rangeTo, 10);
-    if (Number.isNaN(a) || Number.isNaN(b)) return;
-    onSetYearRange(Math.min(a, b), Math.max(a, b));
-    setInputMode(null);
-    setRangeFrom("");
-    setRangeTo("");
+  function updateStart(next: YearMonth | null) {
+    onSetDateRange(next, end);
   }
-
-  function handleCustomSubmit() {
-    const y = parseInt(customInput, 10);
-    if (Number.isNaN(y) || !YEARS.includes(y)) return;
-    if (!selectedYears.has(y)) onToggleYear(y);
-    setCustomInput("");
+  function updateEnd(next: YearMonth | null) {
+    onSetDateRange(start, next);
   }
 
   return (
@@ -148,132 +138,47 @@ export default function FiltersPanel({
         />
       </div>
 
-      {/* Year */}
+      {/* Date range */}
       <div className="space-y-3">
-        <label className="text-[10px] font-bold uppercase tracking-widest">
-          Year
-        </label>
-
-        {/* Quick pick pills — always visible unless All is active */}
-        <div className="flex flex-wrap gap-2">
-          {onSetAllYears && (
+        <div className="flex items-center justify-between">
+          <label className="text-[10px] font-bold uppercase tracking-widest">
+            Date Range
+          </label>
+          {dateRangeActive && (
             <button
-              onClick={makeAllToggle(allYearsSelected, selectedYears, prevYears, setPrevYears, onSetAllYears, onClearYears, onSetYears)}
-              className={allYearsSelected ? PILL_ACTIVE : PILL_INACTIVE}
+              type="button"
+              onClick={onClearDateRange}
+              className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant hover:text-on-surface transition-colors"
             >
-              All
+              Clear
             </button>
-          )}
-          {!allYearsSelected && (
-            <>
-              {displayYears.map((year) => (
-                <button
-                  key={year}
-                  onClick={() => onToggleYear(year)}
-                  className={
-                    selectedYears.has(year)
-                      ? PILL_ACTIVE
-                      : PILL_INACTIVE
-                  }
-                >
-                  {year}
-                </button>
-              ))}
-            </>
           )}
         </div>
 
-        {/* Custom year pills — removable */}
-        {!allYearsSelected && customYears.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {customYears.map((y) => (
-              <span
-                key={y}
-                className="inline-flex items-center bg-tertiary-container text-on-tertiary-container rounded-full text-xs font-semibold"
-              >
-                <span className="pl-2.5 pr-1 py-1">{y}</span>
-                <button
-                  onClick={() => onToggleYear(y)}
-                  className="pr-2 pl-0.5 py-1 hover:opacity-70 transition-opacity"
-                >
-                  <span className="material-symbols-outlined text-[12px]">close</span>
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
+        <div className="space-y-2">
+          <MonthYearPicker
+            label="From"
+            value={start}
+            onChange={updateStart}
+          />
+          <MonthYearPicker
+            label="To"
+            value={end}
+            onChange={updateEnd}
+          />
+        </div>
 
-        {/* Range / Custom input modes */}
-        {!allYearsSelected && (
-          <>
-            {inputMode === "range" ? (
-              <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={rangeFrom}
-                    onChange={(e) => setRangeFrom(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === "Enter") handleRangeSubmit(); }}
-                    placeholder="From"
-                    autoFocus
-                    className="w-20 px-3 py-2.5 rounded-lg text-xs font-semibold bg-surface-container-high text-on-surface border-none focus:ring-2 focus:ring-primary/20 text-center"
-                  />
-                  <span className="text-on-surface-variant text-xs">–</span>
-                  <input
-                    type="text"
-                    inputMode="numeric"
-                    value={rangeTo}
-                    onChange={(e) => setRangeTo(e.target.value)}
-                    onKeyDown={(e) => { if (e.key === "Enter") handleRangeSubmit(); }}
-                    placeholder="To"
-                    className="w-20 px-3 py-2.5 rounded-lg text-xs font-semibold bg-surface-container-high text-on-surface border-none focus:ring-2 focus:ring-primary/20 text-center"
-                  />
-                  <button type="button" onClick={handleRangeSubmit} className="p-2.5 rounded-lg bg-primary text-on-primary hover:opacity-90 transition-all">
-                    <span className="material-symbols-outlined text-[18px]">check</span>
-                  </button>
-                  <button type="button" onClick={() => { setInputMode(null); setRangeFrom(""); setRangeTo(""); }} className="text-on-surface-variant hover:text-on-surface">
-                    <span className="material-symbols-outlined text-[18px]">close</span>
-                  </button>
-                </div>
-                <p className="text-[10px] text-on-surface-variant">e.g. 2001 – 2015</p>
-              </div>
-            ) : inputMode === "custom" ? (
-              <div className="flex items-center gap-2">
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  value={customInput}
-                  onChange={(e) => setCustomInput(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") handleCustomSubmit(); }}
-                  placeholder="Year"
-                  autoFocus
-                  className="w-20 px-3 py-2.5 rounded-lg text-xs font-semibold bg-surface-container-high text-on-surface border-none focus:ring-2 focus:ring-primary/20 text-center"
-                />
-                <button type="button" onClick={handleCustomSubmit} className="p-2.5 rounded-lg bg-primary text-on-primary hover:opacity-90 transition-all">
-                  <span className="material-symbols-outlined text-[18px]">add</span>
-                </button>
-                <button type="button" onClick={() => { setInputMode(null); setCustomInput(""); }} className="text-on-surface-variant hover:text-on-surface">
-                  <span className="material-symbols-outlined text-[18px]">close</span>
-                </button>
-              </div>
-            ) : (
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setInputMode("range")}
-                  className="px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-all border border-dashed border-outline-variant"
-                >
-                  Range
-                </button>
-                <button
-                  onClick={() => setInputMode("custom")}
-                  className="px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-all border border-dashed border-outline-variant"
-                >
-                  Custom
-                </button>
-              </div>
-            )}
-          </>
+        {!dateRangeActive && (
+          <p className="text-[10px] text-on-surface-variant">
+            All available years (2001–{YEARS[YEARS.length - 1]})
+          </p>
+        )}
+        {dateRangeActive && (
+          <p className="text-[10px] text-on-surface-variant">
+            {start ? formatYearMonth(start) : "earliest"}
+            {" – "}
+            {end ? formatYearMonth(end) : "latest"}
+          </p>
         )}
       </div>
 
@@ -340,6 +245,68 @@ export default function FiltersPanel({
         </div>
       </div>
 
+    </div>
+  );
+}
+
+interface MonthYearPickerProps {
+  label: string;
+  value: YearMonth | null;
+  onChange: (next: YearMonth | null) => void;
+}
+
+function MonthYearPicker({ label, value, onChange }: MonthYearPickerProps) {
+  const handleMonth = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    if (v === "") {
+      onChange(null);
+      return;
+    }
+    const month = Number(v);
+    const year = value?.year ?? YEARS[YEARS.length - 1];
+    onChange({ year, month });
+  };
+
+  const handleYear = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    if (v === "") {
+      onChange(null);
+      return;
+    }
+    const year = Number(v);
+    const month = value?.month ?? 1;
+    onChange({ year, month });
+  };
+
+  const selectClass = "px-2.5 py-2 rounded-md text-xs font-semibold bg-surface-container-high text-on-surface border-none focus:ring-2 focus:ring-primary/20";
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-10 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+        {label}
+      </span>
+      <select
+        aria-label={`${label} month`}
+        value={value?.month ?? ""}
+        onChange={handleMonth}
+        className={selectClass}
+      >
+        <option value="">Month</option>
+        {MONTHS.map((m) => (
+          <option key={m.value} value={m.value}>{m.label}</option>
+        ))}
+      </select>
+      <select
+        aria-label={`${label} year`}
+        value={value?.year ?? ""}
+        onChange={handleYear}
+        className={selectClass}
+      >
+        <option value="">Year</option>
+        {[...YEARS].reverse().map((y) => (
+          <option key={y} value={y}>{y}</option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/frontend/src/hooks/useChoroplethData.test.tsx
+++ b/frontend/src/hooks/useChoroplethData.test.tsx
@@ -6,7 +6,7 @@ import { useChoroplethData, type ChoroplethFilters } from "./useChoroplethData";
 import type { MeasureKey } from "../lib/choropleth/measures";
 
 const FILTERS: ChoroplethFilters = {
-  years: [2023],
+  dateRange: { start: { year: 2023, month: 1 }, end: { year: 2023, month: 12 } },
   severities: [],
   causes: [],
 };
@@ -44,9 +44,9 @@ describe("useChoroplethData", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(fetchSpy).toHaveBeenCalledTimes(3);
     const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
-    expect(urls.some((u) => u.includes("/api/stats") && u.includes("group_by=county") && u.includes("year=2023"))).toBe(true);
+    expect(urls.some((u) => u.includes("/api/stats") && u.includes("group_by=county") && u.includes("start=2023-01") && u.includes("end=2023-12"))).toBe(true);
     expect(urls.some((u) => u.includes("/api/stats") && u.includes("group_by=year"))).toBe(true);
-    expect(urls.some((u) => u.includes("/api/demographics") && u.includes("year=2023"))).toBe(true);
+    expect(urls.some((u) => u.includes("/api/demographics") && u.includes("start=2023-01") && u.includes("end=2023-12"))).toBe(true);
     expect(urls.every((u) => !u.includes("county="))).toBe(true);
   });
 
@@ -166,7 +166,11 @@ describe("useChoroplethData", () => {
       ]));
     });
 
-    const filters: ChoroplethFilters = { years: [2023, 2024, 2025], severities: [], causes: [] };
+    const filters: ChoroplethFilters = {
+      dateRange: { start: { year: 2023, month: 1 }, end: { year: 2025, month: 12 } },
+      severities: [],
+      causes: [],
+    };
     const { result } = renderHook(
       () => useChoroplethData("crashes_per_100k", filters),
       { wrapper: makeWrapper() },
@@ -179,7 +183,7 @@ describe("useChoroplethData", () => {
   it("returns empty missingDemoYears in dataSummary when no years are selected", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify([])));
 
-    const filters: ChoroplethFilters = { years: [], severities: [], causes: [] };
+    const filters: ChoroplethFilters = { dateRange: null, severities: [], causes: [] };
     const { result } = renderHook(
       () => useChoroplethData("crashes_per_100k", filters),
       { wrapper: makeWrapper() },
@@ -204,7 +208,11 @@ describe("useChoroplethData", () => {
       return new Response(JSON.stringify(demoRows));
     });
 
-    const filters: ChoroplethFilters = { years: [2007], severities: [], causes: [] };
+    const filters: ChoroplethFilters = {
+      dateRange: { start: { year: 2007, month: 1 }, end: { year: 2007, month: 12 } },
+      severities: [],
+      causes: [],
+    };
     const { result } = renderHook(
       () => useChoroplethData("crashes_per_100k", filters),
       { wrapper: makeWrapper() },
@@ -230,7 +238,11 @@ describe("useChoroplethData", () => {
       return new Response(JSON.stringify([]));
     });
 
-    const filters: ChoroplethFilters = { years: [currentYear - 1, currentYear], severities: [], causes: [] };
+    const filters: ChoroplethFilters = {
+      dateRange: { start: { year: currentYear - 1, month: 1 }, end: { year: currentYear, month: 12 } },
+      severities: [],
+      causes: [],
+    };
     const { result } = renderHook(
       () => useChoroplethData("crashes_raw", filters),
       { wrapper: makeWrapper() },

--- a/frontend/src/hooks/useChoroplethData.ts
+++ b/frontend/src/hooks/useChoroplethData.ts
@@ -7,11 +7,18 @@ import {
   type MeasureKey,
   type MeasureResult,
 } from "../lib/choropleth/measures";
-import { CA_COUNTIES, YEARS, SEVERITIES, CAUSES } from "./useFilterParams";
+import {
+  CA_COUNTIES,
+  SEVERITIES,
+  CAUSES,
+  formatYearMonth,
+  yearsInRange,
+  type DateRangeFilter,
+} from "./useFilterParams";
 import { API_BASE } from "../config";
 
 export type ChoroplethFilters = {
-  years: number[];           // parsed from URL; empty = no year filter
+  dateRange: DateRangeFilter | null;
   severities: string[];      // backend values, e.g. "Fatal"
   causes: string[];          // URL slugs, e.g. ["dui", "lane-change"]
   // NOTE: alcohol / distracted are intentionally NOT here — /api/stats runs
@@ -57,7 +64,7 @@ export type ChoroplethData = {
 
 function normalizeFilters(filters: ChoroplethFilters): ChoroplethFilters {
   return {
-    years: filters.years.length === YEARS.length ? [] : filters.years,
+    dateRange: filters.dateRange,
     severities: filters.severities.length === SEVERITIES.length ? [] : filters.severities,
     causes: filters.causes.length === CAUSES.length ? [] : filters.causes,
   };
@@ -67,10 +74,16 @@ function severityToSlug(s: string): string {
   return s.toLowerCase().replace(/ /g, "-");
 }
 
+function appendDateRange(p: URLSearchParams, dr: DateRangeFilter | null) {
+  if (!dr) return;
+  if (dr.start) p.set("start", formatYearMonth(dr.start));
+  if (dr.end) p.set("end", formatYearMonth(dr.end));
+}
+
 function buildStatsUrl(filters: ChoroplethFilters): string {
   const p = new URLSearchParams();
   p.set("group_by", "county");
-  if (filters.years.length) p.set("year", filters.years.join(","));
+  appendDateRange(p, filters.dateRange);
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.causes.length) p.set("cause", filters.causes.join(","));
   // alcohol / distracted are NOT forwarded — /api/stats rejects them (MVs
@@ -81,7 +94,7 @@ function buildStatsUrl(filters: ChoroplethFilters): string {
 function buildYearStatsUrl(filters: ChoroplethFilters): string {
   const p = new URLSearchParams();
   p.set("group_by", "year");
-  if (filters.years.length) p.set("year", filters.years.join(","));
+  appendDateRange(p, filters.dateRange);
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.causes.length) p.set("cause", filters.causes.join(","));
   return `${API_BASE}/api/stats?${p}`;
@@ -89,17 +102,22 @@ function buildYearStatsUrl(filters: ChoroplethFilters): string {
 
 function buildDemoUrl(filters: ChoroplethFilters): string {
   const p = new URLSearchParams();
-  if (filters.years.length) p.set("year", filters.years.join(","));
+  appendDateRange(p, filters.dateRange);
   const qs = p.toString();
   return `${API_BASE}/api/demographics${qs ? `?${qs}` : ""}`;
 }
 
 export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFilters): ChoroplethData {
   const filters = normalizeFilters(rawFilters);
+  const dateKey = filters.dateRange
+    ? `${filters.dateRange.start ? formatYearMonth(filters.dateRange.start) : ""}|${filters.dateRange.end ? formatYearMonth(filters.dateRange.end) : ""}`
+    : "";
+  const cacheKey = { d: dateKey, s: filters.severities, c: filters.causes };
+
   const queries = useQueries({
     queries: [
       {
-        queryKey: ["choropleth", "stats", filters],
+        queryKey: ["choropleth", "stats", cacheKey],
         placeholderData: (prev: CountyStats[] | undefined) => prev,
         queryFn: async (): Promise<CountyStats[]> => {
           const res = await fetch(buildStatsUrl(filters));
@@ -112,7 +130,7 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
         },
       },
       {
-        queryKey: ["choropleth", "demographics", filters.years],
+        queryKey: ["choropleth", "demographics", dateKey],
         placeholderData: (prev: CountyYearDemo[] | undefined) => prev,
         queryFn: async (): Promise<CountyYearDemo[]> => {
           const res = await fetch(buildDemoUrl(filters));
@@ -121,7 +139,7 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
         },
       },
       {
-        queryKey: ["choropleth", "yearStats", filters],
+        queryKey: ["choropleth", "yearStats", cacheKey],
         placeholderData: (prev: YearStats[] | undefined) => prev,
         queryFn: async (): Promise<YearStats[]> => {
           const res = await fetch(buildYearStatsUrl(filters));
@@ -165,7 +183,8 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
       }
     }
 
-    if (filters.years.length === 0 || !demos) {
+    const yearsForDisclaimer = [...yearsInRange(filters.dateRange)];
+    if (yearsForDisclaimer.length === 0 || !demos) {
       return { totalCrashes, missingDemoYears: [], partialDemoYears: [], sparseYears };
     }
 
@@ -177,13 +196,13 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
     }
     const missingDemoYears: number[] = [];
     const partialDemoYears: number[] = [];
-    for (const y of [...filters.years].sort((a, b) => a - b)) {
+    for (const y of yearsForDisclaimer.sort((a, b) => a - b)) {
       const count = countiesByYear.get(y) ?? 0;
       if (count === 0) missingDemoYears.push(y);
       else if (count < CA_COUNTIES.length) partialDemoYears.push(y);
     }
     return { totalCrashes, missingDemoYears, partialDemoYears, sparseYears };
-  }, [filters.years, demos, yearStats]);
+  }, [filters.dateRange, demos, yearStats]);
 
   const rawError = (statsQ.error ?? demoQ.error ?? yearStatsQ.error) as (Error & { status?: number }) | null;
 

--- a/frontend/src/hooks/useCoordCoverage.ts
+++ b/frontend/src/hooks/useCoordCoverage.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { YEARS } from "./useFilterParams";
+import { YEARS, yearsInRange, type DateRangeFilter } from "./useFilterParams";
 import { API_BASE } from "../config";
 
 type DataQualityRow = {
@@ -15,7 +15,7 @@ export type CoordCoverage = {
   pct: number;
 };
 
-export function useCoordCoverage(selectedYears: number[]): CoordCoverage | null {
+export function useCoordCoverage(dateRange: DateRangeFilter | null): CoordCoverage | null {
   const { data } = useQuery<DataQualityRow[]>({
     queryKey: ["data-quality-statewide"],
     queryFn: async () => {
@@ -31,9 +31,9 @@ export function useCoordCoverage(selectedYears: number[]): CoordCoverage | null 
   // Only statewide per-year rows (county_code null, year present)
   const statewide = data.filter((r) => r.county_code === null && r.year !== null);
 
-  const allYears = selectedYears.length === 0 || selectedYears.length === YEARS.length;
-  const yearSet = allYears ? null : new Set(selectedYears);
-  const rows = yearSet ? statewide.filter((r) => yearSet.has(r.year!)) : statewide;
+  const yearSet = yearsInRange(dateRange);
+  const allYears = yearSet.size === 0 || yearSet.size === YEARS.length;
+  const rows = allYears ? statewide : statewide.filter((r) => yearSet.has(r.year!));
 
   if (!rows.length) return null;
 

--- a/frontend/src/hooks/useCrashHeatmap.test.ts
+++ b/frontend/src/hooks/useCrashHeatmap.test.ts
@@ -34,7 +34,7 @@ describe("useCrashHeatmap", () => {
         useCrashHeatmap({
           enabled: true,
           county: "los-angeles",
-          years: [2023],
+          dateRange: { start: { year: 2023, month: 1 }, end: { year: 2023, month: 12 } },
           severities: [],
           causes: [],
           resolution: "medium",
@@ -50,7 +50,8 @@ describe("useCrashHeatmap", () => {
     const url = String(spy.mock.calls[0][0]);
     expect(url).toContain("/api/crashes/heatmap");
     expect(url).toContain("county=los-angeles");
-    expect(url).toContain("year=2023");
+    expect(url).toContain("start=2023-01");
+    expect(url).toContain("end=2023-12");
     expect(url).toContain("resolution=medium");
   });
 
@@ -64,7 +65,7 @@ describe("useCrashHeatmap", () => {
         useCrashHeatmap({
           enabled: false,
           county: null,
-          years: [],
+          dateRange: null,
           severities: [],
           causes: [],
           resolution: "low",
@@ -85,7 +86,7 @@ describe("useCrashHeatmap", () => {
         useCrashHeatmap({
           enabled: true,
           county: null,
-          years: [],
+          dateRange: null,
           severities: [],
           causes: [],
           resolution: "low",

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useState, useEffect, useCallback } from "react";
 import { API_BASE } from "../config";
 import type { HeatmapResolution } from "./useLayersState";
-import { slugify } from "./useFilterParams";
+import { slugify, formatYearMonth, type DateRangeFilter } from "./useFilterParams";
 
 export interface HeatmapPoint {
   lat: number;
@@ -14,7 +14,7 @@ export interface HeatmapPoint {
 interface HeatmapParams {
   enabled: boolean;
   county: string | null;
-  years: number[];
+  dateRange: DateRangeFilter | null;
   severities: string[];
   causes: string[];
   alcohol?: boolean | null;
@@ -24,6 +24,11 @@ interface HeatmapParams {
   includeRivers?: boolean;
   batch?: number;
   batchSize?: number;
+}
+
+function dateRangeKey(dr: DateRangeFilter | null): string {
+  if (!dr) return "";
+  return `${dr.start ? formatYearMonth(dr.start) : ""}|${dr.end ? formatYearMonth(dr.end) : ""}`;
 }
 
 interface HeatmapApiResponse {
@@ -36,7 +41,8 @@ interface HeatmapApiResponse {
 function buildUrl(params: HeatmapParams): string {
   const sp = new URLSearchParams();
   if (params.county) sp.set("county", params.county);
-  if (params.years.length) sp.set("year", params.years.join(","));
+  if (params.dateRange?.start) sp.set("start", formatYearMonth(params.dateRange.start));
+  if (params.dateRange?.end) sp.set("end", formatYearMonth(params.dateRange.end));
   if (params.severities.length) sp.set("severity", params.severities.map(slugify).join(","));
   if (params.causes.length) sp.set("cause", params.causes.join(","));
   if (params.alcohol != null) sp.set("alcohol", String(params.alcohol));
@@ -60,7 +66,7 @@ export function useCrashHeatmap(params: HeatmapParams) {
     queryKey: [
       "crashHeatmap",
       params.county,
-      params.years,
+      dateRangeKey(params.dateRange),
       params.severities,
       params.causes,
       params.alcohol,
@@ -97,7 +103,7 @@ export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSi
     batchSize: size,
   });
 
-  const filterKey = `${params.county}|${params.years.join(",")}|${params.severities.join(",")}|${params.causes.join(",")}|${params.resolution}|${params.mismatchOnly ?? ""}|${params.includeRivers ?? ""}`;
+  const filterKey = `${params.county}|${dateRangeKey(params.dateRange)}|${params.severities.join(",")}|${params.causes.join(",")}|${params.resolution}|${params.mismatchOnly ?? ""}|${params.includeRivers ?? ""}`;
   useEffect(() => {
     setCurrentBatch(1);
     setAllPoints([]);

--- a/frontend/src/hooks/useDataQualityDisclaimer.ts
+++ b/frontend/src/hooks/useDataQualityDisclaimer.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { YEARS } from "./useFilterParams";
+import { YEARS, yearsInRange, type DateRangeFilter } from "./useFilterParams";
 import { API_BASE } from "../config";
 
 type QualityRow = {
@@ -34,7 +34,7 @@ function slugify(name: string) {
 }
 
 export function useDataQualityDisclaimer(
-  selectedYears: number[],
+  dateRange: DateRangeFilter | null,
   selectedCounties: string[],
 ): DataQualityDisclaimers {
   const singleCounty = selectedCounties.length === 1 ? slugify(selectedCounties[0]) : null;
@@ -54,8 +54,9 @@ export function useDataQualityDisclaimer(
     staleTime: 5 * 60 * 1000,
   });
 
-  const allYears = selectedYears.length === 0 || selectedYears.length === YEARS.length;
-  const years = allYears ? [...YEARS] : selectedYears;
+  const yearsArray = [...yearsInRange(dateRange)];
+  const allYears = yearsArray.length === 0 || yearsArray.length === YEARS.length;
+  const years = allYears ? [...YEARS] : yearsArray;
   const preDataOnly = !allYears && years.every((y) => y < 2016);
   const hasPreCcrsYears = !allYears && !preDataOnly && years.some((y) => y < 2016);
   const hasPreAcsYears = !allYears && years.some((y) => y < 2009);

--- a/frontend/src/hooks/useFilterParams.test.ts
+++ b/frontend/src/hooks/useFilterParams.test.ts
@@ -3,6 +3,9 @@ import {
   parseBoolFlag,
   parseSeverities,
   parseCauses,
+  parseYearMonth,
+  formatYearMonth,
+  yearsInRange,
   SEVERITIES,
   CAUSES,
   INVOLVEMENTS,
@@ -79,5 +82,59 @@ describe("parseCauses", () => {
   it("rejects removed causes", () => {
     const result = parseCauses("distracted,weather");
     expect(result.size).toBe(0);
+  });
+});
+
+describe("parseYearMonth", () => {
+  it("parses YYYY-MM into a YearMonth", () => {
+    expect(parseYearMonth("2023-07")).toEqual({ year: 2023, month: 7 });
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseYearMonth("2023")).toBeNull();
+    expect(parseYearMonth("2023/07")).toBeNull();
+    expect(parseYearMonth("")).toBeNull();
+    expect(parseYearMonth(null)).toBeNull();
+  });
+
+  it("rejects out-of-range months", () => {
+    expect(parseYearMonth("2023-00")).toBeNull();
+    expect(parseYearMonth("2023-13")).toBeNull();
+  });
+
+  it("rejects out-of-range years", () => {
+    expect(parseYearMonth("1990-06")).toBeNull();
+  });
+});
+
+describe("formatYearMonth", () => {
+  it("zero-pads single-digit months", () => {
+    expect(formatYearMonth({ year: 2023, month: 3 })).toBe("2023-03");
+  });
+
+  it("preserves double-digit months", () => {
+    expect(formatYearMonth({ year: 2023, month: 12 })).toBe("2023-12");
+  });
+});
+
+describe("yearsInRange", () => {
+  it("returns an empty set for null", () => {
+    expect(yearsInRange(null).size).toBe(0);
+  });
+
+  it("expands an inclusive range to whole years", () => {
+    const range = {
+      start: { year: 2020, month: 3 },
+      end: { year: 2022, month: 8 },
+    };
+    expect(yearsInRange(range)).toEqual(new Set([2020, 2021, 2022]));
+  });
+
+  it("supports an open-ended start (defaults to first available year)", () => {
+    const range = { start: null, end: { year: 2002, month: 6 } };
+    const out = yearsInRange(range);
+    expect(out.has(2001)).toBe(true);
+    expect(out.has(2002)).toBe(true);
+    expect(out.has(2003)).toBe(false);
   });
 });

--- a/frontend/src/hooks/useFilterParams.ts
+++ b/frontend/src/hooks/useFilterParams.ts
@@ -62,8 +62,92 @@ export const INVOLVEMENTS = [
 
 const CAUSE_VALUES: Set<string> = new Set(CAUSES.map((c) => c.value));
 
-const DEFAULT_YEARS = new Set<number>();
 const DEFAULT_SEVERITIES = new Set<string>();
+
+// ── Date range types ──
+
+export type YearMonth = { year: number; month: number }; // month: 1–12
+
+/**
+ * Filter on `crash_datetime`. `start` and `end` are independent — either side
+ * may be null (open-ended). The "no filter" representation is `null` for the
+ * whole DateRangeFilter, not `{ start: null, end: null }`.
+ */
+export type DateRangeFilter = { start: YearMonth | null; end: YearMonth | null };
+
+export function formatYearMonth(ym: YearMonth): string {
+  return `${ym.year}-${String(ym.month).padStart(2, "0")}`;
+}
+
+export function parseYearMonth(raw: string | null): YearMonth | null {
+  if (!raw) return null;
+  const m = /^(\d{4})-(\d{1,2})$/.exec(raw);
+  if (!m) return null;
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  if (!Number.isInteger(y) || !Number.isInteger(mo)) return null;
+  if (y < START_YEAR || y > currentYear) return null;
+  if (mo < 1 || mo > 12) return null;
+  return { year: y, month: mo };
+}
+
+/** Compare two YearMonths; -1 / 0 / 1 like Array.prototype.sort. */
+function compareYM(a: YearMonth, b: YearMonth): number {
+  if (a.year !== b.year) return a.year - b.year;
+  return a.month - b.month;
+}
+
+/** Read the current date-range filter from the URL. Null = no filter. */
+function readDateRange(searchParams: URLSearchParams): DateRangeFilter | null {
+  const start = parseYearMonth(searchParams.get("start"));
+  const end = parseYearMonth(searchParams.get("end"));
+
+  if (start || end) {
+    return { start, end };
+  }
+
+  // Legacy: ?year=2020,2023 collapses to a Jan(min)–Dec(max) range so old
+  // permalinks keep working. We only convert here for display; year-mode
+  // mutators are no longer exposed.
+  const legacyYears = parseLegacyYearList(searchParams.get("year"));
+  if (legacyYears.length > 0) {
+    const min = Math.min(...legacyYears);
+    const max = Math.max(...legacyYears);
+    return {
+      start: { year: min, month: 1 },
+      end: { year: max, month: 12 },
+    };
+  }
+
+  return null;
+}
+
+function parseLegacyYearList(param: string | null): number[] {
+  if (!param) return [];
+  return param
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(Number)
+    .filter((n) => Number.isInteger(n) && YEARS.includes(n));
+}
+
+/**
+ * Project a date range onto a year set — every year between start.year and
+ * end.year inclusive. Used for legacy consumers (charts, MV-backed endpoints)
+ * that only know about whole-year filtering.
+ */
+export function yearsInRange(range: DateRangeFilter | null): Set<number> {
+  if (!range) return new Set<number>();
+  const startY = range.start ? range.start.year : START_YEAR;
+  const endY = range.end ? range.end.year : currentYear;
+  if (startY > endY) return new Set<number>();
+  const out = new Set<number>();
+  for (let y = startY; y <= endY; y++) {
+    if (y >= START_YEAR && y <= currentYear) out.add(y);
+  }
+  return out;
+}
 
 // ── Slug utilities ──
 
@@ -88,22 +172,6 @@ const COUNTY_SLUG_MAP: Map<string, string> = new Map(
 );
 
 // ── Shared parsers (exported so StatsPage can use them too) ──
-
-export function parseYears(param: string | null): Set<number> {
-  // null = param missing from URL entirely → first visit, use defaults
-  // ""   = param present but empty → user cleared everything, allow empty
-  if (param === null) return new Set(DEFAULT_YEARS);
-  if (param === "") return new Set<number>();
-
-  const parsed = param
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map(Number)
-    .filter((n) => !Number.isNaN(n) && YEARS.includes(n));
-
-  return new Set(parsed);
-}
 
 export function parseSeverities(param: string | null): Set<string> {
   if (param === null) return new Set(DEFAULT_SEVERITIES);
@@ -146,7 +214,9 @@ export function parseBoolFlag(param: string | null): boolean {
 
 // ── Shared utilities ──
 
-const FILTER_KEYS = ["year", "severity", "county", "cause", "alcohol", "distracted"] as const;
+const FILTER_KEYS = [
+  "start", "end", "year", "severity", "county", "cause", "alcohol", "distracted",
+] as const;
 
 export function buildFilterQS(searchParams: URLSearchParams): string {
   const params = new URLSearchParams();
@@ -164,10 +234,12 @@ export function buildFilterQS(searchParams: URLSearchParams): string {
 export function useFilterParams() {
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // ── Memoize parsed Sets by their raw URL string ──────────────────────
-  // Without this, every render produces a brand-new Set object which
-  // cascades through useMemo/useCallback deps in CountyBoundaries,
-  // ChoroplethLegendContainer, etc., causing an infinite re-render loop.
+  // ── Memoize parsed values by their raw URL string ──
+  // Without this, every render produces a brand-new Set/object which
+  // cascades through useMemo deps in CountyBoundaries, ChoroplethLegend,
+  // etc., causing an infinite re-render loop.
+  const startParam = searchParams.get("start");
+  const endParam = searchParams.get("end");
   const yearParam = searchParams.get("year");
   const severityParam = searchParams.get("severity");
   const countyParam = searchParams.get("county");
@@ -176,10 +248,18 @@ export function useFilterParams() {
   const distractedParam = searchParams.get("distracted");
   const panel = searchParams.get("panel");
 
-  // ── Memoized parsed Sets ──
-  // Only recompute when the raw URL string actually changes,
-  // preventing new Set references on every render.
-  const selectedYears = useMemo(() => parseYears(yearParam), [yearParam]);
+  const selectedDateRange = useMemo<DateRangeFilter | null>(() => {
+    // Re-derive directly from the raw URL params so this stays referentially
+    // stable between renders — the parsed result only changes when the raw
+    // URL strings actually change.
+    const sp = new URLSearchParams();
+    if (startParam != null) sp.set("start", startParam);
+    if (endParam != null) sp.set("end", endParam);
+    if (yearParam != null) sp.set("year", yearParam);
+    return readDateRange(sp);
+  }, [startParam, endParam, yearParam]);
+
+  const selectedYears = useMemo(() => yearsInRange(selectedDateRange), [selectedDateRange]);
   const selectedSeverities = useMemo(() => parseSeverities(severityParam), [severityParam]);
   const selectedCounties = useMemo(() => parseCounties(countyParam), [countyParam]);
   const selectedCauses = useMemo(() => parseCauses(causeParam), [causeParam]);
@@ -187,47 +267,34 @@ export function useFilterParams() {
   const selectedDistracted = useMemo(() => parseBoolFlag(distractedParam), [distractedParam]);
 
   // ── Action callbacks ──
-  // Each reads the *latest* URL state via the functional updater
-  // inside setSearchParams, avoiding stale-closure bugs.
 
-  const toggleYear = useCallback(
-    (year: number) => {
+  const setDateRange = useCallback(
+    (start: YearMonth | null, end: YearMonth | null) => {
+      // Auto-correct flipped ranges.
+      if (start && end && compareYM(start, end) > 0) {
+        [start, end] = [end, start];
+      }
       setSearchParams((prev) => {
-        const current = parseYears(prev.get("year"));
-        if (current.has(year)) current.delete(year);
-        else current.add(year);
-        return buildNextParams(prev, { years: current });
+        const params = new URLSearchParams(prev);
+        params.delete("year"); // Drop legacy param when entering date-range mode.
+        if (start) params.set("start", formatYearMonth(start));
+        else params.delete("start");
+        if (end) params.set("end", formatYearMonth(end));
+        else params.delete("end");
+        return params;
       }, { replace: true });
     },
     [setSearchParams],
   );
 
-  const setYearRange = useCallback(
-    (from: number, to: number) => {
-      setSearchParams((prev) => {
-        const current = parseYears(prev.get("year"));
-        for (let y = from; y <= to; y++) {
-          if (YEARS.includes(y)) current.add(y);
-        }
-        return buildNextParams(prev, { years: current });
-      }, { replace: true });
-    },
-    [setSearchParams],
-  );
-
-  const setYears = useCallback(
-    (years: Set<number>) => {
-      setSearchParams((prev) => buildNextParams(prev, { years }), { replace: true });
-    },
-    [setSearchParams],
-  );
-
-  const clearYears = useCallback(() => {
-    setSearchParams((prev) => buildNextParams(prev, { years: new Set() }), { replace: true });
-  }, [setSearchParams]);
-
-  const setAllYears = useCallback(() => {
-    setSearchParams((prev) => buildNextParams(prev, { years: new Set(YEARS) }), { replace: true });
+  const clearDateRange = useCallback(() => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      params.delete("start");
+      params.delete("end");
+      params.delete("year");
+      return params;
+    }, { replace: true });
   }, [setSearchParams]);
 
   const toggleSeverity = useCallback(
@@ -323,11 +390,13 @@ export function useFilterParams() {
     }, { replace: true });
   }, [setSearchParams]);
 
-  // Clears all filter dimensions — year, severity, cause, alcohol, distracted.
+  // Clears all filter dimensions — date range, severity, cause, alcohol, distracted.
   // (County is intentionally preserved; use clearCounties() separately.)
   const clearFilters = useCallback(() => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);
+      params.delete("start");
+      params.delete("end");
       params.delete("year");
       params.delete("severity");
       params.delete("cause");
@@ -345,17 +414,15 @@ export function useFilterParams() {
   }, [setSearchParams]);
 
   return {
+    selectedDateRange,
     selectedYears,
     selectedSeverities,
     selectedCounties,
     selectedCauses,
     selectedAlcohol,
     selectedDistracted,
-    toggleYear,
-    setYearRange,
-    setYears,
-    clearYears,
-    setAllYears,
+    setDateRange,
+    clearDateRange,
     toggleSeverity,
     toggleCounty,
     setCounty,
@@ -376,11 +443,8 @@ export function useFilterParams() {
 }
 
 // ── Helper: build next URLSearchParams from prev + partial overrides ──
-// Used by the functional setSearchParams updaters above so each action
-// reads the *latest* URL state, avoiding stale-closure bugs.
 
 type ParamOverrides = {
-  years?: Set<number>;
   severities?: Set<string>;
   counties?: Set<string>;
   causes?: Set<string>;
@@ -394,16 +458,10 @@ function buildNextParams(
 ): URLSearchParams {
   const params = new URLSearchParams(prev);
 
-  const years = overrides.years ?? parseYears(prev.get("year"));
   const severities = overrides.severities ?? parseSeverities(prev.get("severity"));
   const counties = overrides.counties ?? parseCounties(prev.get("county"));
   const causes = overrides.causes ?? parseCauses(prev.get("cause"));
 
-  if (years.size > 0) {
-    params.set("year", [...years].sort().join(","));
-  } else {
-    params.delete("year");
-  }
   if (severities.size > 0) {
     params.set("severity", [...severities].map(slugify).sort().join(","));
   } else {

--- a/frontend/src/hooks/useStats.test.tsx
+++ b/frontend/src/hooks/useStats.test.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { useStats, type StatsFilters } from "./useStats";
 
 const FILTERS: StatsFilters = {
-  years: [2022, 2023],
+  dateRange: { start: { year: 2022, month: 1 }, end: { year: 2023, month: 12 } },
   severities: [],
   causes: [],
   counties: [],
@@ -75,10 +75,10 @@ describe("useStats", () => {
 
     expect(spy).toHaveBeenCalledTimes(10);
     const urls = spy.mock.calls.map((c) => String(c[0]));
-    expect(urls.some((u) => u.includes("group_by=year") && u.includes("year=2022%2C2023"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=hour") && u.includes("year=2022%2C2023"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=cause") && u.includes("year=2022%2C2023"))).toBe(true);
-    expect(urls.some((u) => u.includes("/api/demographics") && u.includes("year=2022%2C2023"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=year") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=hour") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=cause") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
+    expect(urls.some((u) => u.includes("/api/demographics") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=severity"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=gender"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=age_bracket"))).toBe(true);

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
-import { YEARS, SEVERITIES, CAUSES } from "./useFilterParams";
+import { SEVERITIES, CAUSES, formatYearMonth, type DateRangeFilter } from "./useFilterParams";
 import { API_BASE } from "../config";
 
 export type StatsFilters = {
-  years: number[];
+  dateRange: DateRangeFilter | null;
   severities: string[];
   causes: string[];
   counties: string[];
@@ -102,17 +102,23 @@ function severityToSlug(s: string): string {
 
 function normalizeFilters(f: StatsFilters): StatsFilters {
   return {
-    years: f.years.length === YEARS.length ? [] : f.years,
+    dateRange: f.dateRange,
     severities: f.severities.length === SEVERITIES.length ? [] : f.severities,
     causes: f.causes.length === CAUSES.length ? [] : f.causes,
     counties: f.counties,
   };
 }
 
+function appendDateRange(p: URLSearchParams, dr: DateRangeFilter | null) {
+  if (!dr) return;
+  if (dr.start) p.set("start", formatYearMonth(dr.start));
+  if (dr.end) p.set("end", formatYearMonth(dr.end));
+}
+
 function buildUrl(groupBy: string, filters: StatsFilters): string {
   const p = new URLSearchParams();
   p.set("group_by", groupBy);
-  if (filters.years.length) p.set("year", filters.years.join(","));
+  appendDateRange(p, filters.dateRange);
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.causes.length) p.set("cause", filters.causes.join(","));
   if (filters.counties.length) p.set("county", filters.counties.join(","));
@@ -122,7 +128,7 @@ function buildUrl(groupBy: string, filters: StatsFilters): string {
 function buildVictimUrl(groupBy: string, filters: StatsFilters): string {
   const p = new URLSearchParams();
   p.set("group_by", groupBy);
-  if (filters.years.length) p.set("year", filters.years.join(","));
+  appendDateRange(p, filters.dateRange);
   if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
   if (filters.counties.length) p.set("county", filters.counties.join(","));
   return `${API_BASE}/api/stats?${p}`;
@@ -130,7 +136,7 @@ function buildVictimUrl(groupBy: string, filters: StatsFilters): string {
 
 function buildDemoUrl(filters: StatsFilters): string {
   const p = new URLSearchParams();
-  if (filters.years.length) p.set("year", filters.years.join(","));
+  appendDateRange(p, filters.dateRange);
   if (filters.counties.length) p.set("county", filters.counties.join(","));
   const qs = p.toString();
   return `${API_BASE}/api/demographics${qs ? `?${qs}` : ""}`;
@@ -171,49 +177,54 @@ function computeHeroMetrics(yearRows: YearRow[], population: number | null): Her
 
 export function useStats(rawFilters: StatsFilters): UseStatsResult {
   const filters = normalizeFilters(rawFilters);
-
-  const demoFilters = { years: filters.years, counties: filters.counties };
+  // Stable cache key shape — DateRangeFilter is referentially stable thanks to
+  // useFilterParams's memoization, but we serialize it for the query key so
+  // structural equality checks behave predictably across renders.
+  const dateKey = filters.dateRange
+    ? `${filters.dateRange.start ? formatYearMonth(filters.dateRange.start) : ""}|${filters.dateRange.end ? formatYearMonth(filters.dateRange.end) : ""}`
+    : "";
+  const cacheKey = { d: dateKey, s: filters.severities, c: filters.causes, co: filters.counties };
 
   const queries = useQueries({
     queries: [
       {
-        queryKey: ["stats", "year", filters],
+        queryKey: ["stats", "year", cacheKey],
         queryFn: () => fetchJson<YearRow[]>(buildUrl("year", filters)),
       },
       {
-        queryKey: ["stats", "hour", filters],
+        queryKey: ["stats", "hour", cacheKey],
         queryFn: () => fetchJson<HourRow[]>(buildUrl("hour", filters)),
       },
       {
-        queryKey: ["stats", "cause", filters],
+        queryKey: ["stats", "cause", cacheKey],
         queryFn: () => fetchJson<CauseRow[]>(buildUrl("cause", filters)),
       },
       {
-        queryKey: ["stats", "demographics", demoFilters],
+        queryKey: ["stats", "demographics", { d: dateKey, co: filters.counties }],
         queryFn: () => fetchJson<DemoRow[]>(buildDemoUrl(filters)),
       },
       {
-        queryKey: ["stats", "severity", filters],
+        queryKey: ["stats", "severity", cacheKey],
         queryFn: () => fetchJson<SeverityRow[]>(buildUrl("severity", filters)),
       },
       {
-        queryKey: ["stats", "gender", { years: filters.years, severities: filters.severities, counties: filters.counties }],
+        queryKey: ["stats", "gender", { d: dateKey, s: filters.severities, co: filters.counties }],
         queryFn: () => fetchJson<GenderRow[]>(buildVictimUrl("gender", filters)),
       },
       {
-        queryKey: ["stats", "age_bracket", { years: filters.years, severities: filters.severities, counties: filters.counties }],
+        queryKey: ["stats", "age_bracket", { d: dateKey, s: filters.severities, co: filters.counties }],
         queryFn: () => fetchJson<AgeBracketRow[]>(buildVictimUrl("age_bracket", filters)),
       },
       {
-        queryKey: ["stats", "month", filters],
+        queryKey: ["stats", "month", cacheKey],
         queryFn: () => fetchJson<MonthRow[]>(buildUrl("month", filters)),
       },
       {
-        queryKey: ["stats", "day_of_week", filters],
+        queryKey: ["stats", "day_of_week", cacheKey],
         queryFn: () => fetchJson<DayOfWeekRow[]>(buildUrl("day_of_week", filters)),
       },
       {
-        queryKey: ["stats", "rate", { years: filters.years, counties: filters.counties, severities: filters.severities }],
+        queryKey: ["stats", "rate", { d: dateKey, co: filters.counties, s: filters.severities }],
         queryFn: () => fetchJson<RateRow[]>(buildUrl("rate", filters)),
       },
     ],

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -39,7 +39,7 @@ function buildPopularQuestions(county: string | null) {
 export default function AskAiPage() {
   const [inputValue, setInputValue] = useState("");
   const { messages, isLoading, error, cooldownEnd, sendMessage, retry, clearConversation } = useAskAi();
-  const { selectedCounties, selectedYears, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted } = useFilterParams();
+  const { selectedCounties, selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted } = useFilterParams();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [cooldownRemaining, setCooldownRemaining] = useState(0);
@@ -47,7 +47,11 @@ export default function AskAiPage() {
   const hasMessages = messages.length > 0;
 
   const activeCounty = selectedCounties.size === 1 ? [...selectedCounties][0] : null;
-  const activeYear = selectedYears.size > 0 ? String(Math.min(...selectedYears)) : null;
+  const activeYear = selectedDateRange?.start
+    ? String(selectedDateRange.start.year)
+    : selectedDateRange?.end
+      ? String(selectedDateRange.end.year)
+      : null;
 
   const guidedTopics = useMemo(() => buildGuidedTopics(activeCounty, activeYear), [activeCounty, activeYear]);
   const communityInquiries = useMemo(() => buildPopularQuestions(activeCounty), [activeCounty]);
@@ -86,16 +90,12 @@ export default function AskAiPage() {
     if (selectedCounties.size > 0) {
       parts.push(selectedCounties.size <= 2 ? [...selectedCounties].join(", ") : `${selectedCounties.size} counties`);
     }
-    if (selectedYears.size > 0) {
-      const years = [...selectedYears].map(Number).sort((a, b) => a - b);
-      const ranges: string[] = [];
-      let start = years[0], end = years[0];
-      for (let i = 1; i < years.length; i++) {
-        if (years[i] === end + 1) { end = years[i]; }
-        else { ranges.push(start === end ? `${start}` : `${start}-${end}`); start = end = years[i]; }
-      }
-      ranges.push(start === end ? `${start}` : `${start}-${end}`);
-      parts.push(ranges.join(", "));
+    if (selectedDateRange) {
+      const fmt = (ym: { year: number; month: number } | null) =>
+        ym ? `${ym.year}-${String(ym.month).padStart(2, "0")}` : null;
+      const s = fmt(selectedDateRange.start);
+      const e = fmt(selectedDateRange.end);
+      if (s || e) parts.push(`${s ?? "earliest"} → ${e ?? "latest"}`);
     }
     if (selectedSeverities.size > 0) {
       parts.push(selectedSeverities.size <= 2 ? [...selectedSeverities].join(", ") : `${selectedSeverities.size} severities`);

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -61,17 +61,15 @@ function HeatmapLoadingPill() {
 
 function MapPageInner() {
   const {
+    selectedDateRange,
     selectedYears,
     selectedSeverities,
     selectedCounties,
     selectedCauses,
     selectedAlcohol,
     selectedDistracted,
-    toggleYear,
-    setYearRange,
-    setYears,
-    clearYears,
-    setAllYears,
+    setDateRange,
+    clearDateRange,
     toggleSeverity,
     toggleCounty,
     setCounty,
@@ -124,7 +122,7 @@ function MapPageInner() {
   const statewideHeatmap = useCrashHeatmap({
     enabled: heatmapEnabled && !useCountyDetail,
     county: null,
-    years: [...selectedYears],
+    dateRange: selectedDateRange,
     severities: [...selectedSeverities],
     causes: [...selectedCauses],
     resolution: effectiveResolution,
@@ -133,7 +131,7 @@ function MapPageInner() {
   const countyHeatmap = useBatchedHeatmap({
     enabled: heatmapEnabled && useCountyDetail,
     county: heatmapCountySlugs,
-    years: [...selectedYears],
+    dateRange: selectedDateRange,
     severities: [...selectedSeverities],
     causes: [...selectedCauses],
     resolution: "raw",
@@ -147,7 +145,7 @@ function MapPageInner() {
   const mismatchHeatmap = useCrashHeatmap({
     enabled: otherLayers.coordMismatches && !!mismatchCountySlug,
     county: mismatchCountySlug,
-    years: [...selectedYears],
+    dateRange: selectedDateRange,
     severities: [...selectedSeverities],
     causes: [...selectedCauses],
     resolution: "raw",
@@ -155,14 +153,14 @@ function MapPageInner() {
     includeRivers: otherLayers.coordIncludeRivers,
   });
 
-  const coordCoverage = useCoordCoverage([...selectedYears]);
+  const coordCoverage = useCoordCoverage(selectedDateRange);
   const choroplethFilters = useMemo(
     () => ({
-      years: [...selectedYears].sort((a, b) => a - b),
+      dateRange: selectedDateRange,
       severities: [...selectedSeverities],
       causes: [...selectedCauses],
     }),
-    [selectedYears, selectedSeverities, selectedCauses],
+    [selectedDateRange, selectedSeverities, selectedCauses],
   );
   const choroplethData = useChoroplethData(measure, choroplethFilters);
 
@@ -281,17 +279,14 @@ function MapPageInner() {
   const meta = activePanel ? PANEL_META[activePanel] : null;
 
   const filtersPanelProps = {
-    selectedYears,
+    selectedDateRange,
     selectedSeverities,
     selectedCounties,
     selectedCauses,
     selectedAlcohol,
     selectedDistracted,
-    onToggleYear: toggleYear,
-    onSetYearRange: setYearRange,
-    onSetYears: setYears,
-    onClearYears: clearYears,
-    onSetAllYears: setAllYears,
+    onSetDateRange: setDateRange,
+    onClearDateRange: clearDateRange,
     onToggleSeverity: toggleSeverity,
     onSetSeverities: setSeverities,
     onSetAllSeverities: setAllSeverities,

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
-import { useFilterParams, YEARS, CAUSES as CAUSE_OPTIONS, SEVERITIES } from "../hooks/useFilterParams";
+import { useFilterParams, formatYearMonth, CAUSES as CAUSE_OPTIONS, SEVERITIES } from "../hooks/useFilterParams";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import FiltersPanel from "../components/map/FiltersPanel";
 import {
@@ -107,14 +107,14 @@ export default function StatsPage() {
   const [resetKey, setResetKey] = useState(0);
   const filters = useFilterParams();
   const statsFilters = useMemo(() => ({
-    years: [...filters.selectedYears],
+    dateRange: filters.selectedDateRange,
     severities: [...filters.selectedSeverities],
     causes: [...filters.selectedCauses],
     counties: [...filters.selectedCounties].map((c) => c.toLowerCase().replace(/ /g, "-")),
-  }), [filters.selectedYears, filters.selectedSeverities, filters.selectedCauses, filters.selectedCounties]);
+  }), [filters.selectedDateRange, filters.selectedSeverities, filters.selectedCauses, filters.selectedCounties]);
   const { data, loading, error, refetch } = useStats(statsFilters);
   const dqDisclaimers = useDataQualityDisclaimer(
-    [...filters.selectedYears],
+    filters.selectedDateRange,
     [...filters.selectedCounties],
   );
   const [, forceUpdate] = useState(false);
@@ -155,7 +155,7 @@ export default function StatsPage() {
   const causeColor = (label: string) => causeColorMap[label] ?? clrOnSurfaceVariant;
   const severityColor = (label: string) => severityColorMap[label] ?? clrOnSurfaceVariant;
 
-  const years      = filters.selectedYears;
+  const dateRange  = filters.selectedDateRange;
   const severities = filters.selectedSeverities;
   const counties   = filters.selectedCounties;
   const causes     = filters.selectedCauses;
@@ -167,7 +167,6 @@ export default function StatsPage() {
 
   // Build typed chips so each one knows how to remove itself.
   // "All X" chips open the filter panel instead of removing — they have no onRemove.
-  const sortedYears = [...years].sort((a, b) => a - b);
   type Chip = { label: string; onRemove?: () => void; onOpen?: () => void };
 
   const openFilters = () => setShowMobileFilters(true);
@@ -176,11 +175,12 @@ export default function StatsPage() {
     ? [{ label: "All Counties", onOpen: openFilters }]
     : [...counties].sort().map((c) => ({ label: c, onRemove: () => filters.toggleCounty(c) }));
 
-  const yearChips: Chip[] = years.size === 0 || years.size === YEARS.length
-    ? [{ label: years.size === 0 ? "All Years" : "All Years", onOpen: openFilters }]
-    : sortedYears.length >= 3 && sortedYears.every((y, i) => i === 0 || y === sortedYears[i - 1] + 1)
-      ? [{ label: `${sortedYears[0]}–${sortedYears[sortedYears.length - 1]}`, onRemove: () => filters.clearYears() }]
-      : sortedYears.map((y) => ({ label: String(y), onRemove: () => filters.toggleYear(y) }));
+  const dateRangeLabel = dateRange
+    ? `${dateRange.start ? formatYearMonth(dateRange.start) : "earliest"} – ${dateRange.end ? formatYearMonth(dateRange.end) : "latest"}`
+    : null;
+  const yearChips: Chip[] = dateRangeLabel
+    ? [{ label: dateRangeLabel, onRemove: () => filters.clearDateRange() }]
+    : [{ label: "All Years", onOpen: openFilters }];
 
   const severityChips: Chip[] = severities.size === 0 || severities.size === SEVERITIES.length
     ? [{ label: "All Severities", onOpen: openFilters }]
@@ -973,17 +973,14 @@ export default function StatsPage() {
             icon: "filter_list",
             content: (
               <FiltersPanel
-                selectedYears={filters.selectedYears}
+                selectedDateRange={filters.selectedDateRange}
                 selectedSeverities={filters.selectedSeverities}
                 selectedCounties={filters.selectedCounties}
                 selectedCauses={filters.selectedCauses}
                 selectedAlcohol={filters.selectedAlcohol}
                 selectedDistracted={filters.selectedDistracted}
-                onToggleYear={filters.toggleYear}
-                onSetYearRange={filters.setYearRange}
-                onClearYears={filters.clearYears}
-                onSetYears={filters.setYears}
-                onSetAllYears={filters.setAllYears}
+                onSetDateRange={filters.setDateRange}
+                onClearDateRange={filters.clearDateRange}
                 onToggleSeverity={filters.toggleSeverity}
                 onSetSeverities={filters.setSeverities}
                 onSetAllSeverities={filters.setAllSeverities}


### PR DESCRIPTION
## What does this PR do?

  Resolves #132. Replaces the year-checkbox filter with a month-resolution date-range picker.

  **Backend** — `app/filters.py` adds `parse_date_range(start, end)` accepting `YYYY-MM`, `years_from_date_range()` for
  year-MV-backed endpoints, and a `date_range` parameter on `build_crash_predicates` that emits `crash_datetime`
  predicates and takes precedence over `years` when both are supplied. The `crashes`, `heatmap`, `stats`,
  `crash_people`, `context`, and `demographics` routers now accept `?start=YYYY-MM&end=YYYY-MM` (either side optional).
  `?year=` is still accepted for backward compatibility — old permalinks keep working.

  **Frontend** — `useFilterParams` exposes `selectedDateRange: { start, end }` as the source of truth plus
  `setDateRange` / `clearDateRange` actions; `selectedYears` is now derived for legacy consumers. `FiltersPanel` swaps
  the year-pill UI for two month + year `<select>` pickers (From / To). All data hooks (`useStats`, `useChoroplethData`,
   `useCrashHeatmap`, `useDataQualityDisclaimer`, `useCoordCoverage`) consume the new `DateRangeFilter` and emit
  `?start=&end=`. Pages (`MapPage`, `StatsPage`, `AskAiPage`) and `CountyBoundaries` are updated to match.

  **Stats endpoints note:** because the underlying materialized views aggregate by year, `/api/stats` rounds
  `start`/`end` outward to whole years. For month-precise filtering, hit `/api/crashes` or `/api/crashes/heatmap`.

  **Tests** — 16 new backend tests for `parse_date_range` / `years_from_date_range` / date-range predicates; new
  frontend tests for `parseYearMonth`, `formatYearMonth`, `yearsInRange`; existing hook tests rewritten to assert
  `start=YYYY-MM&end=YYYY-MM` URL params.

  ## Dependencies

  None.

  ## How to test
  - [ ] `docker-compose up --build` (or run backend + frontend separately)
  - [ ] On `/`, open Filters panel: confirm year pills are gone and a Date Range section shows From / To month + year
  dropdowns
  - [ ] Pick `From: Jun 2023` / `To: Aug 2023` → URL becomes `?start=2023-06&end=2023-08`, choropleth + heatmap update
  - [ ] Pick only `From` (leave `To` empty) → only `?start=…` is sent (check DevTools → Network)
  - [ ] Click **Clear** → both params drop from the URL
  - [ ] Open `http://localhost:5180/?year=2020,2023` → dropdowns hydrate to `Jan 2020` / `Dec 2023` (legacy permalink
  compat)
  - [ ] On `/stats`, the filter chip bar shows a single `2023-06 – 2023-08` chip (not one per year); ×-ing it clears the
   range
  - [ ] Backend smoke: `curl "http://localhost:8000/api/crashes?start=2023-03&end=2023-08&limit=5"` returns rows;
  `?start=2023-13` returns 422; `?start=2024-01&end=2023-01` returns 422
  - [ ] `cd backend && pytest tests/unit/test_filters.py` (43 pass)
  - [ ] `cd frontend && npm test` (144 pass) and `npx tsc --noEmit` (clean)

  ## Checklist
  - [x] Code builds without errors
  - [x] Tested locally
  - [x] No console errors/warnings
  - [x] No other PRs need to merge before this one (or listed above)
