### PR TITLE
feat(#172): skip unchanged ETL sources via metadata freshness check

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -826,6 +826,8 @@ class EtlRun(Base):
     rows_after = Column(Integer)
     diff_summary = Column(Text)
     triggered_by = Column(String(20))
+    last_source_modified = Column(DateTime)
+    source_row_count = Column(Integer)
 
     __table_args__ = (
         Index("ix_etl_runs_source_started_at", "source", "started_at"),

--- a/backend/app/routers/etl.py
+++ b/backend/app/routers/etl.py
@@ -27,6 +27,8 @@ class LastRun(BaseModel):
     error_message: Optional[str]
     triggered_by: Optional[str]
     validation_status: Optional[str]
+    last_source_modified: Optional[datetime] = None
+    source_row_count: Optional[int] = None
 
 
 class SourceStatus(BaseModel):
@@ -46,6 +48,8 @@ class RunHistoryItem(BaseModel):
     triggered_by: Optional[str]
     validation_status: Optional[str]
     error_message: Optional[str]
+    last_source_modified: Optional[datetime] = None
+    source_row_count: Optional[int] = None
 
 
 @router.get("/etl/status")
@@ -71,6 +75,8 @@ def etl_status(db: Session = Depends(get_db)):
                 error_message=last.error_message,
                 triggered_by=last.triggered_by,
                 validation_status=last.validation_status,
+                last_source_modified=last.last_source_modified,
+                source_row_count=last.source_row_count,
             ) if last else None,
         ))
     return {"sources": [s.model_dump() for s in sources]}
@@ -98,6 +104,8 @@ def etl_runs(
                 triggered_by=r.triggered_by,
                 validation_status=r.validation_status,
                 error_message=r.error_message,
+                last_source_modified=r.last_source_modified,
+                source_row_count=r.source_row_count,
             ).model_dump()
             for r in rows
         ]
