### PR TITLE
fix(#53): WCAG 2.2 AA accessibility + SEO + performance improvements

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="description" content="Explore 11 million California traffic crashes with interactive maps, AI-powered insights, and demographic analysis. Filter by county, cause, severity, and year." />
     <title>CalSight — California Crash Data Explorer</title>
     <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -12,6 +13,9 @@
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://api.calsight.org" />
+    <link rel="preconnect" href="https://a.basemaps.cartocdn.com" crossorigin />
+    <link rel="preconnect" href="https://b.basemaps.cartocdn.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Public+Sans:wght@300;400;500;600;700;800&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
   </head>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://calsight.org/sitemap.xml

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,14 +26,6 @@ export default function App() {
               <Route path="admin/etl" element={<Suspense fallback={null}><AdminEtlPage /></Suspense>} />
             </Route>
           </Routes>
-          <div
-            className="fixed inset-0 pointer-events-none opacity-[0.03] dark:opacity-0 z-[60]"
-            style={{
-              backgroundImage:
-                "url('https://www.transparenttextures.com/patterns/natural-paper.png')",
-              backgroundRepeat: "repeat",
-            }}
-          />
         </BrowserRouter>
       </ThemeProvider>
     </QueryClientProvider>

--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -14,7 +14,7 @@ export default function BottomTabBar() {
   const qs = buildFilterQS(searchParams);
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-surface-container-lowest bottom-tab-shadow" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
+    <nav aria-label="Main navigation" className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-surface-container-lowest bottom-tab-shadow" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
       <div className="flex items-center justify-around h-14">
         {tabs.map((tab) => (
           <NavLink

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,10 +5,23 @@ import Footer from "./Footer";
 import BottomTabBar from "./BottomTabBar";
 import { OfflineIndicator } from "./ui/OfflineIndicator";
 
+const PAGE_TITLES: Record<string, string> = {
+  "/": "Map Explorer — CalSight",
+  "/stats": "Statistics Dashboard — CalSight",
+  "/ask": "Ask AI — CalSight",
+  "/about": "About — CalSight",
+  "/privacy": "Privacy Policy — CalSight",
+  "/admin/etl": "ETL Admin — CalSight",
+};
+
 export default function Layout() {
   const location = useLocation();
   const isMapPage = location.pathname === "/";
   const isAskPage = location.pathname === "/ask";
+
+  useEffect(() => {
+    document.title = PAGE_TITLES[location.pathname] || "CalSight — California Crash Data Explorer";
+  }, [location.pathname]);
 
   // Scroll to hash anchor when navigating (e.g., /about#data-sources)
   useEffect(() => {
@@ -24,21 +37,27 @@ export default function Layout() {
 
   return (
     <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[60] focus:bg-primary focus:text-on-primary focus:px-4 focus:py-2 focus:rounded-lg focus:text-sm focus:font-semibold"
+      >
+        Skip to main content
+      </a>
       <NavBar />
       <OfflineIndicator />
       {isMapPage ? (
-        <main className="pt-12 pb-14 md:pt-16 md:pb-0 flex h-dvh overflow-hidden">
+        <main id="main-content" className="pt-12 pb-14 md:pt-16 md:pb-0 flex h-dvh overflow-hidden">
           <Outlet />
         </main>
       ) : isAskPage ? (
         <div key={location.pathname} className="page-enter pt-12 pb-14 md:pt-16 md:pb-0 h-dvh flex flex-col overflow-hidden">
-          <main className="flex-1 flex flex-col overflow-hidden">
+          <main id="main-content" className="flex-1 flex flex-col overflow-hidden">
             <Outlet />
           </main>
         </div>
       ) : (
         <div key={location.pathname} className="page-enter pt-12 md:pt-16 min-h-screen flex flex-col pb-20 md:pb-0">
-          <main className="flex-1">
+          <main id="main-content" className="flex-1">
             <Outlet />
           </main>
           <Footer />

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -23,24 +23,24 @@ export default function NavBar() {
     <header className="bg-surface fixed top-0 z-50 flex w-full items-center justify-between px-4 py-2 h-12 md:px-6 md:py-3 md:h-16">
       <div className="flex items-center gap-8">
         <NavLink to="/" className="flex items-center gap-2">
-          <img src={logo} alt="CalSight" className="h-7 w-auto" />
+          <img src={logo} alt="CalSight" className="h-7 w-auto" width={51} height={28} />
           <span className="text-xl font-bold tracking-tighter text-on-surface font-headline">
             CalSight
           </span>
-          <span className="text-[9px] font-bold uppercase tracking-widest text-primary bg-primary-container px-2 py-0.5 rounded-full">
+          <span className="text-[9px] font-bold uppercase tracking-widest text-on-primary-container bg-primary-container px-2 py-0.5 rounded-full">
             Beta
           </span>
         </NavLink>
-        <nav className="hidden md:flex gap-6 items-center">
+        <nav aria-label="Main navigation" className="hidden md:flex gap-6 items-center">
           {navLinks.map((link) => (
             <NavLink
               key={link.to}
               to={qs ? `${link.to}?${qs}` : link.to}
               end={link.to === "/"}
               className={({ isActive }) =>
-                `font-headline tracking-tight text-sm font-semibold transition-colors ${
+                `font-headline tracking-tight text-sm font-semibold transition-colors py-2 px-1 ${
                   isActive
-                    ? "text-on-surface border-b-2 border-primary pb-1"
+                    ? "text-on-surface border-b-2 border-primary"
                     : "text-on-surface-variant hover:text-on-surface"
                 }`
               }
@@ -55,6 +55,8 @@ export default function NavBar() {
       <div ref={settingsRef} className="flex items-center relative">
         <button
           onClick={() => setShowSettings((prev) => !prev)}
+          aria-label="Settings"
+          aria-expanded={showSettings}
           className="p-2 hover:bg-surface-container rounded-md transition-all text-primary"
         >
           <span className="material-symbols-outlined">settings</span>

--- a/frontend/src/components/map/Breadcrumb.tsx
+++ b/frontend/src/components/map/Breadcrumb.tsx
@@ -9,7 +9,7 @@ export default function Breadcrumb({ inspectedCounty, compareCounty, onDeselect 
 
   let label: React.ReactNode;
   if (inspectedCounty && compareCounty) {
-    label = <span className="text-on-surface">{inspectedCounty} <span className="text-on-surface/60">vs</span> {compareCounty}</span>;
+    label = <span className="text-on-surface">{inspectedCounty} <span className="text-on-surface-variant">vs</span> {compareCounty}</span>;
   } else if (inspectedCounty) {
     label = <span className="text-on-surface">{inspectedCounty} County</span>;
   } else {
@@ -18,12 +18,12 @@ export default function Breadcrumb({ inspectedCounty, compareCounty, onDeselect 
 
   return (
     <div className="hidden md:block absolute top-8 left-8 z-10 pointer-events-auto">
-      <div className="bg-surface-container-lowest/40 backdrop-blur-sm px-4 py-2 rounded-lg">
-        <p className="text-[11px] font-medium tracking-[0.3em] text-on-surface/60 uppercase">
+      <div className="bg-surface-container-lowest/90 backdrop-blur-sm px-4 py-2 rounded-lg">
+        <p className="text-[11px] font-medium tracking-[0.3em] text-on-surface-variant uppercase">
           {hasSelection ? (
             <button
               onClick={onDeselect}
-              className="hover:underline hover:text-on-surface/80 cursor-pointer transition-colors"
+              className="hover:underline hover:text-on-surface cursor-pointer transition-colors"
             >
               State Index
             </button>

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -251,7 +251,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           <span className="font-mono font-semibold">{formatCount(dataSummary.totalCrashes)}</span> crashes
 
           {coordValidation && coordValidation.mismatched > 0 && (
-            <div className="mt-0.5 text-[10px] text-on-surface-variant/80">
+            <div className="mt-0.5 text-[10px] text-on-surface-variant">
               <span className="font-mono">{formatCount(coordValidation.mismatched)}</span> audited outside county
             </div>
           )}

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -73,7 +73,7 @@ export default function AboutPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">CCRS</h3>
+              <h2 className="font-headline text-xl font-bold text-on-surface">CCRS</h2>
               <p className="text-sm text-on-surface-variant mt-1">California Crash Reporting System</p>
               <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
                 4.35M crashes from 2016-2026. Includes party-level demographics (age, gender, sobriety) and victim records. Published by CHP via data.ca.gov.
@@ -87,7 +87,7 @@ export default function AboutPage() {
 
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">SWITRS</h3>
+              <h2 className="font-headline text-xl font-bold text-on-surface">SWITRS</h2>
               <p className="text-sm text-on-surface-variant mt-1">Statewide Integrated Traffic Records System</p>
               <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
                 6.78M crashes from 2001-2015. Crash-level records only — no party or driver demographics. Archived by UC Berkeley and published by CHP.
@@ -101,7 +101,7 @@ export default function AboutPage() {
 
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">US Census Bureau</h3>
+              <h2 className="font-headline text-xl font-bold text-on-surface">US Census Bureau</h2>
               <p className="text-sm text-on-surface-variant mt-1">ACS Demographics + TIGER/Line Boundaries</p>
               <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
                 28 demographic fields per county per year (population, income, poverty, race, education). TIGER/Line 2023 survey-grade county boundaries for coordinate validation. AREAWATER 2023 for lake and harbor exclusion.
@@ -115,7 +115,7 @@ export default function AboutPage() {
 
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">California State Agencies</h3>
+              <h2 className="font-headline text-xl font-bold text-on-surface">California State Agencies</h2>
               <p className="text-sm text-on-surface-variant mt-1">DMV, Caltrans, OEHHA, CDE, OSHPD</p>
               <ul className="text-xs text-on-surface-variant mt-3 leading-relaxed space-y-1">
                 <li>CA DMV vehicle registrations (2019-2026)</li>
@@ -134,7 +134,7 @@ export default function AboutPage() {
 
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">Federal Agencies</h3>
+              <h2 className="font-headline text-xl font-bold text-on-surface">Federal Agencies</h2>
               <p className="text-sm text-on-surface-variant mt-1">NOAA, BLS, FHWA</p>
               <ul className="text-xs text-on-surface-variant mt-3 leading-relaxed space-y-1">
                 <li>NOAA monthly county weather data (2001-2025)</li>
@@ -150,7 +150,7 @@ export default function AboutPage() {
 
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h3 className="font-headline text-xl font-bold text-on-surface">OpenStreetMap + AI</h3>
+              <h2 className="font-headline text-xl font-bold text-on-surface">OpenStreetMap + AI</h2>
               <p className="text-sm text-on-surface-variant mt-1">Spatial validation and insight generation</p>
               <ul className="text-xs text-on-surface-variant mt-3 leading-relaxed space-y-1">
                 <li>OSM bridge locations (55K+ segments) for coordinate validation</li>
@@ -203,7 +203,7 @@ export default function AboutPage() {
             },
           ].map(({ title, body }) => (
             <div key={title} className="border-t border-outline-variant/20 pt-4">
-              <h4 className="text-sm font-semibold text-on-surface mb-1">{title}</h4>
+              <h3 className="text-sm font-semibold text-on-surface mb-1">{title}</h3>
               <p className="text-sm text-on-surface-variant leading-relaxed">{body}</p>
             </div>
           ))}
@@ -226,9 +226,9 @@ export default function AboutPage() {
             <div className="w-12 h-12 flex items-center justify-center rounded-full bg-primary-container text-primary">
               <span className="material-symbols-outlined">map</span>
             </div>
-            <h4 className="font-headline font-bold text-lg text-on-surface">
+            <h3 className="font-headline font-bold text-lg text-on-surface">
               Explore
-            </h4>
+            </h3>
             <p className="text-sm text-on-surface-variant leading-relaxed">
               Interactive GIS mapping allows you to visualize incident density
               across specific neighborhoods and corridors.
@@ -239,9 +239,9 @@ export default function AboutPage() {
             <div className="w-12 h-12 flex items-center justify-center rounded-full bg-tertiary-container text-tertiary">
               <span className="material-symbols-outlined">insights</span>
             </div>
-            <h4 className="font-headline font-bold text-lg text-on-surface">
+            <h3 className="font-headline font-bold text-lg text-on-surface">
               Analyze
-            </h4>
+            </h3>
             <p className="text-sm text-on-surface-variant leading-relaxed">
               Drill down into time-of-day, weather conditions, and vehicle types
               to understand the root causes of risk.
@@ -252,9 +252,9 @@ export default function AboutPage() {
             <div className="w-12 h-12 flex items-center justify-center rounded-full bg-secondary-container text-secondary">
               <span className="material-symbols-outlined">psychology</span>
             </div>
-            <h4 className="font-headline font-bold text-lg text-on-surface">
+            <h3 className="font-headline font-bold text-lg text-on-surface">
               Discover
-            </h4>
+            </h3>
             <p className="text-sm text-on-surface-variant leading-relaxed">
               Cross-reference crash patterns with demographics, weather, and
               infrastructure data to find unexpected correlations.
@@ -274,7 +274,7 @@ export default function AboutPage() {
               JS
             </div>
             <div>
-              <h4 className="font-bold text-on-surface">Jeffrey Sardella</h4>
+              <h3 className="font-bold text-on-surface">Jeffrey Sardella</h3>
               <p className="text-xs text-primary font-medium">
                 Project Lead & Full-Stack Developer
               </p>
@@ -286,7 +286,7 @@ export default function AboutPage() {
               MS
             </div>
             <div>
-              <h4 className="font-bold text-on-surface">Maksim Shkrabak</h4>
+              <h3 className="font-bold text-on-surface">Maksim Shkrabak</h3>
               <p className="text-xs text-primary font-medium">
                 Developer
               </p>
@@ -298,7 +298,7 @@ export default function AboutPage() {
               JL
             </div>
             <div>
-              <h4 className="font-bold text-on-surface">John Longarini</h4>
+              <h3 className="font-bold text-on-surface">John Longarini</h3>
               <p className="text-xs text-primary font-medium">
                 Developer
               </p>
@@ -310,7 +310,7 @@ export default function AboutPage() {
               GK
             </div>
             <div>
-              <h4 className="font-bold text-on-surface">Gavin Kabel</h4>
+              <h3 className="font-bold text-on-surface">Gavin Kabel</h3>
               <p className="text-xs text-primary font-medium">
                 Developer
               </p>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -358,6 +358,7 @@ function MapPageInner() {
 
   return (
     <>
+      <h1 className="sr-only">California Crash Map Explorer</h1>
       {/* Sidebar — hidden on mobile */}
       <div className="hidden md:flex h-full z-40">
         <IconRail activePanel={activePanel} onPanelToggle={handleToggle} />
@@ -399,14 +400,14 @@ function MapPageInner() {
           <div className="absolute top-3 right-3 z-20 md:hidden flex items-center gap-2">
             <button
               onClick={() => setMobileSearchExpanded(true)}
-              className="flex items-center justify-center w-10 h-10 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
+              className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
               aria-label="Search"
             >
               <span className="material-symbols-outlined text-[20px]">search</span>
             </button>
             <button
               onClick={() => setShowMobileFilters(true)}
-              className="flex items-center justify-center w-10 h-10 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
+              className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
               aria-label="Open filters"
             >
               <span className="material-symbols-outlined text-[20px]">tune</span>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -269,6 +269,7 @@ export default function StatsPage() {
 
   return (
     <main className="max-w-[1200px] mx-auto px-4 md:px-6 py-6 md:py-8 space-y-6 md:space-y-8 relative">
+      <h1 className="sr-only">Statistics Dashboard</h1>
       {/* Filter Summary Bar */}
       <section className="bg-surface-container-low rounded-lg px-4 md:px-6 py-3 flex flex-col md:flex-row items-start md:items-center justify-between gap-3 md:gap-0">
         <div className="flex items-center gap-3 overflow-x-auto no-scrollbar w-full md:w-auto">


### PR DESCRIPTION
## What does this PR do?
Accessibility:
- Skip-nav link (WCAG 2.4.1)
- Dynamic page titles per route (WCAG 2.4.2)
- Heading hierarchy: sr-only h1 on Map/Stats, h3>h2 on About (WCAG 1.3.1)
- Contrast fixes on breadcrumb, legend, BETA badge (WCAG 1.4.3)
- Touch targets bumped to 44px on nav links and mobile buttons (WCAG 2.5.8)
- aria-label on nav elements and settings button (WCAG 4.1.2)

SEO:
- Meta description added
- robots.txt created (was serving SPA HTML fallback)
- Preconnects for api.calsight.org and cartocdn

Performance:
- Removed 99KB transparent texture overlay (external PNG at 3% opacity)
- Added width/height to logo img (prevents CLS)

## How to test
  Automated:
  - Lighthouse accessibility score ≥ 95 on desktop and mobile
  - Lighthouse SEO score ≥ 90
  - robots.txt returns proper text (not HTML) at calsight.org/robots.txt
  - TypeScript builds with no errors

  WCAG manual checks:
  - Tab through all pages — focus indicator visible on every interactive element
  - Skip-nav link appears on focus (press Tab on page load)
  - Each page has a unique browser tab title
  - Breadcrumb text readable over map background
  - Legend text readable over map background
  - Mobile: search and filter buttons are easy to tap (44px targets)
  - Mobile: bottom tab bar navigates correctly
  - Screen reader (NVDA/VoiceOver): announces page headings and landmarks

  Visual regression:
  - BETA badge still looks correct (darker text)
  - Breadcrumb background not too opaque over the map
  - No paper texture visible (removed)
  - Logo renders at correct size (no CLS flash)


## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
