### PR TITLE
fix(#101): per-job timeout + DetachedInstanceError fix in orchestrator

### DIFF
--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -29,6 +29,7 @@ def build_default_registry() -> JobRegistry:
         schedule="daily",
         table_name="crash_parties",
         max_drop_pct=5,
+        timeout=21600,
     ))
     registry.register(Job(
         name="victims",
@@ -38,6 +39,7 @@ def build_default_registry() -> JobRegistry:
         schedule="daily",
         table_name="crash_victims",
         max_drop_pct=5,
+        timeout=14400,
     ))
     registry.register(Job(
         name="demographics",

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -22,6 +22,7 @@ class Job:
     schedule: str = "daily"
     max_drop_pct: float = 10.0
     table_name: str | None = None
+    timeout: int = 3600
 
 
 class JobRegistry:
@@ -92,7 +93,7 @@ def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
             cmd,
             capture_output=True,
             text=True,
-            timeout=3600,
+            timeout=job.timeout,
         )
         elapsed = time.monotonic() - start
 
@@ -110,7 +111,7 @@ def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
 
     except subprocess.TimeoutExpired:
         record.status = "error"
-        record.error_message = "Job timed out after 3600s"
+        record.error_message = f"Job timed out after {job.timeout}s"
         record.finished_at = datetime.utcnow()
         record.validation_status = "skipped"
         db.commit()
@@ -125,6 +126,7 @@ def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
         logger.exception("Job %s failed unexpectedly", job.name)
 
     finally:
+        db.refresh(record)
         db.expunge(record)
         db.close()
 


### PR DESCRIPTION
## What does this PR do?

- Add timeout field to Job dataclass (default 3600s)
- parties gets 21600s (6hr), victims gets 14400s (4hr) for full dataset pulls
- Fix DetachedInstanceError: db.refresh(record) before db.expunge(record) so attributes are loaded into memory before session closes


## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