@@ -108,13 +116,19 @@ def etl_runs(
 def trigger_etl_run(
     background_tasks: BackgroundTasks,
     only: Optional[str] = Query(None, description="Comma-separated job names"),
+    force_refresh: bool = Query(False, description="Bypass freshness checks"),
 ):
     from etl.orchestrator import run_pipeline
 
     job_names = only.split(",") if only else None
 
     def _run():
-        run_pipeline(_registry, triggered_by="api", only=job_names)
+        run_pipeline(
+            _registry,
+            triggered_by="api",
+            only=job_names,
+            force_refresh=force_refresh,
+        )
 
     background_tasks.add_task(_run)
-    return {"status": "started", "jobs": job_names or "all"}
+    return {"status": "started", "jobs": job_names or "all", "force_refresh": force_refresh}

--- a/backend/etl/_utils.py
+++ b/backend/etl/_utils.py
@@ -35,13 +35,18 @@ import functools
 import logging
 import time
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Iterator, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeVar
 
 import httpx
+from sqlalchemy import desc, text
 
 from app.database import SessionLocal
 from app.models import EtlRun
+
+if TYPE_CHECKING:
+    from etl.orchestrator import Job
 
 logger = logging.getLogger(__name__)
 
@@ -279,3 +284,143 @@ def track_etl_run(source: str) -> Callable[[F], F]:
         return wrapper  # type: ignore[return-value]
 
     return decorator
+
+
+# ---------------------------------------------------------------------------
+# Source freshness checking
+# ---------------------------------------------------------------------------
+
+CKAN_RESOURCE_SHOW_URL = "https://data.ca.gov/api/3/action/resource_show"
+
+
+@dataclass
+class FreshnessResult:
+    is_fresh: bool
+    last_source_modified: datetime | None
+    source_row_count: int | None
+    reason: str
+
+
+def check_source_freshness(job: Job, db_session) -> FreshnessResult:
+    """Check whether a source has new data since the last successful run.
+
+    Returns is_fresh=False when source is unchanged and job should be
+    skipped.  Returns is_fresh=True when source has new data, or when
+    no prior successful run exists (first-time load always runs).
+    """
+    if job.source_type == "none":
+        return FreshnessResult(True, None, None, "no freshness config")
+
+    last_run = (
+        db_session.query(EtlRun)
+        .filter(EtlRun.source == job.name, EtlRun.status == "success")
+        .order_by(desc(EtlRun.finished_at))
+        .first()
+    )
+
+    if last_run is None:
+        return FreshnessResult(True, None, None, "no prior successful run")
+
+    if job.source_type == "ckan":
+        return _check_ckan_freshness(job, last_run)
+    if job.source_type == "arcgis":
+        return _check_arcgis_freshness(job, last_run)
+    if job.source_type == "federal":
+        return _check_federal_freshness(job, last_run, db_session)
+
+    return FreshnessResult(True, None, None, f"unknown source_type {job.source_type!r}")
+
+
+def _check_ckan_freshness(job: Job, last_run: EtlRun) -> FreshnessResult:
+    if not job.freshness_resource_id:
+        return FreshnessResult(True, None, None, "ckan type but no resource_id")
+
+    try:
+        resp = get_with_retry(
+            CKAN_RESOURCE_SHOW_URL,
+            params={"id": job.freshness_resource_id},
+            timeout=15.0,
+        )
+        resource = resp.json().get("result", {})
+        modified_str = resource.get("last_modified") or resource.get("created")
+        if not modified_str:
+            return FreshnessResult(True, None, None, "ckan returned no timestamp")
+
+        source_modified = datetime.fromisoformat(
+            modified_str.replace("Z", "+00:00")
+        ).replace(tzinfo=None)
+
+        if source_modified <= last_run.finished_at:
+            return FreshnessResult(
+                False, source_modified, None,
+                f"source unchanged ({source_modified.isoformat()} <= {last_run.finished_at.isoformat()})",
+            )
+
+        return FreshnessResult(
+            True, source_modified, None,
+            f"source updated ({source_modified.isoformat()} > {last_run.finished_at.isoformat()})",
+        )
+    except Exception as exc:
+        logger.warning("CKAN freshness check failed for %s: %s", job.name, exc)
+        return FreshnessResult(True, None, None, f"freshness check error: {exc}")
+
+
+def _check_arcgis_freshness(job: Job, last_run: EtlRun) -> FreshnessResult:
+    if not job.freshness_url:
+        return FreshnessResult(True, None, None, "arcgis type but no freshness_url")
+
+    try:
+        resp = get_with_retry(
+            job.freshness_url,
+            params={"where": "1=1", "returnCountOnly": "true", "f": "json"},
+            timeout=15.0,
+        )
+        count = resp.json().get("count")
+        if count is None:
+            return FreshnessResult(True, None, None, "arcgis returned no count")
+
+        prior_count = last_run.source_row_count
+        if prior_count is not None and count == prior_count:
+            return FreshnessResult(
+                False, None, count,
+                f"row count unchanged at {count}",
+            )
+
+        return FreshnessResult(
+            True, None, count,
+            f"row count changed: {prior_count} -> {count}" if prior_count else f"first count: {count}",
+        )
+    except Exception as exc:
+        logger.warning("ArcGIS freshness check failed for %s: %s", job.name, exc)
+        return FreshnessResult(True, None, None, f"freshness check error: {exc}")
+
+
+_ALLOWED_FRESHNESS_TABLES = {"demographics", "county_weather", "bls_unemployment"}
+
+
+def _check_federal_freshness(job: Job, last_run: EtlRun, db_session) -> FreshnessResult:
+    if not job.freshness_table:
+        return FreshnessResult(True, None, None, "federal type but no freshness_table")
+
+    if job.freshness_table not in _ALLOWED_FRESHNESS_TABLES:
+        return FreshnessResult(True, None, None, f"unknown freshness_table {job.freshness_table!r}")
+
+    try:
+        current_count = int(
+            db_session.execute(text(f"SELECT COUNT(*) FROM {job.freshness_table}")).scalar()  # noqa: S608
+        )
+        prior_count = last_run.source_row_count
+
+        if prior_count is not None and current_count == prior_count:
+            return FreshnessResult(
+                False, None, current_count,
+                f"DB row count unchanged at {current_count}",
+            )
+
+        return FreshnessResult(
+            True, None, current_count,
+            f"DB count changed: {prior_count} -> {current_count}" if prior_count else f"first count: {current_count}",
+        )
+    except Exception as exc:
+        logger.warning("Federal freshness check failed for %s: %s", job.name, exc)
+        return FreshnessResult(True, None, None, f"freshness check error: {exc}")

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -20,6 +20,8 @@ def build_default_registry() -> JobRegistry:
         schedule="daily",
         table_name="crashes",
         max_drop_pct=5,
+        source_type="ckan",
+        freshness_resource_id="b8ce0ca4-b4e9-490d-b4d1-1f4ec48cbefb",
     ))
     registry.register(Job(
         name="parties",
@@ -30,6 +32,8 @@ def build_default_registry() -> JobRegistry:
         table_name="crash_parties",
         max_drop_pct=5,
         timeout=21600,
+        source_type="ckan",
+        freshness_resource_id="348a4266-bbb6-439f-b6c7-0018cc79f0fe",
     ))
     registry.register(Job(
         name="victims",
@@ -40,6 +44,8 @@ def build_default_registry() -> JobRegistry:
         table_name="crash_victims",
         max_drop_pct=5,
         timeout=14400,
+        source_type="ckan",
+        freshness_resource_id="bbe0c38e-d0eb-4152-86e2-0b0895e66ba9",
     ))
     registry.register(Job(
         name="demographics",
@@ -47,6 +53,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="demographics",
         max_drop_pct=10,
+        source_type="federal",
+        freshness_table="demographics",
     ))
     registry.register(Job(
         name="weather",
@@ -54,6 +62,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="county_weather",
         max_drop_pct=5,
+        source_type="federal",
+        freshness_table="county_weather",
     ))
     registry.register(Job(
         name="hospitals",
@@ -61,6 +71,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="hospitals",
         max_drop_pct=20,
+        source_type="ckan",
+        freshness_resource_id="3d2503d7-56ad-4f38-8435-3d86d27b7407",
     ))
     registry.register(Job(
         name="schools",
@@ -68,6 +80,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="schools",
         max_drop_pct=20,
+        source_type="ckan",
+        freshness_resource_id="23740f30-e860-4ada-a7cb-8de6d21e2c78",
     ))
     registry.register(Job(
         name="speed_limits",
@@ -75,6 +89,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="speed_limits",
         max_drop_pct=20,
+        source_type="arcgis",
+        freshness_url="https://geo.dot.gov/server/rest/services/Hosted/HPMS_Full_CA_2022/FeatureServer/0/query",
     ))
     registry.register(Job(
         name="aadt",
@@ -82,6 +98,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="caltrans_aadt",
         max_drop_pct=20,
+        source_type="arcgis",
+        freshness_url="https://caltrans-gis.dot.ca.gov/arcgis/rest/services/CHhighway/Traffic_AADT/FeatureServer/0/query",
     ))
     registry.register(Job(
         name="vehicles",
@@ -89,6 +107,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="dmv_vehicles",
         max_drop_pct=10,
+        source_type="ckan",
+        freshness_resource_id="b459d957-5d94-4b10-999d-770419870364",
     ))
     registry.register(Job(
         name="unemployment",
@@ -96,6 +116,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="bls_unemployment",
         max_drop_pct=10,
+        source_type="federal",
+        freshness_table="bls_unemployment",
     ))
     registry.register(Job(
         name="calenviroscreen",
@@ -103,6 +125,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="calenviroscreen",
         max_drop_pct=20,
+        source_type="arcgis",
+        freshness_url="https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services/CalEnviroScreen_4_0_Results_/FeatureServer/0/query",
     ))
     registry.register(Job(
         name="licensed_drivers",
@@ -110,6 +134,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="licensed_drivers",
         max_drop_pct=10,
+        source_type="ckan",
+        freshness_resource_id="0abef7f0-285f-4887-9b4e-69e86d89ceb1",
     ))
     registry.register(Job(
         name="road_miles",
@@ -117,6 +143,8 @@ def build_default_registry() -> JobRegistry:
         schedule="monthly",
         table_name="road_miles",
         max_drop_pct=20,
+        source_type="ckan",
+        freshness_resource_id="5180390d-e323-4751-8ce9-939e62918233",
     ))
 
     # --- Tier 2: Internal transforms (depend on external loads) ---

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -6,11 +6,14 @@ import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Literal
 
 from app.database import SessionLocal
 from app.models import EtlRun
 
 logger = logging.getLogger(__name__)
