### PR TITLE
(#125) Add at-fault demographics materialized view and API endpoint

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -19,6 +19,8 @@ from app.filters import (
 from app.models import County, Crash
 from app.schemas.stats import (
     AgeBracketRow,
+    AtFaultAgeBracketRow,
+    AtFaultGenderRow,
     CauseRow,
     CountyRow,
     DayOfWeekRow,
@@ -83,6 +85,21 @@ mv_victims = Table(
     Column("age_bracket", String),
     Column("victim_count", Integer),
     Column("fatal_victim_count", Integer),
+)
+
+# Per at-fault-party demographic aggregates. Backs ?group_by=at_fault_gender
+# / at_fault_age_bracket. Source: crash_parties WHERE at_fault=TRUE, JOINed
+# to crashes on (collision_id, data_source). Columns must mirror migration
+# f8a1b2c3d4e5_add_mv_at_fault_parties_by_demographics.
+mv_at_fault = Table(
+    "mv_at_fault_parties_by_demographics", _metadata,
+    Column("county_code", SmallInteger),
+    Column("crash_year", SmallInteger),
+    Column("severity", String),
+    Column("gender", String),
+    Column("age_bracket", String),
+    Column("party_count", Integer),
+    Column("fatal_party_count", Integer),
 )
 
 mv_month = Table(
@@ -152,7 +169,7 @@ def stats(
     driver_age: str | None = Query(None),
     group_by: str | None = Query(
         None,
-        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|rate)$",
+        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|at_fault_gender|at_fault_age_bracket|rate)$",
     ),
     db: Session = Depends(get_db),
 ):
@@ -163,12 +180,16 @@ def stats(
       - `cause` OR any cause filter -> mv_crashes_by_cause
       - `gender` / `age_bracket` -> mv_crash_victims_by_demographics
         (counts VICTIMS, not crashes — see GenderRow docstring)
+      - `at_fault_gender` / `at_fault_age_bracket` ->
+        mv_at_fault_parties_by_demographics (counts AT-FAULT PARTIES —
+        typically drivers — not victims and not crashes)
       - everything else -> mv_crashes_by_year
 
     `alcohol` / `distracted` are not supported here (crash views don't carry
     those columns). Use `/api/crashes` with those filters for drill-down.
-    `cause` filter is incompatible with `group_by=gender|age_bracket`
-    because the victim-demographics view doesn't carry canonical_cause.
+    `cause` filter is incompatible with `group_by=gender|age_bracket|
+    at_fault_gender|at_fault_age_bracket` because the demographic views
+    don't carry canonical_cause.
 
     `start`/`end` (YYYY-MM) are accepted but rounded outward to year
     boundaries here, since the underlying materialized views aggregate by
@@ -204,11 +225,12 @@ def stats(
     severities = parse_severity(severity)
     causes = parse_cause(cause)
 
-    if group_by in ("gender", "age_bracket") and causes:
+    if group_by in ("gender", "age_bracket", "at_fault_gender", "at_fault_age_bracket") and causes:
         raise FilterError(
             "cause",
-            "cause filter is not supported with group_by=gender or age_bracket "
-            "(victim-demographics view doesn't carry canonical_cause).",
+            "cause filter is not supported with demographic group_by values "
+            "(gender, age_bracket, at_fault_gender, at_fault_age_bracket) — "
+            "those views don't carry canonical_cause.",
         )
 
     view = _pick_view(group_by, has_cause_filter=bool(causes))
@@ -492,6 +514,62 @@ def stats(
                 age_bracket=r.age_bracket,
                 victim_count=r.victim_count,
                 fatal_victim_count=r.fatal_victim_count,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=at_fault_gender (at-fault-parties MV) ---
+    if group_by == "at_fault_gender":
+        v = mv_at_fault
+        stmt = (
+            select(
+                v.c.gender,
+                func.sum(v.c.party_count).label("party_count"),
+                func.sum(v.c.fatal_party_count).label("fatal_party_count"),
+            )
+            .group_by(v.c.gender)
+            .order_by(func.sum(v.c.party_count).desc())
+        )
+        if years:
+            stmt = stmt.where(v.c.crash_year.in_(years))
+        if county_codes:
+            stmt = stmt.where(v.c.county_code.in_(county_codes))
+        if severities:
+            stmt = stmt.where(v.c.severity.in_(severities))
+        rows = db.execute(stmt).all()
+        return [
+            AtFaultGenderRow(
+                gender=r.gender,
+                party_count=r.party_count,
+                fatal_party_count=r.fatal_party_count,
+            ).model_dump()
+            for r in rows
+        ]
+
+    # --- group_by=at_fault_age_bracket (at-fault-parties MV) ---
+    if group_by == "at_fault_age_bracket":
+        v = mv_at_fault
+        stmt = (
+            select(
+                v.c.age_bracket,
+                func.sum(v.c.party_count).label("party_count"),
+                func.sum(v.c.fatal_party_count).label("fatal_party_count"),
+            )
+            .group_by(v.c.age_bracket)
+            .order_by(func.sum(v.c.party_count).desc())
+        )
+        if years:
+            stmt = stmt.where(v.c.crash_year.in_(years))
+        if county_codes:
+            stmt = stmt.where(v.c.county_code.in_(county_codes))
+        if severities:
+            stmt = stmt.where(v.c.severity.in_(severities))
+        rows = db.execute(stmt).all()
+        return [
+            AtFaultAgeBracketRow(
+                age_bracket=r.age_bracket,
+                party_count=r.party_count,
+                fatal_party_count=r.fatal_party_count,
             ).model_dump()
             for r in rows
         ]

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -61,6 +61,26 @@ class AgeBracketRow(BaseModel):
     fatal_victim_count: int
 
 
+class AtFaultGenderRow(BaseModel):
+    """Row from /api/stats?group_by=at_fault_gender. Counts AT-FAULT PARTIES
+    (typically drivers), not victims and not crashes. Sourced from
+    mv_at_fault_parties_by_demographics. Complements GenderRow's victim
+    counts: a single fatal crash with a male at-fault driver and 2 female
+    passenger victims contributes 1 to this row's party_count and 2 to
+    GenderRow's victim_count."""
+    gender: str
+    party_count: int
+    fatal_party_count: int
+
+
+class AtFaultAgeBracketRow(BaseModel):
+    """Row from /api/stats?group_by=at_fault_age_bracket. Same at-fault-party
+    caveat as AtFaultGenderRow. Buckets match AgeBracketRow."""
+    age_bracket: str
+    party_count: int
+    fatal_party_count: int
+
+
 class MonthRow(BaseModel):
     month: int
     crash_count: int

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -5,6 +5,7 @@ Views and the migrations that defined them:
   - mv_crashes_by_cause                    (f3d4e5f6a7b8)
   - mv_crashes_by_year                     (f3d4e5f6a7b8)
   - mv_crash_victims_by_demographics       (b5e9d3f1c8a4) — gender / age
+  - mv_at_fault_parties_by_demographics    (f8a1b2c3d4e5) — at-fault party gender / age
   - mv_crashes_by_month                    (g4h5i6j7k8l9) — seasonality
   - mv_crash_rates                         (g4h5i6j7k8l9) — per-capita rates
 
@@ -41,6 +42,7 @@ _VIEWS = [
     "mv_crashes_by_hour",
     "mv_crashes_by_month",
     "mv_crash_victims_by_demographics",
+    "mv_at_fault_parties_by_demographics",
     "mv_crash_rates",
 ]
 

--- a/backend/migrations/versions/f8a1b2c3d4e5_add_mv_at_fault_parties_by_demographics.py
+++ b/backend/migrations/versions/f8a1b2c3d4e5_add_mv_at_fault_parties_by_demographics.py
@@ -1,0 +1,88 @@
+"""create materialized view mv_at_fault_parties_by_demographics
+
+Powers /api/stats?group_by=at_fault_gender|at_fault_age_bracket. Mirrors
+mv_crash_victims_by_demographics (b5e9d3f1c8a4) but counts AT-FAULT parties
+(typically drivers) instead of victims. Useful for the "who causes crashes"
+question that complements the "who gets hurt" question covered by the
+victim view.
+
+Source: crash_parties WHERE at_fault = TRUE, joined to crashes on
+(collision_id, data_source) — see docs/db-schema.md for why both columns
+are required.
+
+Estimated size: similar order to victim view (~140K rows). One row per
+(county, year, severity, gender, age_bracket).
+
+Refresh is concurrent (UNIQUE index below); add to refresh_materialized_views.
+
+Revision ID: f8a1b2c3d4e5
+Revises: e2f3a4b5c6d7
+Create Date: 2026-05-09 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'f8a1b2c3d4e5'
+down_revision: Union[str, None] = 'e2f3a4b5c6d7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # GROUP BY uses the same COALESCE/CASE expressions as SELECT so that
+    # NULL-gender rows fold into 'U' and don't form a separate group from
+    # rows where cp.gender = 'U' — same trick as the victim MV migration.
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_at_fault_parties_by_demographics AS
+        SELECT
+            c.county_code,
+            c.crash_year,
+            COALESCE(c.severity, 'Unknown') AS severity,
+            COALESCE(cp.gender, 'U') AS gender,
+            CASE
+                WHEN cp.age IS NULL THEN 'unknown'
+                WHEN cp.age < 18  THEN 'under_18'
+                WHEN cp.age <= 24 THEN '18_24'
+                WHEN cp.age <= 44 THEN '25_44'
+                WHEN cp.age <= 64 THEN '45_64'
+                ELSE 'over_65'
+            END AS age_bracket,
+            COUNT(*)::integer AS party_count,
+            SUM(CASE WHEN c.severity = 'Fatal' THEN 1 ELSE 0 END)::integer AS fatal_party_count
+        FROM crash_parties cp
+        JOIN crashes c
+          ON c.collision_id = cp.collision_id
+         AND c.data_source = cp.data_source
+        WHERE cp.at_fault = TRUE
+          AND c.crash_year IS NOT NULL
+        GROUP BY
+            c.county_code,
+            c.crash_year,
+            COALESCE(c.severity, 'Unknown'),
+            COALESCE(cp.gender, 'U'),
+            CASE
+                WHEN cp.age IS NULL THEN 'unknown'
+                WHEN cp.age < 18  THEN 'under_18'
+                WHEN cp.age <= 24 THEN '18_24'
+                WHEN cp.age <= 44 THEN '25_44'
+                WHEN cp.age <= 64 THEN '45_64'
+                ELSE 'over_65'
+            END
+        WITH NO DATA
+    """)
+    # UNIQUE index required for REFRESH CONCURRENTLY.
+    op.execute("""
+        CREATE UNIQUE INDEX ix_mv_at_fault_parties_by_demographics_pk
+        ON mv_at_fault_parties_by_demographics
+        (county_code, crash_year, severity, gender, age_bracket)
+    """)
+    op.execute("""
+        CREATE INDEX ix_mv_at_fault_parties_by_demographics_county_year
+        ON mv_at_fault_parties_by_demographics (county_code, crash_year)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_at_fault_parties_by_demographics")

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -221,6 +221,7 @@ def _seed(session: Session) -> None:
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_cause"))
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_hour"))
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crash_victims_by_demographics"))
+    session.execute(text("REFRESH MATERIALIZED VIEW mv_at_fault_parties_by_demographics"))
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_month"))
     session.execute(text("REFRESH MATERIALIZED VIEW mv_crash_rates"))
     session.commit()

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -134,6 +134,81 @@ def test_stats_gender_severity_filter_works(client):
     assert len(body) >= 1
 
 
+# --- group_by=at_fault_gender / at_fault_age_bracket
+#     (mv_at_fault_parties_by_demographics) ---
+
+
+def test_stats_group_by_at_fault_gender_returns_party_buckets(client):
+    response = client.get("/api/stats?group_by=at_fault_gender")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    # Seed has 2 at-fault parties total, both male (parties 1001 + 1003).
+    # The non-at-fault parties (1002, 1004) MUST NOT appear.
+    male_row = next((r for r in body if r["gender"] == "M"), None)
+    assert male_row is not None
+    assert male_row["party_count"] == 2
+    # No female at-fault parties in seed → row should not exist or be 0.
+    female_row = next((r for r in body if r["gender"] == "F"), None)
+    assert female_row is None or female_row["party_count"] == 0
+    for row in body:
+        # Party-count fields must not leak as victim_count.
+        assert "victim_count" not in row
+        assert "party_count" in row
+        assert "fatal_party_count" in row
+
+
+def test_stats_group_by_at_fault_age_bracket(client):
+    response = client.get("/api/stats?group_by=at_fault_age_bracket")
+    assert response.status_code == 200
+    body = response.json()
+    brackets = {row["age_bracket"] for row in body}
+    # Seed: at-fault driver ages 42 (25_44) and 22 (18_24).
+    assert "25_44" in brackets
+    assert "18_24" in brackets
+
+
+def test_stats_at_fault_gender_with_county_filter(client):
+    response = client.get("/api/stats?group_by=at_fault_gender&county=los-angeles")
+    assert response.status_code == 200
+    body = response.json()
+    # Only crash 3 (LA) has an at-fault party (1001, M, 42).
+    male_row = next((r for r in body if r["gender"] == "M"), None)
+    assert male_row is not None
+    assert male_row["party_count"] == 1
+    assert male_row["fatal_party_count"] == 1
+
+
+def test_stats_at_fault_gender_rejects_cause_filter(client):
+    response = client.get("/api/stats?group_by=at_fault_gender&cause=dui")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "cause"
+
+
+def test_stats_at_fault_age_bracket_rejects_cause_filter(client):
+    response = client.get("/api/stats?group_by=at_fault_age_bracket&cause=speeding")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "cause"
+
+
+def test_stats_at_fault_gender_severity_filter_works(client):
+    """Severity filter IS supported — mv_at_fault has a severity column."""
+    response = client.get("/api/stats?group_by=at_fault_gender&severity=fatal")
+    assert response.status_code == 200
+    body = response.json()
+    # Crash 3 (LA, Fatal severity) has 1 male at-fault party.
+    male_row = next((r for r in body if r["gender"] == "M"), None)
+    assert male_row is not None
+    assert male_row["party_count"] == 1
+
+
+def test_stats_rejects_unknown_group_by(client):
+    """Sanity: pattern validator still rejects garbage values, even with the
+    new at_fault_* options on the allowlist."""
+    response = client.get("/api/stats?group_by=at_fault_height")
+    assert response.status_code == 422
+
+
 # --- group_by=month (mv_crashes_by_month) ---
 
 

--- a/frontend/src/hooks/useStats.test.tsx
+++ b/frontend/src/hooks/useStats.test.tsx
@@ -73,7 +73,7 @@ describe("useStats", () => {
     });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(spy).toHaveBeenCalledTimes(10);
+    expect(spy).toHaveBeenCalledTimes(12);
     const urls = spy.mock.calls.map((c) => String(c[0]));
     expect(urls.some((u) => u.includes("group_by=year") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=hour") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
@@ -82,9 +82,56 @@ describe("useStats", () => {
     expect(urls.some((u) => u.includes("group_by=severity"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=gender"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=age_bracket"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=at_fault_gender"))).toBe(true);
+    expect(urls.some((u) => u.includes("group_by=at_fault_age_bracket"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=month"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=day_of_week"))).toBe(true);
     expect(urls.some((u) => u.includes("group_by=rate"))).toBe(true);
+  });
+
+  it("maps at-fault demographic responses to chart data points", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("group_by=at_fault_gender")) {
+        return new Response(JSON.stringify([
+          { gender: "M", party_count: 7000, fatal_party_count: 200 },
+          { gender: "F", party_count: 3000, fatal_party_count: 80 },
+          { gender: "U", party_count: 100, fatal_party_count: 1 },
+        ]));
+      }
+      if (url.includes("group_by=at_fault_age_bracket")) {
+        return new Response(JSON.stringify([
+          { age_bracket: "25_44", party_count: 5000, fatal_party_count: 100 },
+          { age_bracket: "18_24", party_count: 2500, fatal_party_count: 60 },
+          { age_bracket: "45_64", party_count: 2000, fatal_party_count: 40 },
+          { age_bracket: "over_65", party_count: 800, fatal_party_count: 30 },
+          { age_bracket: "under_18", party_count: 200, fatal_party_count: 5 },
+          { age_bracket: "unknown", party_count: 50, fatal_party_count: 0 },
+        ]));
+      }
+      if (url.includes("group_by=year")) return new Response(JSON.stringify(YEAR_ROWS));
+      if (url.includes("group_by=hour")) return new Response(JSON.stringify(HOUR_ROWS));
+      if (url.includes("group_by=cause")) return new Response(JSON.stringify(CAUSE_ROWS));
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(() => useStats(FILTERS), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const data = result.current.data!;
+    // "U" passes through — matches the existing victim Gender chart behavior
+    // (the filter excludes the literal string "unknown", but the MV stores
+    // the value as "U"). Worth a follow-up to filter both, but out of scope.
+    expect(data.atFaultGenderData).toEqual([
+      { label: "M", count: 7000 },
+      { label: "F", count: 3000 },
+      { label: "U", count: 100 },
+    ]);
+    // Sorted by AGE_ORDER (under_18 → over_65), with "unknown" filtered out.
+    expect(data.atFaultAgeBracketData.map((r) => r.label)).toEqual([
+      "Under 18", "18–24", "25–44", "45–64", "65+",
+    ]);
+    expect(data.atFaultAgeBracketData.find((r) => r.label === "25–44")?.count).toBe(5000);
   });
 
   it("maps API responses to chart data shapes", async () => {

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -16,6 +16,8 @@ export interface CauseDataPoint { label: string; count: number }
 export interface SeverityDataPoint { label: string; count: number }
 export interface GenderDataPoint { label: string; count: number }
 export interface AgeBracketDataPoint { label: string; count: number }
+export interface AtFaultGenderDataPoint { label: string; count: number }
+export interface AtFaultAgeBracketDataPoint { label: string; count: number }
 export interface HeroMetrics {
   totalIncidents?: number;
   incidentYoYPct?: number;
@@ -39,6 +41,8 @@ export interface StatsData {
   severityData: SeverityDataPoint[];
   genderData: GenderDataPoint[];
   ageBracketData: AgeBracketDataPoint[];
+  atFaultGenderData: AtFaultGenderDataPoint[];
+  atFaultAgeBracketData: AtFaultAgeBracketDataPoint[];
   monthlyData: MonthlyDataPoint[];
   dayOfWeekData: DayOfWeekDataPoint[];
   rateData: RateDataPoint[];
@@ -58,6 +62,8 @@ type CauseRow = { canonical_cause: string; crash_count: number; total_killed: nu
 type SeverityRow = { severity: string; crash_count: number; total_killed: number; total_injured: number };
 type GenderRow = { gender: string; victim_count: number; fatal_victim_count: number };
 type AgeBracketRow = { age_bracket: string; victim_count: number; fatal_victim_count: number };
+type AtFaultGenderRow = { gender: string; party_count: number; fatal_party_count: number };
+type AtFaultAgeBracketRow = { age_bracket: string; party_count: number; fatal_party_count: number };
 type DemoRow = { county_code: number; year: number; population: number | null };
 type MonthRow = { month: number; crash_count: number; total_killed: number; total_injured: number };
 type DayOfWeekRow = { day_of_week: number; crash_count: number };
@@ -216,6 +222,14 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
         queryFn: () => fetchJson<AgeBracketRow[]>(buildVictimUrl("age_bracket", filters)),
       },
       {
+        queryKey: ["stats", "at_fault_gender", { d: dateKey, s: filters.severities, co: filters.counties }],
+        queryFn: () => fetchJson<AtFaultGenderRow[]>(buildVictimUrl("at_fault_gender", filters)),
+      },
+      {
+        queryKey: ["stats", "at_fault_age_bracket", { d: dateKey, s: filters.severities, co: filters.counties }],
+        queryFn: () => fetchJson<AtFaultAgeBracketRow[]>(buildVictimUrl("at_fault_age_bracket", filters)),
+      },
+      {
         queryKey: ["stats", "month", cacheKey],
         queryFn: () => fetchJson<MonthRow[]>(buildUrl("month", filters)),
       },
@@ -230,7 +244,7 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
     ],
   });
 
-  const [yearQ, hourQ, causeQ, demoQ, severityQ, genderQ, ageQ, monthQ, dowQ, rateQ] = queries;
+  const [yearQ, hourQ, causeQ, demoQ, severityQ, genderQ, ageQ, atFaultGenderQ, atFaultAgeQ, monthQ, dowQ, rateQ] = queries;
   const loading = yearQ.isLoading || hourQ.isLoading || causeQ.isLoading;
   const rawError = yearQ.error ?? hourQ.error ?? causeQ.error;
 
@@ -274,6 +288,21 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
         count: r.victim_count,
       }));
 
+    const atFaultGenderData: AtFaultGenderDataPoint[] = (atFaultGenderQ.data ?? [])
+      .filter((r) => r.gender && r.gender !== "unknown")
+      .map((r) => ({
+        label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1),
+        count: r.party_count,
+      }));
+
+    const atFaultAgeBracketData: AtFaultAgeBracketDataPoint[] = (atFaultAgeQ.data ?? [])
+      .sort((a, b) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b.age_bracket))
+      .filter((r) => r.age_bracket !== "unknown")
+      .map((r) => ({
+        label: AGE_LABEL[r.age_bracket] ?? r.age_bracket,
+        count: r.party_count,
+      }));
+
     const monthlyData: MonthlyDataPoint[] = (monthQ.data ?? []).map((r) => ({
       month: r.month,
       label: MONTH_LABEL[r.month - 1] ?? String(r.month),
@@ -308,8 +337,8 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
       : null;
     const heroMetrics = computeHeroMetrics(yearQ.data, population);
 
-    return { hourlyData, yearlyData, causesData, severityData, genderData, ageBracketData, monthlyData, dayOfWeekData, rateData, heroMetrics };
-  }, [yearQ.data, hourQ.data, causeQ.data, demoQ.data, severityQ.data, genderQ.data, ageQ.data, monthQ.data, dowQ.data, rateQ.data]);
+    return { hourlyData, yearlyData, causesData, severityData, genderData, ageBracketData, atFaultGenderData, atFaultAgeBracketData, monthlyData, dayOfWeekData, rateData, heroMetrics };
+  }, [yearQ.data, hourQ.data, causeQ.data, demoQ.data, severityQ.data, genderQ.data, ageQ.data, atFaultGenderQ.data, atFaultAgeQ.data, monthQ.data, dowQ.data, rateQ.data]);
 
   return {
     data,

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -221,8 +221,10 @@ export default function StatsPage() {
   const yearlyData     = data?.yearlyData     ?? [];
   const causesData     = data?.causesData     ?? [];
   const severityData   = data?.severityData   ?? [];
-  const genderData     = data?.genderData     ?? [];
-  const ageBracketData = data?.ageBracketData ?? [];
+  const genderData             = data?.genderData             ?? [];
+  const ageBracketData         = data?.ageBracketData         ?? [];
+  const atFaultGenderData      = data?.atFaultGenderData      ?? [];
+  const atFaultAgeBracketData  = data?.atFaultAgeBracketData  ?? [];
   const monthlyData    = data?.monthlyData    ?? [];
   const dayOfWeekData  = data?.dayOfWeekData  ?? [];
   const rateData       = data?.rateData       ?? [];
@@ -853,6 +855,108 @@ export default function StatsPage() {
                       <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
                         <p className="font-headline font-bold text-on-surface">{d.label}</p>
                         <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} victims</p>
+                      </div>
+                    );
+                  }}
+                  cursor={{ fill: "rgba(87,95,107,0.06)" }}
+                />
+                <Bar dataKey="count" radius={[2, 2, 0, 0]} fill={clrPrimaryContainer} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* At-Fault Drivers by Gender */}
+        <div className="col-span-12 md:col-span-4 bg-surface-container-lowest rounded-lg p-5 md:p-8 ambient-shadow">
+          <h3 className="text-on-surface font-headline font-bold text-lg mb-4 leading-tight">
+            At-Fault Drivers by Gender
+          </h3>
+          {dqDisclaimers.preDataOnly && (
+            <DataQualityNote text="At-fault driver data is only available from 2016 onward (CCRS)." />
+          )}
+          {!dqDisclaimers.preDataOnly && dqDisclaimers.hasPreCcrsYears && (
+            <DataQualityNote text="Pre-2016 years have no at-fault data — chart covers 2016+ only." />
+          )}
+          {loading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : !atFaultGenderData.length ? (
+            <EmptyState
+              icon="person_off"
+              description={dqDisclaimers.preDataOnly ? "At-fault data requires 2016 or later (CCRS)." : "No at-fault driver data for the current filters."}
+              className="h-48"
+            />
+          ) : (
+            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
+              <BarChart data={atFaultGenderData} barCategoryGap="25%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                <XAxis
+                  dataKey="label"
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
+                />
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0].payload as { label: string; count: number };
+                    const total = atFaultGenderData.reduce((s, g) => s + g.count, 0);
+                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
+                    return (
+                      <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
+                        <p className="font-headline font-bold text-on-surface">{d.label}</p>
+                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} drivers</p>
+                      </div>
+                    );
+                  }}
+                  cursor={{ fill: "rgba(87,95,107,0.06)" }}
+                />
+                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
+                  {atFaultGenderData.map((_, i) => (
+                    <Cell key={i} fill={[clrPrimary, clrTertiary, clrPrimaryContainer][i] ?? clrPrimaryContainer} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* At-Fault Drivers by Age */}
+        <div className="col-span-12 md:col-span-4 bg-surface-container-lowest rounded-lg p-5 md:p-8 ambient-shadow">
+          <h3 className="text-on-surface font-headline font-bold text-lg mb-4 leading-tight">
+            At-Fault Drivers by Age
+          </h3>
+          {dqDisclaimers.preDataOnly && (
+            <DataQualityNote text="At-fault driver data is only available from 2016 onward (CCRS)." />
+          )}
+          {!dqDisclaimers.preDataOnly && dqDisclaimers.hasPreCcrsYears && (
+            <DataQualityNote text="Pre-2016 years have no at-fault data — chart covers 2016+ only." />
+          )}
+          {loading ? (
+            <Skeleton className="h-48 w-full" />
+          ) : !atFaultAgeBracketData.length ? (
+            <EmptyState
+              icon="person_off"
+              description={dqDisclaimers.preDataOnly ? "At-fault data requires 2016 or later (CCRS)." : "No at-fault driver data for the current filters."}
+              className="h-48"
+            />
+          ) : (
+            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
+              <BarChart data={atFaultAgeBracketData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
+                <XAxis
+                  dataKey="label"
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
+                />
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const d = payload[0].payload as { label: string; count: number };
+                    const total = atFaultAgeBracketData.reduce((s, a) => s + a.count, 0);
+                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
+                    return (
+                      <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
+                        <p className="font-headline font-bold text-on-surface">{d.label}</p>
+                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} drivers</p>
                       </div>
                     );
                   }}


### PR DESCRIPTION
## What does this PR do?

  Resolves #125. Adds at-fault party (driver) demographic aggregates — the "who causes crashes" companion to the
  existing "who gets hurt" victim demographics. Mirrors the `mv_crash_victims_by_demographics` pattern end-to-end so the
   new charts sit naturally alongside the existing ones on the Stats page.

  **Backend** — new Alembic migration `f8a1b2c3d4e5_add_mv_at_fault_parties_by_demographics` creates a materialized view
   joining `crash_parties WHERE at_fault = TRUE` to `crashes` on `(collision_id, data_source)`, grouped by
  `(county_code, crash_year, severity, gender, age_bracket)`. Same `COALESCE/CASE` GROUP-BY trick as the victim MV to
  keep the UNIQUE index from blowing up on first refresh. New schemas `AtFaultGenderRow` / `AtFaultAgeBracketRow` count
  `party_count` / `fatal_party_count` (deliberately distinct field names from the victim view's `victim_count` so the
  two are never confused on the wire). `/api/stats` gains two new `group_by` values — `at_fault_gender` and
  `at_fault_age_bracket` — that dispatch to the new MV. Cause-filter incompatibility check extended to cover them (the
  demographic views don't carry `canonical_cause`). `etl/refresh_materialized_views.py` adds the new MV to its refresh
  list; the orchestrator's existing `matviews` job picks it up automatically.

  **Frontend** — `useStats` fires two new queries (cache-keyed independently from victim demographics so a severity
  filter only invalidates the relevant pair), maps the responses through the same `AGE_ORDER` sort + label dictionary as
   the victim charts, and exposes `atFaultGenderData` / `atFaultAgeBracketData` on `StatsData`. The Stats page renders
  two new cards immediately after "Victims by Gender" / "Victims by Age" so the audience can compare at-a-glance — same
  column span, same skeleton/empty/data-quality states, tooltips relabeled to say "drivers" instead of "victims". Same
  pre-2016 disclaimer as the victim charts since `crash_parties` is CCRS-only.

  **Notes** — fatality counts on the new MV are derived from `crashes.severity = 'Fatal'` (one fatal driver per fatal
  crash), not from per-person injury severity. Different semantic from victim `fatal_victim_count`, which counts
  individual fatal injuries — a fatal crash with 3 dead occupants contributes 1 fatal at-fault driver and 3 fatal
  victims.

  **Tests** — 7 new backend API tests covering the happy path, county filter narrowing, severity filter, cause-filter
  rejection, response-shape leakage (no `victim_count` field on at-fault rows), and the regex pattern still rejecting
  unknown `group_by` values. Conftest refreshes the new MV alongside the existing six. Frontend gets an updated count
  assertion (10 → 12 queries) and a new mapping test that exercises gender + age data through the hook.

  ## Dependencies

  None.

  ## How to test
  - [ ] `docker-compose up --build` (or backend + frontend separately)
  - [ ] `cd backend && alembic upgrade head` to create the new MV (or rely on the deploy workflow on prod)
  - [ ] `python -m etl.refresh_materialized_views` to populate it (first run does a non-concurrent REFRESH; subsequent
  runs go CONCURRENT)
  - [ ] `curl 'http://localhost:8000/api/stats?group_by=at_fault_gender' | jq` — returns rows with `gender`,
  `party_count`, `fatal_party_count`
  - [ ] `curl 'http://localhost:8000/api/stats?group_by=at_fault_age_bracket&severity=fatal&county=los-angeles' | jq` —
  narrows correctly
  - [ ] `curl 'http://localhost:8000/api/stats?group_by=at_fault_gender&cause=dui' -i` — returns 422 with `{"filter":
  "cause"}`
  - [ ] Open `/stats` and confirm two new cards — "At-Fault Drivers by Gender" and "At-Fault Drivers by Age" — appear
  after the Victims charts. Tooltips should say "drivers", not "victims"
  - [ ] Apply a date-range filter that includes only pre-2016 years (e.g. 2010–2015) → both at-fault cards show the
  "data only available from 2016 onward (CCRS)" empty state
  - [ ] `cd frontend && npm test` (150 pass) and `npx tsc --noEmit` (clean)
  - [ ] `cd backend && pytest tests/unit/ tests/test_models.py tests/test_settings.py` (95 pass); CI runs the full
  integration suite including `tests/api/test_stats.py` against Postgres

  ## Checklist
  - [x] Code builds without errors
  - [x] Tested locally
  - [x] No console errors/warnings
  - [x] No other PRs need to merge before this one (or listed above)