### PR TITLE
fix: mobile insight cards overflow — truncate, cap height, add dismiss

### DIFF
--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -154,7 +154,7 @@ export default function AiInsightCard({
 
   return (
     <div className="fixed bottom-card-mobile left-0 right-0 z-40 md:absolute md:bottom-2 md:left-16 md:right-auto md:w-[480px] md:z-30">
-      <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden">
+      <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden max-h-[50vh] md:max-h-none overflow-y-auto">
         {/* Collapsed bar — always visible */}
         <div
           className="flex items-center justify-between px-4 py-3 cursor-pointer select-none"
@@ -237,7 +237,7 @@ export default function AiInsightCard({
                         </button>
                       )}
                     </div>
-                    <p className="text-xs text-on-surface-variant font-body leading-relaxed">
+                    <p className="text-xs text-on-surface-variant font-body leading-relaxed md:line-clamp-none line-clamp-4">
                       {narrative}
                     </p>
                   </div>

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -131,6 +131,33 @@ const ANGLE_LABELS: Record<string, string> = {
   tourism: "Tourism",
   nighttime: "Nighttime",
   wildlife: "Wildlife",
+  county_spotlight: "Spotlight",
+  surprising_stat: "Surprise",
+  historical_context: "History",
+  fatality_paradox: "Fatality",
+  speeding: "Speeding",
+  urban_rural: "Urban vs Rural",
+  time_of_day: "Time of Day",
+  cause_breakdown: "Causes",
+  data_quality: "Data Quality",
+  holiday: "Holiday",
+  vehicle_tech: "Vehicle Tech",
+  income_inequality: "Income",
+  motorcycle: "Motorcycle",
+  recovery_pattern: "Recovery",
+  commuter_corridor: "Commuter",
+  weekend_weekday: "Weekday vs Weekend",
+  age: "Age",
+  injury_severity: "Severity",
+  decade_comparison: "Decade",
+  what_if: "What If",
+  policy: "Policy",
+  enforcement: "Enforcement",
+  rideshare_impact: "Rideshare",
+  intersection: "Intersection",
+  hit_and_run: "Hit & Run",
+  population_growth: "Population",
+  gender: "Gender",
 };
 
 export default function AiInsightCard({
@@ -162,7 +189,7 @@ export default function AiInsightCard({
         >
           <div className="min-w-0">
             <h3 className="font-headline text-base font-bold text-on-surface tracking-tight truncate">
-              {isComparing ? `${countyName} vs ${compareCountyName}` : `${countyName} County`}
+              {isComparing ? `${countyName} vs ${compareCountyName}` : data ? `${countyName} County` : "California Insight"}
             </h3>
             {data && !expanded && (
               <p className="text-[11px] text-on-surface-variant mt-0.5">
@@ -249,7 +276,7 @@ export default function AiInsightCard({
                   </p>
                 )}
 
-                {!compareMode && (
+                {!compareMode && data && (
                   <button
                     onClick={onCompare}
                     className="w-full bg-primary-container text-on-primary-container py-2 rounded-lg text-[11px] font-bold tracking-widest uppercase hover:opacity-90 transition-opacity"

--- a/frontend/src/components/map/StatewideInsightCard.tsx
+++ b/frontend/src/components/map/StatewideInsightCard.tsx
@@ -36,17 +36,25 @@ export default function StatewideInsightCard({
   searchOpen,
 }: StatewideInsightCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const shouldTruncate = card.narrative.length > 180;
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  const mobileLimit = 100;
+  const desktopLimit = 200;
+  const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
+  const limit = isMobile ? mobileLimit : desktopLimit;
+  const shouldTruncate = card.narrative.length > limit;
   const displayText = shouldTruncate && !expanded
-    ? card.narrative.slice(0, 180) + "..."
+    ? card.narrative.slice(0, limit) + "..."
     : card.narrative;
 
   return (
     <div
       className={`absolute bottom-card-mobile left-0 right-0 z-20 md:bottom-2 md:left-16 md:right-auto md:w-[400px] md:z-30 transition-opacity duration-200 ${searchOpen ? "opacity-0 pointer-events-none" : ""}`}
     >
-      <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden">
-        <div className="px-4 py-3 space-y-2">
+      <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border md:rounded-xl overflow-hidden max-h-[40vh] md:max-h-none overflow-y-auto">
+        <div className="px-3 py-2.5 md:px-4 md:py-3 space-y-1.5 md:space-y-2">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2 min-w-0">
               <span className="material-symbols-outlined text-[16px] text-primary shrink-0">
@@ -59,13 +67,22 @@ export default function StatewideInsightCard({
                 {ANGLE_LABELS[card.angle] ?? card.angle}
               </span>
             </div>
-            <button
-              onClick={onRefresh}
-              className="p-1.5 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors shrink-0"
-              title="Show another insight"
-            >
-              <span className="material-symbols-outlined text-[16px]">refresh</span>
-            </button>
+            <div className="flex items-center gap-1 shrink-0">
+              <button
+                onClick={onRefresh}
+                className="p-1.5 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
+                title="Show another insight"
+              >
+                <span className="material-symbols-outlined text-[16px]">refresh</span>
+              </button>
+              <button
+                onClick={() => setDismissed(true)}
+                className="p-1.5 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors md:hidden"
+                aria-label="Dismiss insight"
+              >
+                <span className="material-symbols-outlined text-[16px]">close</span>
+              </button>
+            </div>
           </div>
           <p className="text-xs text-on-surface-variant font-body leading-relaxed">
             {displayText}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -30,7 +30,6 @@ import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import { useCoordCoverage } from "../hooks/useCoordCoverage";
 import { useCountyInsight } from "../hooks/useCountyInsight";
 import { useRandomInsight } from "../hooks/useRandomInsight";
-import StatewideInsightCard from "../components/map/StatewideInsightCard";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
   filters: { title: "Filters", subtitle: "Secondary Parameters" },
@@ -490,10 +489,16 @@ function MapPageInner() {
           />
         )}
         {!focusedCounty && randomCard && (
-          <StatewideInsightCard
-            card={randomCard}
-            onRefresh={refreshRandomCard}
-            searchOpen={mobileSearchExpanded}
+          <AiInsightCard
+            onClose={() => {}}
+            countyName="California"
+            data={undefined}
+            measureLabel=""
+            compareMode={false}
+            onCompare={() => {}}
+            narrative={randomCard.narrative}
+            narrativeAngle={randomCard.angle}
+            onRefreshNarrative={refreshRandomCard}
           />
         )}
         {heatmapEnabled && heatmap.isLoading && (


### PR DESCRIPTION
StatewideInsightCard: shorter truncation on mobile (100 chars vs 200), max-height 40vh, dismiss button (mobile only), reset on card change.

AiInsightCard: max-height 50vh on mobile, line-clamp-4 on narrative text to prevent long cards from covering the map.