+
+SourceType = Literal["ckan", "arcgis", "federal", "none"]
 
 
 @dataclass
@@ -23,6 +26,10 @@ class Job:
     max_drop_pct: float = 10.0
     table_name: str | None = None
     timeout: int = 3600
+    source_type: SourceType = "none"
+    freshness_resource_id: str | None = None
+    freshness_url: str | None = None
+    freshness_table: str | None = None
 
 
 class JobRegistry:
@@ -72,8 +79,35 @@ def resolve_execution_order(registry: JobRegistry) -> list[Job]:
     return order
 
 
-def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
+def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False) -> EtlRun:
+    from etl._utils import check_source_freshness
+
     db = SessionLocal()
+
+    freshness = None
+    if not force_refresh and job.source_type != "none":
+        freshness = check_source_freshness(job, db)
+        logger.info("Freshness check for %s: %s", job.name, freshness.reason)
+
+        if not freshness.is_fresh:
+            record = EtlRun(
+                source=job.name,
+                status="skipped_unchanged",
+                started_at=datetime.utcnow(),
+                finished_at=datetime.utcnow(),
+                triggered_by=triggered_by,
+                error_message=freshness.reason,
+                validation_status="skipped",
+                last_source_modified=freshness.last_source_modified,
+                source_row_count=freshness.source_row_count,
+            )
+            db.add(record)
+            db.commit()
+            db.refresh(record)
+            db.expunge(record)
+            db.close()
+            return record
+
     record = EtlRun(
         source=job.name,
         status="running",
@@ -104,6 +138,9 @@ def run_job(job: Job, triggered_by: str = "manual") -> EtlRun:
         else:
             record.status = "success"
             record.validation_status = "passed"
+            if freshness:
+                record.last_source_modified = freshness.last_source_modified
+                record.source_row_count = freshness.source_row_count
 
         record.finished_at = datetime.utcnow()
         db.commit()
@@ -138,6 +175,7 @@ def run_pipeline(
     triggered_by: str = "manual",
     only: list[str] | None = None,
     skip_static: bool = True,
+    force_refresh: bool = False,
 ) -> list[EtlRun]:
     order = resolve_execution_order(registry)
 
@@ -149,6 +187,7 @@ def run_pipeline(
 
     results: list[EtlRun] = []
     failed: set[str] = set()
+    skipped_unchanged: set[str] = set()
 
     for job in order:
         blocked_by = [dep for dep in job.depends_on if dep in failed]
@@ -171,9 +210,35 @@ def run_pipeline(
             failed.add(job.name)
             continue
 
-        record = run_job(job, triggered_by=triggered_by)
+        if (
+            not force_refresh
+            and job.source_type == "none"
+            and job.depends_on
+            and all(dep in skipped_unchanged for dep in job.depends_on)
+        ):
+            logger.info("Skipping %s — all deps unchanged: %s", job.name, job.depends_on)
+            db = SessionLocal()
+            record = EtlRun(
+                source=job.name,
+                status="skipped_unchanged",
+                started_at=datetime.utcnow(),
+                finished_at=datetime.utcnow(),
+                triggered_by=triggered_by,
+                error_message=f"All dependencies unchanged: {', '.join(job.depends_on)}",
+                validation_status="skipped",
+            )
+            db.add(record)
+            db.commit()
+            db.close()
+            results.append(record)
+            skipped_unchanged.add(job.name)
+            continue
+
+        record = run_job(job, triggered_by=triggered_by, force_refresh=force_refresh)
         results.append(record)
         if record.status == "error":
             failed.add(job.name)
+        elif record.status == "skipped_unchanged":
+            skipped_unchanged.add(job.name)
 
     return results

--- a/backend/etl/run_all.py
+++ b/backend/etl/run_all.py
@@ -43,6 +43,11 @@ def main() -> int:
         choices=["manual", "schedule", "api"],
         help="How this run was triggered (recorded in etl_runs)",
     )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Bypass freshness checks and re-run all jobs regardless of source state",
+    )
     args = parser.parse_args()
 
     registry = build_default_registry()
@@ -58,7 +63,10 @@ def main() -> int:
         print(f"\nExecution order ({len(order)} jobs):\n")
         for i, job in enumerate(order, 1):
             deps = f" (after: {', '.join(job.depends_on)})" if job.depends_on else ""
-            print(f"  {i:2d}. {job.name:<25s} [{job.schedule}]{deps}")
+            fresh = f" src={job.source_type}" if job.source_type != "none" else ""
+            print(f"  {i:2d}. {job.name:<25s} [{job.schedule}]{deps}{fresh}")
+        if args.force_refresh:
+            print("  [--force-refresh: freshness checks disabled]")
         print()
         return 0
 
@@ -71,17 +79,22 @@ def main() -> int:
         triggered_by=args.triggered_by,
         only=only,
         skip_static=not args.include_static,
+        force_refresh=args.force_refresh,
     )
 
     succeeded = sum(1 for r in results if r.status == "success")
