### PR TITLE
(#135) Crashes by income

### DIFF
--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -131,7 +131,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           >
             {allMeasures.map((m) => {
               const isSelected = m.key === measure;
-              const isDisabled = m.kind === "perCapita" && !demographicsAvailable;
+              const isDisabled = (m.kind === "perCapita" || m.kind === "perIncome") && !demographicsAvailable;
               return (
                 <button
                   key={m.key}
@@ -231,7 +231,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
         </div>
       )}
 
-      {!countyActive && activeMeasure.kind === "perCapita" && (dataSummary.missingDemoYears.length > 0 || dataSummary.partialDemoYears.length > 0) && (
+      {!countyActive && (activeMeasure.kind === "perCapita" || activeMeasure.kind === "perIncome") && (dataSummary.missingDemoYears.length > 0 || dataSummary.partialDemoYears.length > 0) && (
         <div role="alert" className="bg-red-500/15 rounded-md px-2 py-1.5 mt-1.5 text-[10px] text-red-600 dark:text-red-400 font-semibold">
           {dataSummary.missingDemoYears.length > 0 && (
             <div>No census data for {formatYearList(dataSummary.missingDemoYears)}</div>

--- a/frontend/src/lib/choropleth/measures.test.ts
+++ b/frontend/src/lib/choropleth/measures.test.ts
@@ -8,7 +8,7 @@ const tenCrashes = {
   total_killed: 2,
   total_injured: 3,
 };
-const pop50k = { county_code: 19, year: 2023, population: 50_000 };
+const pop50k = { county_code: 19, year: 2023, population: 50_000, median_income: 75_000 };
 
 describe("computeMeasureValue", () => {
   it("crashes_per_100k divides crashes by (pop/100k)", () => {
@@ -56,21 +56,61 @@ describe("computeMeasureValue", () => {
     // total: 25 per 100k
     const stats = { ...tenCrashes, crash_count: 15 };
     const demos = [
-      { county_code: 19, year: 2020, population: 100_000 },
-      { county_code: 19, year: 2023, population: 50_000 },
+      { county_code: 19, year: 2020, population: 100_000, median_income: 60_000 },
+      { county_code: 19, year: 2023, population: 50_000, median_income: 75_000 },
     ];
     const perYearCrashes = new Map<number, number>([[2020, 5], [2023, 10]]);
     const r = computeMeasureValue("crashes_per_100k", stats, demos, { perYearCrashes });
     expect(r.value).toBe(25);
   });
 
+  it("crashes_per_10k_income normalizes by median household income", () => {
+    // 10 crashes / 75,000 income * 10,000 = 1.333…
+    const r = computeMeasureValue("crashes_per_10k_income", tenCrashes, [pop50k]);
+    expect(r.hasEnoughData).toBe(true);
+    expect(r.value).toBeCloseTo((10 / 75_000) * 10_000, 5);
+  });
+
+  it("crashes_per_10k_income returns no-data when median_income is null", () => {
+    const r = computeMeasureValue("crashes_per_10k_income", tenCrashes, [
+      { ...pop50k, median_income: null },
+    ]);
+    expect(r.hasEnoughData).toBe(false);
+    expect(r.value).toBeNull();
+  });
+
+  it("crashes_per_10k_income returns no-data below MIN_CRASHES_FOR_RATE", () => {
+    const sparse = { ...tenCrashes, crash_count: 4 };
+    const r = computeMeasureValue("crashes_per_10k_income", sparse, [pop50k]);
+    expect(r.hasEnoughData).toBe(false);
+  });
+
+  it("crashes_per_10k_income works for multi-year via perYearCrashes", () => {
+    // 2020: 5 / 60,000 * 10,000 ≈ 0.8333
+    // 2023: 10 / 75,000 * 10,000 ≈ 1.3333
+    // total ≈ 2.1666
+    const stats = { ...tenCrashes, crash_count: 15 };
+    const demos = [
+      { county_code: 19, year: 2020, population: 100_000, median_income: 60_000 },
+      { county_code: 19, year: 2023, population: 50_000, median_income: 75_000 },
+    ];
+    const perYearCrashes = new Map<number, number>([[2020, 5], [2023, 10]]);
+    const r = computeMeasureValue("crashes_per_10k_income", stats, demos, { perYearCrashes });
+    expect(r.value).toBeCloseTo((5 / 60_000) * 10_000 + (10 / 75_000) * 10_000, 5);
+  });
+
   it("MIN_CRASHES_FOR_RATE equals 5", () => {
     expect(MIN_CRASHES_FOR_RATE).toBe(5);
   });
 
-  it("MEASURES exposes 5 measures including default", () => {
+  it("MEASURES exposes 6 measures including default and income", () => {
     const keys: MeasureKey[] = Object.keys(MEASURES) as MeasureKey[];
-    expect(keys).toHaveLength(5);
+    expect(keys).toHaveLength(6);
     expect(keys).toContain("crashes_per_100k");
+    expect(keys).toContain("crashes_per_10k_income");
+  });
+
+  it("crashes_per_10k_income measure is tagged as perIncome", () => {
+    expect(MEASURES.crashes_per_10k_income.kind).toBe("perIncome");
   });
 });

--- a/frontend/src/lib/choropleth/measures.ts
+++ b/frontend/src/lib/choropleth/measures.ts
@@ -8,14 +8,15 @@ export type MeasureKey =
   | "crashes_per_100k"
   | "fatalities_per_100k"
   | "injuries_per_100k"
+  | "crashes_per_10k_income"
   | "crashes_raw"
   | "fatality_rate";
 
 export type Measure = {
   key: MeasureKey;
   label: string;
-  /** "perCapita" needs demographics; "raw" and "rate" do not. */
-  kind: "perCapita" | "raw" | "rate";
+  /** "perCapita" / "perIncome" need demographics; "raw" and "rate" do not. */
+  kind: "perCapita" | "perIncome" | "raw" | "rate";
   formatLabel: (n: number) => string;
 };
 
@@ -37,6 +38,16 @@ export const MEASURES: Record<MeasureKey, Measure> = {
     label: "Injuries per 100k residents",
     kind: "perCapita",
     formatLabel: (n) => n.toFixed(0),
+  },
+  crashes_per_10k_income: {
+    // Crashes normalized by median household income — surfaces equity
+    // dimensions that pure population-based rates miss. Higher values
+    // mean more crashes per dollar of income, a proxy for under-invested
+    // / lower-resource areas. ACS B19013 median household income.
+    key: "crashes_per_10k_income",
+    label: "Crashes per $10K median income",
+    kind: "perIncome",
+    formatLabel: compact,
   },
   crashes_raw: {
     key: "crashes_raw",
@@ -70,6 +81,7 @@ export type CountyYearDemo = {
   county_code: number;
   year: number;
   population: number | null;
+  median_income: number | null;
 };
 
 export type MeasureResult = {
@@ -103,10 +115,29 @@ export function computeMeasureValue(
     return { value: (stats.total_killed / stats.crash_count) * 100, hasEnoughData: true };
   }
 
-  // Per-capita branches need population.
   if (stats.crash_count < MIN_CRASHES_FOR_RATE) {
     return { value: null, hasEnoughData: false };
   }
+
+  if (measure === "crashes_per_10k_income") {
+    if (demographics.length === 0 || demographics.some((d) => d.median_income == null)) {
+      return { value: null, hasEnoughData: false };
+    }
+    if (opts.perYearCrashes && opts.perYearCrashes.size > 0) {
+      let total = 0;
+      for (const d of demographics) {
+        const crashes = opts.perYearCrashes.get(d.year);
+        if (crashes == null || d.median_income == null || d.median_income === 0) continue;
+        total += (crashes / d.median_income) * 10_000;
+      }
+      return { value: total, hasEnoughData: true };
+    }
+    const summedIncome = demographics.reduce((acc, d) => acc + (d.median_income ?? 0), 0);
+    if (summedIncome === 0) return { value: null, hasEnoughData: false };
+    return { value: (stats.crash_count / summedIncome) * 10_000, hasEnoughData: true };
+  }
+
+  // Per-capita branches need population.
   if (demographics.length === 0 || demographics.some((d) => d.population == null)) {
     return { value: null, hasEnoughData: false };
   }


### PR DESCRIPTION
## What does this PR do?

  Resolves #135. Adds a "Crashes per $10K median income" choropleth measure that surfaces equity dimensions — counties
  with more crashes per dollar of household income, a proxy for under-invested or lower-resource areas.

  **Frontend** — `lib/choropleth/measures.ts` adds a new `crashes_per_10k_income` `MeasureKey`, a `"perIncome"` `kind`,
  an entry in `MEASURES`, and a `median_income` field on `CountyYearDemo` (already returned by `/api/demographics`, just
   type-narrowed in the hook). `computeMeasureValue` gets a new branch that computes `(crashes / median_income) *
  10,000` per county, with the same multi-year accuracy pattern as the per-100k measures: when `perYearCrashes` is
  supplied each year is divided by that year's median income and summed, otherwise it falls back to `total crashes /
  summed median income`. `ChoroplethLegend` extends its two `kind === "perCapita"` checks (measure-disabled state +
  missing-demographics warning) to also fire on `"perIncome"`. The measure picker UI (`LayersPanel`) and choropleth
  rendering pick the new measure up automatically since they iterate `MEASURES`.

  No backend changes — `DemographicOut.median_income` was already in the response schema.

  **Behavior** — values are gated by the same `MIN_CRASHES_FOR_RATE` threshold as per-capita measures, so tiny-county /
  sparse-data combos render as no-data rather than implausible spikes. Pre-2009 small counties (where ACS 1-year
  estimates don't cover counties under 65k pop) appear as no-data and trigger the existing "missing census data"
  warning.

  **Tests** — 5 new unit tests for `computeMeasureValue` covering the income branch (single-year math, null income,
  sub-threshold crashes, multi-year per-year sum, kind metadata), plus an updated count assertion (5 → 6 measures).

  ## Dependencies

  None.

  ## How to test
  - [ ] `docker-compose up --build` (or backend + frontend separately)
  - [ ] Open `/`, expand the measure picker on the choropleth legend → confirm **"Crashes per $10K median income"**
  appears as a new option below the per-100k measures
  - [ ] Select it → counties recolor; legend bucket labels switch to compact-formatted income-normalized values
  - [ ] Hover/click a populous county and a small county and confirm the values differ in a sensible direction
  (lower-income county → higher crashes-per-$10K)
  - [ ] Pick a date range covering pre-2009 years (e.g. 2005) → counties with no ACS coverage render as no-data and the
  "No census data for…" warning appears with a "Switch to Total Crashes" link
  - [ ] Pick a multi-year range → values accumulate across years (use a single county to spot-check: roughly the sum of
  per-year ratios)
  - [ ] `cd frontend && npm test` (140 pass) and `npx tsc --noEmit` (clean)

  ## Checklist
  - [x] Code builds without errors
  - [x] Tested locally
  - [x] No console errors/warnings
  - [x] No other PRs need to merge before this one (or listed above)