-    failed = sum(1 for r in results if r.status == "error")
+    failed_count = sum(1 for r in results if r.status == "error")
     skipped = sum(1 for r in results if r.status == "skipped")
+    unchanged = sum(1 for r in results if r.status == "skipped_unchanged")
 
     logger.info("=" * 50)
-    logger.info("  Complete: %d succeeded, %d failed, %d skipped", succeeded, failed, skipped)
+    logger.info(
+        "  Complete: %d succeeded, %d failed, %d skipped, %d unchanged",
+        succeeded, failed_count, skipped, unchanged,
+    )
     logger.info("=" * 50)
 
-    return 1 if failed > 0 else 0
+    return 1 if failed_count > 0 else 0
 
 
 if __name__ == "__main__":

--- a/backend/migrations/versions/e2f3a4b5c6d7_add_freshness_cols_to_etl_runs.py
+++ b/backend/migrations/versions/e2f3a4b5c6d7_add_freshness_cols_to_etl_runs.py
@@ -1,0 +1,26 @@
+"""add last_source_modified and source_row_count to etl_runs
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1a2b3c4d5e6
+Create Date: 2026-05-08 18:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e2f3a4b5c6d7'
+down_revision: Union[str, None] = 'd1a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("etl_runs", sa.Column("last_source_modified", sa.DateTime(), nullable=True))
+    op.add_column("etl_runs", sa.Column("source_row_count", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("etl_runs", "source_row_count")
+    op.drop_column("etl_runs", "last_source_modified")


### PR DESCRIPTION
## What does this PR do?

  - Adds source freshness checking to the ETL orchestrator — before spawning each loader subprocess, makes one cheap
  metadata API call to determine if the source has actually changed since our last successful run
  - CKAN sources (8 jobs): calls resource_show and compares last_modified timestamp against our finished_at
  - ArcGIS sources (3 jobs): calls returnCountOnly=true and compares row count against stored source_row_count
  - Federal APIs (3 jobs): compares COUNT(*) on our DB table against stored count
  - Unchanged jobs are recorded as skipped_unchanged with the reason in error_message for full audit trail
  - Tier 2 transforms (backfill, matviews, insights, etc.) cascade-skip when ALL their dependencies were unchanged
  - Adds --force-refresh CLI flag and /etl/run?force_refresh=true API param to bypass checks
  - Fail-open: any metadata check error → job runs anyway
  - No loader files were modified — entire feature is orchestrator-level


## How to test

  - python -m etl.run_all --dry-run — verify all 20 jobs show src= type
  - python -m etl.run_all --only hospitals — first run loads normally
  - python -m etl.run_all --only hospitals — second run shows 1 unchanged in ~1s
  - python -m etl.run_all --only hospitals --force-refresh — bypasses check, runs normally
  - Check /api/etl/status returns last_source_modified and source_row_count fields
  - alembic upgrade head succeeds (adds 2 nullable columns to etl_runs)

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
