### PR TITLE
Fix/190 filter redesign

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Run database migrations
         run: docker compose -f docker-compose.prod.yml exec -T backend alembic upgrade head
 
+      - name: Backfill canonical condition columns (idempotent, skips existing)
+        run: docker compose -f docker-compose.prod.yml exec -T backend python -m etl.backfill_conditions
+        timeout-minutes: 240
+
       - name: Refresh materialized views
         run: docker compose -f docker-compose.prod.yml exec -T backend python -m etl.refresh_materialized_views
 

--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -237,6 +237,44 @@ def parse_bool_flag(raw: str | None, name: str) -> bool | None:
     )
 
 
+def parse_weather(raw: str | None) -> list[str] | None:
+    if raw is None or raw == "":
+        return None
+    valid = {"clear", "cloudy", "rain", "fog", "snow", "wind", "other"}
+    values = [v.strip() for v in raw.split(",")]
+    return [v for v in values if v in valid] or None
+
+
+def parse_lighting(raw: str | None) -> list[str] | None:
+    if raw is None or raw == "":
+        return None
+    valid = {"daylight", "dark_lit", "dark_unlit", "dusk_dawn", "other"}
+    values = [v.strip() for v in raw.split(",")]
+    return [v for v in values if v in valid] or None
+
+
+def parse_collision_type(raw: str | None) -> list[str] | None:
+    if raw is None or raw == "":
+        return None
+    valid = {"rear_end", "broadside", "sideswipe", "hit_object", "head_on", "other"}
+    values = [v.strip() for v in raw.split(",")]
+    return [v for v in values if v in valid] or None
+
+
+def parse_road_type(raw: str | None) -> bool | None:
+    if raw is None or raw == "":
+        return None
+    if raw == "highway":
+        return True
+    if raw == "local":
+        return False
+    return None
+
+
+def parse_hit_run(raw: str | None) -> bool | None:
+    return parse_bool_flag(raw, "hit_run")
+
+
 def parse_driver_age(raw: str | None) -> tuple[int, int] | None:
     """Parse ?driver_age=16-21 or ?driver_age=65+ into (min, max) tuple."""
     if raw is None or raw == "":
@@ -276,6 +314,11 @@ def build_crash_predicates(
     cyclist: bool | None = None,
     drug: bool | None = None,
     driver_age: tuple[int, int] | None = None,
+    weather: list[str] | None = None,
+    lighting: list[str] | None = None,
+    collision_type: list[str] | None = None,
+    road_type: bool | None = None,
+    hit_run: bool | None = None,
 ) -> list[ColumnElement]:
     """Build SQLAlchemy WHERE predicates for the crashes table.
 
@@ -309,4 +352,17 @@ def build_crash_predicates(
         preds.append(Crash.is_drug_involved.is_(drug))
     if driver_age is not None:
         preds.append(Crash.at_fault_driver_age.between(driver_age[0], driver_age[1]))
+    if weather:
+        preds.append(Crash.canonical_weather.in_(weather))
+    if lighting:
+        preds.append(Crash.canonical_lighting.in_(lighting))
+    if collision_type:
+        preds.append(Crash.canonical_collision_type.in_(collision_type))
+    if road_type is not None:
+        preds.append(Crash.is_highway.is_(road_type))
+    if hit_run is not None:
+        if hit_run:
+            preds.append(Crash.hit_run.isnot(None))
+        else:
+            preds.append(Crash.hit_run.is_(None))
     return preds

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -117,6 +117,14 @@ class Crash(Base):
     # 'unsafe_backing', 'lane_change', 'other', or NULL.
     canonical_cause = Column(String(25))
 
+    # Canonical condition fields — same pattern as canonical_cause.
+    # Collapse messy free-text weather/lighting/road_condition/collision_type
+    # into a fixed vocabulary for fast API filtering.
+    canonical_weather = Column(String(15))
+    canonical_lighting = Column(String(15))
+    canonical_road_condition = Column(String(20))
+    canonical_collision_type = Column(String(20))
+
     # Denormalized from counties.name so dashboard tooltip/export queries
     # don't need to JOIN to counties. County names are effectively immutable
     # in CA — a rerun of backfill_derived re-syncs if that ever changes.
@@ -146,6 +154,10 @@ class Crash(Base):
         Index("ix_crashes_pedestrian", "pedestrian_involved", postgresql_where="pedestrian_involved = true"),
         Index("ix_crashes_cyclist", "cyclist_involved", postgresql_where="cyclist_involved IS NOT NULL"),
         Index("ix_crashes_drug", "is_drug_involved", postgresql_where="is_drug_involved IS NOT NULL"),
+        Index("ix_crashes_canonical_weather", "canonical_weather"),
+        Index("ix_crashes_canonical_lighting", "canonical_lighting"),
+        Index("ix_crashes_canonical_road_condition", "canonical_road_condition"),
+        Index("ix_crashes_canonical_collision_type", "canonical_collision_type"),
     )
 
 

--- a/backend/app/routers/crashes.py
+++ b/backend/app/routers/crashes.py
@@ -14,10 +14,15 @@ from app.filters import (
     build_crash_predicates,
     parse_bool_flag,
     parse_cause,
+    parse_collision_type,
     parse_county_codes,
     parse_date_range,
     parse_driver_age,
+    parse_hit_run,
+    parse_lighting,
+    parse_road_type,
     parse_severity,
+    parse_weather,
     parse_year,
 )
 from app.models import Crash
@@ -54,6 +59,11 @@ def list_crashes(
     cyclist: str | None = Query(None),
     drug: str | None = Query(None),
     driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
     include_total: bool = Query(False),
@@ -89,12 +99,19 @@ def list_crashes(
     cyclist_v = parse_bool_flag(cyclist, "cyclist")
     drug_v = parse_bool_flag(drug, "drug")
     driver_age_v = parse_driver_age(driver_age)
+    weather_v = parse_weather(weather)
+    lighting_v = parse_lighting(lighting)
+    collision_type_v = parse_collision_type(collision_type)
+    road_type_v = parse_road_type(road_type)
+    hit_run_v = parse_hit_run(hit_run)
 
     if include_total and not any([
         date_range is not None, years, county_codes, severities, causes,
         alcohol_v is not None, distracted_v is not None,
         pedestrian_v is not None, cyclist_v is not None,
         drug_v is not None, driver_age_v is not None,
+        weather_v, lighting_v, collision_type_v,
+        road_type_v is not None, hit_run_v is not None,
     ]):
         raise FilterError(
             "include_total",
@@ -116,6 +133,11 @@ def list_crashes(
         cyclist=cyclist_v,
         drug=drug_v,
         driver_age=driver_age_v,
+        weather=weather_v,
+        lighting=lighting_v,
+        collision_type=collision_type_v,
+        road_type=road_type_v,
+        hit_run=hit_run_v,
     )
 
     q = db.query(Crash).filter(*preds).order_by(

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -14,10 +14,15 @@ from app.filters import (
     build_crash_predicates,
     parse_bool_flag,
     parse_cause,
+    parse_collision_type,
     parse_county_codes,
     parse_date_range,
     parse_driver_age,
+    parse_hit_run,
+    parse_lighting,
+    parse_road_type,
     parse_severity,
+    parse_weather,
     parse_year,
 )
 from app.models import Crash
@@ -64,6 +69,11 @@ def crash_heatmap(
     cyclist: str | None = Query(None),
     drug: str | None = Query(None),
     driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
     resolution: Resolution | None = Query(None),
     mismatch_only: str | None = Query(None),
     include_rivers: str | None = Query(None),
@@ -92,6 +102,11 @@ def crash_heatmap(
     cyclist_v = parse_bool_flag(cyclist, "cyclist")
     drug_v = parse_bool_flag(drug, "drug")
     driver_age_v = parse_driver_age(driver_age)
+    weather_v = parse_weather(weather)
+    lighting_v = parse_lighting(lighting)
+    collision_type_v = parse_collision_type(collision_type)
+    road_type_v = parse_road_type(road_type)
+    hit_run_v = parse_hit_run(hit_run)
 
     if resolution is None:
         resolution = Resolution.raw if county_codes else Resolution.low
@@ -114,6 +129,11 @@ def crash_heatmap(
         cyclist=cyclist_v,
         drug=drug_v,
         driver_age=driver_age_v,
+        weather=weather_v,
+        lighting=lighting_v,
+        collision_type=collision_type_v,
+        road_type=road_type_v,
+        hit_run=hit_run_v,
     )
     preds.append(Crash.latitude.isnot(None))
     preds.append(Crash.longitude.isnot(None))

--- a/backend/etl/backfill_conditions.py
+++ b/backend/etl/backfill_conditions.py
@@ -76,6 +76,7 @@ _WEATHER_RULES = [
 # then dark_unlit, then daylight.
 _LIGHTING_RULES = [
     (re.compile(r"dusk|dawn", re.IGNORECASE), "dusk_dawn"),
+    (re.compile(r"dark.*no\s*street|dark.*not\s*func", re.IGNORECASE), "dark_unlit"),
     (re.compile(r"dark.*street|street.*light", re.IGNORECASE), "dark_lit"),
     (re.compile(r"dark", re.IGNORECASE), "dark_unlit"),
     (re.compile(r"day|daylight", re.IGNORECASE), "daylight"),

--- a/backend/etl/backfill_conditions.py
+++ b/backend/etl/backfill_conditions.py
@@ -1,0 +1,211 @@
+"""Backfill canonical condition columns on the crashes table.
+
+Canonicalizes four messy free-text fields into fixed vocabularies:
+
+  - weather        -> canonical_weather     (clear, cloudy, rain, fog, snow, wind, other)
+  - lighting       -> canonical_lighting    (daylight, dusk_dawn, dark_lit, dark_unlit, other)
+  - road_condition -> canonical_road_condition (dry, wet, snow_ice, construction, other)
+  - collision_type -> canonical_collision_type (rear_end, broadside, sideswipe, hit_object, head_on, other)
+
+Uses the same two-step temp-table approach as canonical_cause in
+backfill_derived.py:
+
+  1. SELECT DISTINCT from the raw column (~hundreds of values, not 11M).
+  2. Categorize in Python with regex (fast — runs on the distinct set).
+  3. Load into a temp table.
+  4. UPDATE crashes year-by-year via JOIN to the temp table.
+
+Idempotent — only updates rows where the canonical value IS NULL or
+differs from the computed value.
+
+Usage:
+    python -m etl.backfill_conditions
+"""
+
+import logging
+import re
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+from etl._utils import track_etl_run
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Year range helper (same pattern as backfill_derived._all_crash_year_range)
+# ---------------------------------------------------------------------------
+
+def _all_crash_year_range(db) -> range:
+    """Year range covering every crash in the DB."""
+    row = db.execute(text("""
+        SELECT
+            MIN(EXTRACT(YEAR FROM crash_datetime)::int),
+            MAX(EXTRACT(YEAR FROM crash_datetime)::int)
+        FROM crashes
+    """)).one_or_none()
+
+    if row is None or row[0] is None:
+        return range(0)
+
+    return range(int(row[0]), int(row[1]) + 1)
+
+
+# ---------------------------------------------------------------------------
+# Regex rules for each field
+# ---------------------------------------------------------------------------
+
+# Weather: raw -> canonical
+_WEATHER_RULES = [
+    (re.compile(r"clear|sunny|fine", re.IGNORECASE), "clear"),
+    (re.compile(r"cloud|overcast", re.IGNORECASE), "cloudy"),
+    (re.compile(r"rain|wet|precip|drizzl", re.IGNORECASE), "rain"),
+    (re.compile(r"fog|visibility|haze|smoke|smok", re.IGNORECASE), "fog"),
+    (re.compile(r"snow|sleet|ice|freez|hail", re.IGNORECASE), "snow"),
+    (re.compile(r"wind|gust", re.IGNORECASE), "wind"),
+]
+
+# Lighting: raw -> canonical
+# Order matters: dusk_dawn first, then dark_lit (must check before dark_unlit),
+# then dark_unlit, then daylight.
+_LIGHTING_RULES = [
+    (re.compile(r"dusk|dawn", re.IGNORECASE), "dusk_dawn"),
+    (re.compile(r"dark.*street|street.*light", re.IGNORECASE), "dark_lit"),
+    (re.compile(r"dark", re.IGNORECASE), "dark_unlit"),
+    (re.compile(r"day|daylight", re.IGNORECASE), "daylight"),
+]
+
+# Road condition: raw -> canonical
+_ROAD_CONDITION_RULES = [
+    (re.compile(r"^dry$|no.*unusual|normal", re.IGNORECASE), "dry"),
+    (re.compile(r"wet|rain|water|puddle|flood", re.IGNORECASE), "wet"),
+    (re.compile(r"snow|ice|slippery|slick", re.IGNORECASE), "snow_ice"),
+    (re.compile(r"construct|repair|work zone", re.IGNORECASE), "construction"),
+]
+
+# Collision type: raw -> canonical
+_COLLISION_TYPE_RULES = [
+    (re.compile(r"rear", re.IGNORECASE), "rear_end"),
+    (re.compile(r"broadside|t.?bone", re.IGNORECASE), "broadside"),
+    (re.compile(r"sideswipe|side.*swipe", re.IGNORECASE), "sideswipe"),
+    (re.compile(r"hit.*object|fixed.*object|overturn", re.IGNORECASE), "hit_object"),
+    (re.compile(r"head.*on", re.IGNORECASE), "head_on"),
+]
+
+
+def _categorize(value: str, rules: list[tuple[re.Pattern, str]]) -> str:
+    """Return the first matching canonical value, or 'other'."""
+    for pattern, label in rules:
+        if pattern.search(value):
+            return label
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Generic backfill for one column
+# ---------------------------------------------------------------------------
+
+def _backfill_canonical_column(
+    db,
+    raw_col: str,
+    canonical_col: str,
+    rules: list[tuple[re.Pattern, str]],
+) -> int:
+    """Backfill a single canonical column using the temp-table approach.
+
+    Returns the total number of rows updated.
+    """
+    logger.info("Building %s -> %s mapping...", raw_col, canonical_col)
+
+    # Step 1: get distinct raw values
+    rows = db.execute(text(f"""
+        SELECT DISTINCT {raw_col}
+        FROM crashes
+        WHERE {raw_col} IS NOT NULL
+    """)).scalars().all()  # noqa: S608
+
+    logger.info("Found %d distinct %s values", len(rows), raw_col)
+
+    if not rows:
+        logger.info("No %s values to categorize — skipping", raw_col)
+        return 0
+
+    # Step 2: categorize in Python
+    mapping = {val: _categorize(val, rules) for val in rows}
+
+    # Step 3: load into temp table
+    tmp_table = f"_canon_{canonical_col}_tmp"
+    db.execute(text(f"DROP TABLE IF EXISTS {tmp_table}"))
+    db.execute(text(f"""
+        CREATE TEMP TABLE {tmp_table} (
+            raw_value TEXT PRIMARY KEY,
+            canonical_value TEXT NOT NULL
+        )
+    """))
+    db.execute(
+        text(f"INSERT INTO {tmp_table} VALUES (:raw, :canon)"),
+        [{"raw": raw, "canon": canon} for raw, canon in mapping.items()],
+    )
+    db.commit()
+    logger.info("Loaded %d mappings into temp table %s", len(mapping), tmp_table)
+
+    # Step 4: UPDATE year-by-year
+    total = 0
+    for year in _all_crash_year_range(db):
+        r = db.execute(text(f"""
+            UPDATE crashes c
+            SET {canonical_col} = m.canonical_value
+            FROM {tmp_table} m
+            WHERE c.{raw_col} = m.raw_value
+              AND (c.{canonical_col} IS NULL OR c.{canonical_col} <> m.canonical_value)
+              AND c.crash_datetime >= :start
+              AND c.crash_datetime < :end
+        """), {"start": f"{year}-01-01", "end": f"{year + 1}-01-01"})
+        db.commit()
+        if r.rowcount > 0:
+            logger.info("%s %d: %d rows", canonical_col, year, r.rowcount)
+            total += r.rowcount
+
+    logger.info("%s backfill done: %d rows categorized", canonical_col, total)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+@track_etl_run("backfill_conditions")
+def run() -> int:
+    """Backfill all four canonical condition columns."""
+    db = SessionLocal()
+    try:
+        logger.info("=== Backfilling canonical condition columns ===")
+        total = 0
+
+        total += _backfill_canonical_column(
+            db, "weather", "canonical_weather", _WEATHER_RULES,
+        )
+        total += _backfill_canonical_column(
+            db, "lighting", "canonical_lighting", _LIGHTING_RULES,
+        )
+        total += _backfill_canonical_column(
+            db, "road_condition", "canonical_road_condition", _ROAD_CONDITION_RULES,
+        )
+        total += _backfill_canonical_column(
+            db, "collision_type", "canonical_collision_type", _COLLISION_TYPE_RULES,
+        )
+
+        logger.info("=== Done — %d total rows updated ===", total)
+        return total
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -155,9 +155,15 @@ def build_default_registry() -> JobRegistry:
         schedule="daily",
     ))
     registry.register(Job(
+        name="backfill_conditions",
+        module="etl.backfill_conditions",
+        depends_on=["backfill"],
+        schedule="daily",
+    ))
+    registry.register(Job(
         name="data_quality",
         module="etl.compute_data_quality",
-        depends_on=["backfill"],
+        depends_on=["backfill", "backfill_conditions"],
         schedule="daily",
     ))
     registry.register(Job(

--- a/backend/migrations/versions/h6i7j8k9l0m1_add_canonical_condition_columns.py
+++ b/backend/migrations/versions/h6i7j8k9l0m1_add_canonical_condition_columns.py
@@ -1,0 +1,34 @@
+"""Add canonical columns for weather, lighting, road_condition, collision_type
+
+Revision ID: h6i7j8k9l0m1
+Revises: g5h6i7j8k9l0
+Create Date: 2026-05-10 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "h6i7j8k9l0m1"
+down_revision: Union[str, None] = "g5h6i7j8k9l0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+def upgrade() -> None:
+    op.add_column("crashes", sa.Column("canonical_weather", sa.String(15), nullable=True))
+    op.add_column("crashes", sa.Column("canonical_lighting", sa.String(15), nullable=True))
+    op.add_column("crashes", sa.Column("canonical_road_condition", sa.String(20), nullable=True))
+    op.add_column("crashes", sa.Column("canonical_collision_type", sa.String(20), nullable=True))
+    op.create_index("ix_crashes_canonical_weather", "crashes", ["canonical_weather"])
+    op.create_index("ix_crashes_canonical_lighting", "crashes", ["canonical_lighting"])
+    op.create_index("ix_crashes_canonical_road_condition", "crashes", ["canonical_road_condition"])
+    op.create_index("ix_crashes_canonical_collision_type", "crashes", ["canonical_collision_type"])
+
+def downgrade() -> None:
+    op.drop_index("ix_crashes_canonical_collision_type")
+    op.drop_index("ix_crashes_canonical_road_condition")
+    op.drop_index("ix_crashes_canonical_lighting")
+    op.drop_index("ix_crashes_canonical_weather")
+    op.drop_column("crashes", "canonical_collision_type")
+    op.drop_column("crashes", "canonical_road_condition")
+    op.drop_column("crashes", "canonical_lighting")
+    op.drop_column("crashes", "canonical_weather")

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -74,7 +74,7 @@ def test_resolve_detects_missing_dependency():
 
 def test_default_registry_has_all_jobs():
     registry = build_default_registry()
-    assert len(registry.jobs) == 21
+    assert len(registry.jobs) == 22
 
 
 def test_default_registry_resolves_without_error():

--- a/frontend/src/components/map/ActiveFiltersBanner.tsx
+++ b/frontend/src/components/map/ActiveFiltersBanner.tsx
@@ -63,7 +63,7 @@ export default function ActiveFiltersBanner({
   if (chips.length === 0) return null;
 
   return (
-    <div className={`absolute top-14 md:top-2 left-2 right-14 md:left-16 md:right-auto md:max-w-[500px] z-20 transition-opacity duration-200 ${searchOpen ? "opacity-0 pointer-events-none" : ""}`}>
+    <div className={`hidden md:block absolute top-20 left-16 right-auto max-w-[500px] z-20 transition-opacity duration-200 ${searchOpen ? "opacity-0 pointer-events-none" : ""}`}>
       <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-xl px-3 py-2 ambient-shadow">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="material-symbols-outlined text-[14px] text-primary shrink-0">filter_list</span>

--- a/frontend/src/components/map/ActiveFiltersBanner.tsx
+++ b/frontend/src/components/map/ActiveFiltersBanner.tsx
@@ -1,0 +1,97 @@
+import type { DateRangeFilter } from "../../hooks/useFilterParams";
+import { formatYearMonth } from "../../hooks/useFilterParams";
+
+interface ActiveFiltersBannerProps {
+  dateRange: DateRangeFilter | null;
+  severities: Set<string>;
+  causes: Set<string>;
+  alcohol: boolean;
+  distracted: boolean;
+  pedestrian: boolean;
+  cyclist: boolean;
+  drug: boolean;
+  driverAge: string | null;
+  totalCrashes: number;
+  isLoading: boolean;
+  onClear: () => void;
+  searchOpen?: boolean;
+}
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString();
+}
+
+export default function ActiveFiltersBanner({
+  dateRange,
+  severities,
+  causes,
+  alcohol,
+  distracted,
+  pedestrian,
+  cyclist,
+  drug,
+  driverAge,
+  totalCrashes,
+  isLoading,
+  onClear,
+  searchOpen,
+}: ActiveFiltersBannerProps) {
+  const chips: string[] = [];
+
+  if (dateRange) {
+    const s = dateRange.start ? formatYearMonth(dateRange.start) : "earliest";
+    const e = dateRange.end ? formatYearMonth(dateRange.end) : "latest";
+    chips.push(`${s} – ${e}`);
+  }
+  if (severities.size > 0 && severities.size < 3) {
+    chips.push(...severities);
+  }
+  if (causes.size > 0 && causes.size < 10) {
+    chips.push(`${causes.size} cause${causes.size > 1 ? "s" : ""}`);
+  }
+  if (alcohol) chips.push("Alcohol");
+  if (distracted) chips.push("Distracted");
+  if (pedestrian) chips.push("Ped. Involved");
+  if (cyclist) chips.push("Cyclist");
+  if (drug) chips.push("Drug");
+  if (driverAge) chips.push(`Age ${driverAge}`);
+
+  const hasInvolvement = alcohol || distracted || pedestrian || cyclist || drug || !!driverAge;
+
+  if (chips.length === 0) return null;
+
+  return (
+    <div className={`absolute top-14 md:top-2 left-2 right-14 md:left-16 md:right-auto md:max-w-[500px] z-20 transition-opacity duration-200 ${searchOpen ? "opacity-0 pointer-events-none" : ""}`}>
+      <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-xl px-3 py-2 ambient-shadow">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="material-symbols-outlined text-[14px] text-primary shrink-0">filter_list</span>
+          <span className={`text-[11px] font-bold text-on-surface ${isLoading ? "animate-pulse" : ""}`}>
+            {isLoading ? "Updating..." : `${fmt(totalCrashes)} crashes`}
+          </span>
+          <span className="text-[10px] text-on-surface-variant">|</span>
+          {chips.map((chip) => (
+            <span
+              key={chip}
+              className="text-[10px] font-semibold bg-primary-container text-on-primary-container px-2 py-0.5 rounded-full"
+            >
+              {chip}
+            </span>
+          ))}
+          {hasInvolvement && (
+            <span className="text-[10px] font-semibold bg-tertiary-container text-on-tertiary-container px-2 py-0.5 rounded-full">
+              2016+ only
+            </span>
+          )}
+          <button
+            onClick={onClear}
+            className="text-[10px] font-bold text-on-surface-variant hover:text-on-surface transition-colors ml-auto"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -131,7 +131,8 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           >
             {allMeasures.map((m) => {
               const isSelected = m.key === measure;
-              const isDisabled = m.kind === "perCapita" && !demographicsAvailable;
+              const needsDemo = m.kind === "perCapita" || m.kind === "perIncome" || m.kind === "demographic" || m.kind === "crashDemographic";
+              const isDisabled = needsDemo && !demographicsAvailable;
               return (
                 <button
                   key={m.key}

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -127,7 +127,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           <div
             role="listbox"
             aria-labelledby="choropleth-measure-label"
-            className="absolute z-50 left-0 right-0 top-full mt-1 bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15 overflow-hidden"
+            className="absolute z-50 left-0 right-0 top-full mt-1 bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15 overflow-y-auto max-h-[50vh]"
           >
             {allMeasures.map((m) => {
               const isSelected = m.key === measure;

--- a/frontend/src/components/map/FilteredUrlPrompt.tsx
+++ b/frontend/src/components/map/FilteredUrlPrompt.tsx
@@ -1,0 +1,40 @@
+interface FilteredUrlPromptProps {
+  filters: string[];
+  onViewFiltered: () => void;
+  onShowAll: () => void;
+}
+
+export default function FilteredUrlPrompt({ filters, onViewFiltered, onShowAll }: FilteredUrlPromptProps) {
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-on-surface/30 backdrop-blur-sm" />
+      <div className="relative bg-surface-container-lowest rounded-xl ambient-shadow px-6 py-5 max-w-sm w-full space-y-4">
+        <h2 className="text-lg font-bold text-on-surface font-headline">Filtered View</h2>
+        <p className="text-sm text-on-surface-variant">
+          This link has filters applied:
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {filters.map((f) => (
+            <span key={f} className="text-[11px] font-semibold bg-primary-container text-on-primary-container px-2.5 py-1 rounded-full">
+              {f}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-3 pt-2">
+          <button
+            onClick={onShowAll}
+            className="flex-1 py-3 rounded-xl text-sm font-semibold text-on-surface-variant bg-surface-container-high hover:bg-surface-variant transition-colors"
+          >
+            Show All Data
+          </button>
+          <button
+            onClick={onViewFiltered}
+            className="flex-1 py-3 rounded-xl text-sm font-bold bg-primary text-on-primary hover:opacity-90 transition-opacity"
+          >
+            View Filtered
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/FiltersPanel.tsx
+++ b/frontend/src/components/map/FiltersPanel.tsx
@@ -76,13 +76,11 @@ export default function FiltersPanel({
   onSetDateRange,
   onClearDateRange,
   onToggleSeverity,
-  onSetSeverities,
   onSetAllSeverities,
   onClearSeverities,
   onToggleCounty,
   onClearCounties,
   onToggleCause,
-  onSetCauses,
   onSetAllCauses,
   onClearCauses,
   onToggleAlcohol,
@@ -93,36 +91,8 @@ export default function FiltersPanel({
   onSetDriverAge,
   resetKey = 0,
 }: FiltersPanelProps) {
-  // Stash previous selections so "All" toggle can restore them
-  const [prevCauses, setPrevCauses] = useState<Set<string> | null>(null);
-  const [prevSeverities, setPrevSeverities] = useState<Set<string> | null>(null);
-
-  const allCausesSelected = selectedCauses.size === CAUSES.length;
-  const allSeveritiesSelected = selectedSeverities.size === SEVERITIES.length;
-
-  function makeAllToggle<T>(
-    allSelected: boolean,
-    current: Set<T>,
-    prev: Set<T> | null,
-    setPrev: (s: Set<T> | null) => void,
-    setAll: (() => void) | undefined,
-    clear: (() => void) | undefined,
-    restore: ((s: Set<T>) => void) | undefined,
-  ) {
-    return () => {
-      if (allSelected) {
-        if (prev && prev.size > 0 && restore) {
-          restore(prev);
-        } else if (clear) {
-          clear();
-        }
-        setPrev(null);
-      } else {
-        setPrev(new Set(current));
-        setAll?.();
-      }
-    };
-  }
+  const allCausesSelected = selectedCauses.size === 0 || selectedCauses.size === CAUSES.length;
+  const allSeveritiesSelected = selectedSeverities.size === 0 || selectedSeverities.size === SEVERITIES.length;
 
   // Date range — derive partial values so changing year/month either side
   // independently still produces a valid range.
@@ -207,22 +177,39 @@ export default function FiltersPanel({
       {/* Cause Type */}
       <div className="space-y-3">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          Cause Type
+          Cause <span className="normal-case font-medium">(why it happened)</span>
         </label>
+        <p className="text-[10px] text-on-surface-variant leading-snug -mt-1">
+          The primary factor that caused the crash. Available for all years.
+        </p>
         <div className="flex flex-wrap gap-2">
           {onSetAllCauses && onClearCauses && (
             <button
-              onClick={makeAllToggle(allCausesSelected, selectedCauses, prevCauses, setPrevCauses, onSetAllCauses, onClearCauses, onSetCauses)}
+              onClick={() => {
+                if (allCausesSelected) return;
+                onClearCauses();
+              }}
               className={allCausesSelected ? PILL_ACTIVE : PILL_INACTIVE}
             >
               All
             </button>
           )}
-          {!allCausesSelected && CAUSES.map((cause) => (
+          {CAUSES.map((cause) => (
             <button
               key={cause.value}
-              onClick={() => onToggleCause(cause.value)}
-              className={`flex items-center gap-1.5 ${selectedCauses.has(cause.value) ? PILL_ACTIVE : PILL_INACTIVE}`}
+              onClick={() => {
+                if (allCausesSelected && selectedCauses.size === 0) {
+                  onSetAllCauses?.();
+                  setTimeout(() => onToggleCause(cause.value), 0);
+                } else {
+                  onToggleCause(cause.value);
+                }
+              }}
+              className={`flex items-center gap-1.5 ${
+                allCausesSelected
+                  ? PILL_INACTIVE
+                  : selectedCauses.has(cause.value) ? PILL_ACTIVE : PILL_INACTIVE
+              }`}
             >
               <span className="material-symbols-outlined text-[14px]">
                 {cause.icon}
@@ -238,27 +225,36 @@ export default function FiltersPanel({
         <label className="text-[10px] font-bold uppercase tracking-widest">
           Severity
         </label>
+        <p className="text-[10px] text-on-surface-variant leading-snug -mt-1">
+          How severe was the crash outcome.
+        </p>
         <div className="flex flex-wrap gap-2">
           {onSetAllSeverities && onClearSeverities && (
             <button
-              onClick={makeAllToggle(allSeveritiesSelected, selectedSeverities, prevSeverities, setPrevSeverities, onSetAllSeverities, onClearSeverities, onSetSeverities)}
-              className={
-                allSeveritiesSelected
-                  ? PILL_ACTIVE
-                  : PILL_INACTIVE
-              }
+              onClick={() => {
+                if (allSeveritiesSelected) return;
+                onClearSeverities();
+              }}
+              className={allSeveritiesSelected ? PILL_ACTIVE : PILL_INACTIVE}
             >
               All
             </button>
           )}
-          {!allSeveritiesSelected && SEVERITIES.map((severity) => (
+          {SEVERITIES.map((severity) => (
             <button
               key={severity}
-              onClick={() => onToggleSeverity(severity)}
+              onClick={() => {
+                if (allSeveritiesSelected && selectedSeverities.size === 0) {
+                  onSetAllSeverities?.();
+                  setTimeout(() => onToggleSeverity(severity), 0);
+                } else {
+                  onToggleSeverity(severity);
+                }
+              }}
               className={
-                selectedSeverities.has(severity)
-                  ? PILL_ACTIVE
-                  : PILL_INACTIVE
+                allSeveritiesSelected
+                  ? PILL_INACTIVE
+                  : selectedSeverities.has(severity) ? PILL_ACTIVE : PILL_INACTIVE
               }
             >
               {severity}
@@ -270,8 +266,11 @@ export default function FiltersPanel({
       {/* Involvement Type */}
       <div className="space-y-3">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          Involvement
+          Involvement <span className="normal-case font-medium">(who was involved, 2016+)</span>
         </label>
+        <p className="text-[10px] text-on-surface-variant leading-snug -mt-1">
+          Whether a specific party type was present, regardless of fault. Only available for 2016+ crashes.
+        </p>
         <div className="flex flex-wrap gap-2">
           {INVOLVEMENTS.map((inv) => {
             const isActive =
@@ -306,8 +305,11 @@ export default function FiltersPanel({
       {/* Driver Age */}
       <div className="space-y-3">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
-          At-Fault Driver Age
+          At-Fault Driver Age <span className="normal-case font-medium">(2016+)</span>
         </label>
+        <p className="text-[10px] text-on-surface-variant leading-snug -mt-1">
+          Age of the driver determined to be at fault. Select one bracket at a time.
+        </p>
         <div className="flex flex-wrap gap-2">
           {DRIVER_AGE_BRACKETS.map((bracket) => (
             <button

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -15,6 +15,7 @@ vi.mock("./CaliforniaMask", () => ({
   default: () => null,
 }));
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Map as LeafletMap } from "leaflet";
 import MapCanvas from "./MapCanvas";
 import { mockMapInstance } from "../../__mocks__/leaflet";
@@ -29,10 +30,15 @@ const defaultHeatmapProps = {
 };
 
 function renderWithTheme(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <ThemeProvider>
-      <LayersStateProvider>{ui}</LayersStateProvider>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <LayersStateProvider>{ui}</LayersStateProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -6,8 +6,10 @@ import CountyBoundaries from "./CountyBoundaries";
 import CrashHeatmap from "./CrashHeatmap";
 import CoordMismatchLayer from "./CoordMismatchLayer";
 import CaliforniaMask from "./CaliforniaMask";
+import OverlayMarkers from "./OverlayMarkers";
 import type { HeatmapPoint } from "../../hooks/useCrashHeatmap";
 import { useLayersState, type HeatmapResolution } from "../../hooks/useLayersState";
+import { useHospitals, useSchools } from "../../hooks/useMapOverlays";
 import type { PaletteKey } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 
@@ -57,6 +59,8 @@ function MapInternals({
   const map = useMap();
   const { otherLayers } = useLayersState();
   const showMask = heatmapActive && !otherLayers.coordMismatches && !countyDrilldown;
+  const { data: hospitals = [] } = useHospitals(otherLayers.hospitals);
+  const { data: schools = [] } = useSchools(otherLayers.schools);
 
   useEffect(() => {
     onMapReady(map);
@@ -103,6 +107,12 @@ function MapInternals({
         />
       )}
       {mismatchPoints.length > 0 && <CoordMismatchLayer points={mismatchPoints} palette={heatmapPalette} />}
+      <OverlayMarkers
+        hospitals={hospitals}
+        schools={schools}
+        showHospitals={otherLayers.hospitals}
+        showSchools={otherLayers.schools}
+      />
     </>
   );
 }

--- a/frontend/src/components/map/MobileFilterSheet.tsx
+++ b/frontend/src/components/map/MobileFilterSheet.tsx
@@ -7,6 +7,7 @@ interface Tab {
   label: string;
   icon: string;
   content: React.ReactNode;
+  hideFooter?: boolean;
 }
 
 interface MobileFilterSheetProps {
@@ -102,21 +103,23 @@ export default function MobileFilterSheet({
           {currentTab.content}
         </div>
 
-        {/* Sticky footer */}
-        <div className="px-6 py-5 border-t border-outline-variant/15 flex items-center gap-4" style={{ paddingBottom: 'calc(1.25rem + env(safe-area-inset-bottom, 0px))' }}>
-          <button
-            onClick={onClear}
-            className="text-sm font-semibold text-on-surface-variant hover:text-on-surface transition-colors"
-          >
-            Reset
-          </button>
-          <button
-            onClick={onClose}
-            className="flex-1 bg-primary text-on-primary py-4 rounded-xl text-sm font-bold tracking-widest uppercase hover:opacity-90 transition-opacity"
-          >
-            Done
-          </button>
-        </div>
+        {/* Sticky footer — hidden when tab has its own nav (e.g. FilterWizard) */}
+        {!currentTab.hideFooter && (
+          <div className="px-6 py-5 border-t border-outline-variant/15 flex items-center gap-4" style={{ paddingBottom: 'calc(1.25rem + env(safe-area-inset-bottom, 0px))' }}>
+            <button
+              onClick={onClear}
+              className="text-sm font-semibold text-on-surface-variant hover:text-on-surface transition-colors"
+            >
+              Reset
+            </button>
+            <button
+              onClick={onClose}
+              className="flex-1 bg-primary text-on-primary py-4 rounded-xl text-sm font-bold tracking-widest uppercase hover:opacity-90 transition-opacity"
+            >
+              Done
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/map/OverlayMarkers.tsx
+++ b/frontend/src/components/map/OverlayMarkers.tsx
@@ -1,0 +1,47 @@
+import { CircleMarker, Popup } from "react-leaflet";
+import type { Hospital, School } from "../../hooks/useMapOverlays";
+
+interface OverlayMarkersProps {
+  hospitals: Hospital[];
+  schools: School[];
+  showHospitals: boolean;
+  showSchools: boolean;
+}
+
+export default function OverlayMarkers({ hospitals, schools, showHospitals, showSchools }: OverlayMarkersProps) {
+  return (
+    <>
+      {showHospitals && hospitals.filter(h => h.latitude && h.longitude).map((h) => (
+        <CircleMarker
+          key={h.facility_id}
+          center={[h.latitude!, h.longitude!]}
+          radius={4}
+          pathOptions={{ color: "#ef4444", fillColor: "#ef4444", fillOpacity: 0.8, weight: 1 }}
+        >
+          <Popup>
+            <div className="text-xs">
+              <p className="font-bold">{h.facility_name}</p>
+              <p>{h.city}</p>
+              {h.trauma_center && <p className="text-error font-semibold">{h.trauma_center}</p>}
+            </div>
+          </Popup>
+        </CircleMarker>
+      ))}
+      {showSchools && schools.filter(s => s.latitude && s.longitude).map((s) => (
+        <CircleMarker
+          key={s.cds_code}
+          center={[s.latitude!, s.longitude!]}
+          radius={3}
+          pathOptions={{ color: "#3b82f6", fillColor: "#3b82f6", fillOpacity: 0.6, weight: 1 }}
+        >
+          <Popup>
+            <div className="text-xs">
+              <p className="font-bold">{s.school_name}</p>
+              <p>{s.city} — {s.school_type}</p>
+            </div>
+          </Popup>
+        </CircleMarker>
+      ))}
+    </>
+  );
+}

--- a/frontend/src/components/map/filters/FilterChip.tsx
+++ b/frontend/src/components/map/filters/FilterChip.tsx
@@ -1,0 +1,27 @@
+interface FilterChipProps {
+  label: string;
+  icon?: string;
+  active: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+const ACTIVE = "px-3 py-1.5 rounded-full text-xs font-semibold bg-primary text-on-primary transition-all";
+const INACTIVE = "px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-all";
+const DISABLED = "px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant/40 cursor-not-allowed";
+
+export default function FilterChip({ label, icon, active, disabled, onClick }: FilterChipProps) {
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      className={`flex items-center gap-1.5 ${disabled ? DISABLED : active ? ACTIVE : INACTIVE}`}
+      aria-pressed={active}
+      disabled={disabled}
+    >
+      {icon && (
+        <span className="material-symbols-outlined text-[14px]">{icon}</span>
+      )}
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/map/filters/FilterChip.tsx
+++ b/frontend/src/components/map/filters/FilterChip.tsx
@@ -1,6 +1,7 @@
 interface FilterChipProps {
   label: string;
   icon?: string;
+  count?: string;
   active: boolean;
   disabled?: boolean;
   onClick: () => void;
@@ -10,7 +11,7 @@ const ACTIVE = "px-3 py-1.5 rounded-full text-xs font-semibold bg-primary text-o
 const INACTIVE = "px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-all";
 const DISABLED = "px-3 py-1.5 rounded-full text-xs font-semibold bg-surface-container-high text-on-surface-variant/40 cursor-not-allowed";
 
-export default function FilterChip({ label, icon, active, disabled, onClick }: FilterChipProps) {
+export default function FilterChip({ label, icon, count, active, disabled, onClick }: FilterChipProps) {
   return (
     <button
       onClick={disabled ? undefined : onClick}
@@ -22,6 +23,11 @@ export default function FilterChip({ label, icon, active, disabled, onClick }: F
         <span className="material-symbols-outlined text-[14px]">{icon}</span>
       )}
       {label}
+      {count && (
+        <span className={`text-[9px] ${active ? "text-on-primary/70" : "text-on-surface-variant/50"}`}>
+          ({count})
+        </span>
+      )}
     </button>
   );
 }

--- a/frontend/src/components/map/filters/FilterPanelRouter.tsx
+++ b/frontend/src/components/map/filters/FilterPanelRouter.tsx
@@ -1,0 +1,45 @@
+import { useState, useCallback } from "react";
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import SimpleFilterPanel from "./SimpleFilterPanel";
+import FilterWizard from "./FilterWizard";
+
+interface FilterPanelRouterProps {
+  initial: StagedFilters;
+  selectedCounties: Set<string>;
+  onToggleCounty: (county: string) => void;
+  onClearCounties: () => void;
+  onApply: (filters: StagedFilters) => void;
+  onClear: () => void;
+}
+
+export default function FilterPanelRouter(props: FilterPanelRouterProps) {
+  const [mode, setMode] = useState<"simple" | "advanced">(() => {
+    return (localStorage.getItem("calsight-filter-mode") as "simple" | "advanced") || "simple";
+  });
+
+  const switchToAdvanced = useCallback(() => {
+    setMode("advanced");
+    localStorage.setItem("calsight-filter-mode", "advanced");
+  }, []);
+
+  const switchToSimple = useCallback(() => {
+    setMode("simple");
+    localStorage.setItem("calsight-filter-mode", "simple");
+  }, []);
+
+  if (mode === "simple") {
+    return (
+      <SimpleFilterPanel
+        {...props}
+        onSwitchToAdvanced={switchToAdvanced}
+      />
+    );
+  }
+
+  return (
+    <FilterWizard
+      {...props}
+      onSwitchToSimple={switchToSimple}
+    />
+  );
+}

--- a/frontend/src/components/map/filters/FilterPanelRouter.tsx
+++ b/frontend/src/components/map/filters/FilterPanelRouter.tsx
@@ -27,19 +27,40 @@ export default function FilterPanelRouter(props: FilterPanelRouterProps) {
     localStorage.setItem("calsight-filter-mode", "simple");
   }, []);
 
-  if (mode === "simple") {
-    return (
-      <SimpleFilterPanel
-        {...props}
-        onSwitchToAdvanced={switchToAdvanced}
-      />
-    );
-  }
-
   return (
-    <FilterWizard
-      {...props}
-      onSwitchToSimple={switchToSimple}
-    />
+    <div className="space-y-4">
+      {/* Mode toggle — always visible */}
+      <div className="flex gap-1 rounded-lg bg-surface-container p-1">
+        <button
+          onClick={switchToSimple}
+          className={`flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-semibold transition-all ${
+            mode === "simple"
+              ? "bg-primary-container text-on-primary-container"
+              : "text-on-surface-variant hover:text-on-surface"
+          }`}
+        >
+          <span className="material-symbols-outlined text-[14px]">tune</span>
+          Simple
+        </button>
+        <button
+          onClick={switchToAdvanced}
+          className={`flex-1 flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-semibold transition-all ${
+            mode === "advanced"
+              ? "bg-primary-container text-on-primary-container"
+              : "text-on-surface-variant hover:text-on-surface"
+          }`}
+        >
+          <span className="material-symbols-outlined text-[14px]">settings</span>
+          Advanced
+        </button>
+      </div>
+
+      {/* Panel content */}
+      {mode === "simple" ? (
+        <SimpleFilterPanel {...props} />
+      ) : (
+        <FilterWizard {...props} />
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/map/filters/FilterPresets.tsx
+++ b/frontend/src/components/map/filters/FilterPresets.tsx
@@ -1,4 +1,5 @@
 import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import { usePresetCounts } from "../../../hooks/usePresetCounts";
 
 interface Preset {
   label: string;
@@ -70,7 +71,15 @@ interface FilterPresetsProps {
   onApplyPreset: (filters: Partial<StagedFilters>) => void;
 }
 
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
+}
+
 export default function FilterPresets({ staged, onApplyPreset }: FilterPresetsProps) {
+  const { data: counts } = usePresetCounts();
+
   return (
     <div className="space-y-3">
       <div>
@@ -97,7 +106,12 @@ export default function FilterPresets({ staged, onApplyPreset }: FilterPresetsPr
               </span>
               <div className="min-w-0">
                 <p className={`text-sm font-semibold ${isActive ? "text-on-primary-container" : "text-on-surface"}`}>{preset.label}</p>
-                <p className={`text-[10px] ${isActive ? "text-on-primary-container/70" : "text-on-surface-variant"}`}>{preset.description}</p>
+                <p className={`text-[10px] ${isActive ? "text-on-primary-container/70" : "text-on-surface-variant"}`}>
+                {preset.description}
+                {counts?.[preset.label] != null && (
+                  <span className="ml-1 font-semibold">({fmtCount(counts[preset.label])})</span>
+                )}
+              </p>
               </div>
               {isActive && (
                 <span className="material-symbols-outlined text-[16px] text-primary ml-auto shrink-0">check</span>

--- a/frontend/src/components/map/filters/FilterPresets.tsx
+++ b/frontend/src/components/map/filters/FilterPresets.tsx
@@ -12,82 +12,99 @@ const PRESETS: Preset[] = [
     label: "Fatal DUI Crashes",
     icon: "local_bar",
     description: "DUI-caused crashes with fatalities",
-    filters: {
-      causes: new Set(["dui"]),
-      severities: new Set(["Fatal"]),
-    },
+    filters: { causes: new Set(["dui"]), severities: new Set(["Fatal"]) },
   },
   {
     label: "Pedestrian Safety",
     icon: "directions_walk",
     description: "All crashes involving pedestrians (2016+)",
-    filters: {
-      pedestrian: true,
-    },
+    filters: { pedestrian: true },
   },
   {
     label: "Teen Drivers",
     icon: "speed",
     description: "At-fault drivers age 16-21 (2016+)",
-    filters: {
-      driverAge: "16-21",
-    },
+    filters: { driverAge: "16-21" },
   },
   {
     label: "Senior Drivers",
-    icon: "elderly",
+    icon: "trending_up",
     description: "At-fault drivers age 65+ (2016+)",
-    filters: {
-      driverAge: "65+",
-    },
+    filters: { driverAge: "65+" },
   },
   {
     label: "Cyclist Crashes",
     icon: "pedal_bike",
     description: "All crashes involving cyclists (2016+)",
-    filters: {
-      cyclist: true,
-    },
+    filters: { cyclist: true },
   },
   {
     label: "Fatal Crashes Only",
     icon: "warning",
     description: "All fatal crashes across all years",
-    filters: {
-      severities: new Set(["Fatal"]),
-    },
+    filters: { severities: new Set(["Fatal"]) },
   },
 ];
 
+function presetMatches(preset: Partial<StagedFilters>, staged: StagedFilters): boolean {
+  const pCauses = preset.causes ?? new Set();
+  const pSev = preset.severities ?? new Set();
+  const pPed = preset.pedestrian ?? false;
+  const pCyc = preset.cyclist ?? false;
+  const pAge = preset.driverAge ?? null;
+  const pAlc = preset.alcohol ?? false;
+
+  if (staged.causes.size !== pCauses.size) return false;
+  for (const c of pCauses) if (!staged.causes.has(c)) return false;
+  if (staged.severities.size !== pSev.size) return false;
+  for (const s of pSev) if (!staged.severities.has(s)) return false;
+  if (staged.pedestrian !== pPed) return false;
+  if (staged.cyclist !== pCyc) return false;
+  if (staged.driverAge !== pAge) return false;
+  if (staged.alcohol !== pAlc) return false;
+  return true;
+}
+
 interface FilterPresetsProps {
+  staged: StagedFilters;
   onApplyPreset: (filters: Partial<StagedFilters>) => void;
 }
 
-export default function FilterPresets({ onApplyPreset }: FilterPresetsProps) {
+export default function FilterPresets({ staged, onApplyPreset }: FilterPresetsProps) {
   return (
     <div className="space-y-3">
       <div>
         <h3 className="text-sm font-bold text-on-surface mb-1">Quick Presets</h3>
         <p className="text-[11px] text-on-surface-variant leading-snug">
-          One-tap filter combinations for common analyses.
+          Tap to load filters, then click Apply to see results.
         </p>
       </div>
       <div className="space-y-2">
-        {PRESETS.map((preset) => (
-          <button
-            key={preset.label}
-            onClick={() => onApplyPreset(preset.filters)}
-            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl bg-surface-container-high hover:bg-surface-variant transition-colors text-left"
-          >
-            <span className="material-symbols-outlined text-[20px] text-primary shrink-0">
-              {preset.icon}
-            </span>
-            <div className="min-w-0">
-              <p className="text-sm font-semibold text-on-surface">{preset.label}</p>
-              <p className="text-[10px] text-on-surface-variant">{preset.description}</p>
-            </div>
-          </button>
-        ))}
+        {PRESETS.map((preset) => {
+          const isActive = presetMatches(preset.filters, staged);
+          return (
+            <button
+              key={preset.label}
+              onClick={() => onApplyPreset(preset.filters)}
+              className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors text-left ${
+                isActive
+                  ? "bg-primary-container ring-2 ring-primary/30"
+                  : "bg-surface-container-high hover:bg-surface-variant"
+              }`}
+            >
+              <span className={`material-symbols-outlined text-[20px] shrink-0 ${isActive ? "text-on-primary-container" : "text-primary"}`}>
+                {preset.icon}
+              </span>
+              <div className="min-w-0">
+                <p className={`text-sm font-semibold ${isActive ? "text-on-primary-container" : "text-on-surface"}`}>{preset.label}</p>
+                <p className={`text-[10px] ${isActive ? "text-on-primary-container/70" : "text-on-surface-variant"}`}>{preset.description}</p>
+              </div>
+              {isActive && (
+                <span className="material-symbols-outlined text-[16px] text-primary ml-auto shrink-0">check</span>
+              )}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/components/map/filters/FilterPresets.tsx
+++ b/frontend/src/components/map/filters/FilterPresets.tsx
@@ -1,0 +1,94 @@
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
+
+interface Preset {
+  label: string;
+  icon: string;
+  description: string;
+  filters: Partial<StagedFilters>;
+}
+
+const PRESETS: Preset[] = [
+  {
+    label: "Fatal DUI Crashes",
+    icon: "local_bar",
+    description: "DUI-caused crashes with fatalities",
+    filters: {
+      causes: new Set(["dui"]),
+      severities: new Set(["Fatal"]),
+    },
+  },
+  {
+    label: "Pedestrian Safety",
+    icon: "directions_walk",
+    description: "All crashes involving pedestrians (2016+)",
+    filters: {
+      pedestrian: true,
+    },
+  },
+  {
+    label: "Teen Drivers",
+    icon: "speed",
+    description: "At-fault drivers age 16-21 (2016+)",
+    filters: {
+      driverAge: "16-21",
+    },
+  },
+  {
+    label: "Senior Drivers",
+    icon: "elderly",
+    description: "At-fault drivers age 65+ (2016+)",
+    filters: {
+      driverAge: "65+",
+    },
+  },
+  {
+    label: "Cyclist Crashes",
+    icon: "pedal_bike",
+    description: "All crashes involving cyclists (2016+)",
+    filters: {
+      cyclist: true,
+    },
+  },
+  {
+    label: "Fatal Crashes Only",
+    icon: "warning",
+    description: "All fatal crashes across all years",
+    filters: {
+      severities: new Set(["Fatal"]),
+    },
+  },
+];
+
+interface FilterPresetsProps {
+  onApplyPreset: (filters: Partial<StagedFilters>) => void;
+}
+
+export default function FilterPresets({ onApplyPreset }: FilterPresetsProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <h3 className="text-sm font-bold text-on-surface mb-1">Quick Presets</h3>
+        <p className="text-[11px] text-on-surface-variant leading-snug">
+          One-tap filter combinations for common analyses.
+        </p>
+      </div>
+      <div className="space-y-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.label}
+            onClick={() => onApplyPreset(preset.filters)}
+            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl bg-surface-container-high hover:bg-surface-variant transition-colors text-left"
+          >
+            <span className="material-symbols-outlined text-[20px] text-primary shrink-0">
+              {preset.icon}
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-on-surface">{preset.label}</p>
+              <p className="text-[10px] text-on-surface-variant">{preset.description}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -106,6 +106,31 @@ export default function FilterWizard({
         ))}
       </div>
 
+      {/* Current filter summary */}
+      {(staged.selectedYears.size > 0 || staged.severities.size > 0 || staged.causes.size > 0 || staged.alcohol || staged.pedestrian || staged.cyclist || staged.drug || staged.distracted || staged.driverAge) && (
+        <div className="flex items-center gap-2 flex-wrap px-1 pb-3">
+          <span className="text-[10px] text-on-surface-variant">Active:</span>
+          {staged.selectedYears.size > 0 && (
+            <span className="text-[9px] bg-primary-container text-on-primary-container px-1.5 py-0.5 rounded-full">
+              {staged.selectedYears.size} year{staged.selectedYears.size > 1 ? "s" : ""}
+            </span>
+          )}
+          {[...staged.severities].map((s) => (
+            <span key={s} className="text-[9px] bg-primary-container text-on-primary-container px-1.5 py-0.5 rounded-full">{s}</span>
+          ))}
+          {[...staged.causes].map((c) => (
+            <span key={c} className="text-[9px] bg-primary-container text-on-primary-container px-1.5 py-0.5 rounded-full">{c}</span>
+          ))}
+          {staged.alcohol && <span className="text-[9px] bg-tertiary-container text-on-tertiary-container px-1.5 py-0.5 rounded-full">Alcohol</span>}
+          {staged.pedestrian && <span className="text-[9px] bg-tertiary-container text-on-tertiary-container px-1.5 py-0.5 rounded-full">Pedestrian</span>}
+          {staged.cyclist && <span className="text-[9px] bg-tertiary-container text-on-tertiary-container px-1.5 py-0.5 rounded-full">Cyclist</span>}
+          {staged.drug && <span className="text-[9px] bg-tertiary-container text-on-tertiary-container px-1.5 py-0.5 rounded-full">Drug</span>}
+          {staged.distracted && <span className="text-[9px] bg-tertiary-container text-on-tertiary-container px-1.5 py-0.5 rounded-full">Distracted</span>}
+          {staged.driverAge && <span className="text-[9px] bg-tertiary-container text-on-tertiary-container px-1.5 py-0.5 rounded-full">Age {staged.driverAge}</span>}
+          {facets.loading && <span className="text-[9px] text-on-surface-variant animate-pulse">updating...</span>}
+        </div>
+      )}
+
       {/* Step content */}
       <div className="pb-4">
         {step === 0 && (

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -3,6 +3,7 @@ import { CA_COUNTIES } from "../../../hooks/useFilterParams";
 import { useLayersState } from "../../../hooks/useLayersState";
 import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
 import { useLiveCrashCount } from "../../../hooks/useLiveCrashCount";
+import { useFacetCounts } from "../../../hooks/useFacetCounts";
 import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
 import StepWhen from "./StepWhen";
 import StepWhat from "./StepWhat";
@@ -53,6 +54,7 @@ export default function FilterWizard({
   } = useLayersState();
 
   const { count: liveCount, loading: countLoading } = useLiveCrashCount(staged);
+  const facets = useFacetCounts(staged);
 
   const handleApply = useCallback(() => {
     onApply(staged);
@@ -107,7 +109,7 @@ export default function FilterWizard({
       {/* Step content */}
       <div className="pb-4">
         {step === 0 && (
-          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} />
+          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} yearCounts={facets.years} />
         )}
         {step === 1 && (
           <StepWhat
@@ -116,6 +118,8 @@ export default function FilterWizard({
             onClearCauses={clearCauses}
             onToggleSeverity={toggleSeverity}
             onClearSeverities={clearSeverities}
+            causeCounts={facets.causes}
+            severityCounts={facets.severities}
           />
         )}
         {step === 2 && (
@@ -124,6 +128,7 @@ export default function FilterWizard({
             has2016Plus={has2016Plus}
             onToggleInvolvement={toggleInvolvement}
             onSetDriverAge={setDriverAge}
+            involvementCounts={facets.involvement}
           />
         )}
         {step === 3 && (

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -2,14 +2,16 @@ import { useState, useCallback } from "react";
 import { CA_COUNTIES } from "../../../hooks/useFilterParams";
 import { useLayersState } from "../../../hooks/useLayersState";
 import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
+import { useLiveCrashCount } from "../../../hooks/useLiveCrashCount";
 import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
 import StepWhen from "./StepWhen";
 import StepWhat from "./StepWhat";
 import StepWho from "./StepWho";
+import StepConditions from "./StepConditions";
 import StepViewBy from "./StepViewBy";
 import StepDisplay from "./StepDisplay";
 
-const STEPS = ["When", "What", "Who", "View", "Display"] as const;
+const STEPS = ["When", "What", "Who", "Conditions", "View", "Display"] as const;
 
 const countyOptions = [
   { value: "__all__", label: "All Counties (Statewide)" },
@@ -24,7 +26,6 @@ interface FilterWizardProps {
   onClearCounties: () => void;
   onApply: (filters: StagedFilters) => void;
   onClear: () => void;
-  onSwitchToSimple?: () => void;
 }
 
 export default function FilterWizard({
@@ -34,14 +35,13 @@ export default function FilterWizard({
   onClearCounties,
   onApply,
   onClear,
-  onSwitchToSimple,
 }: FilterWizardProps) {
   const [step, setStep] = useState(0);
   const {
     staged, toggleYear, setAllYears,
     toggleSeverity, clearSeverities,
     toggleCause, clearCauses,
-    toggleInvolvement, setDriverAge,
+    toggleInvolvement, setDateRange, setDriverAge,
     clearAll, has2016Plus,
   } = useStagedFilters(initial);
 
@@ -51,6 +51,8 @@ export default function FilterWizard({
     palette, setPalette,
     otherLayers, toggleOtherLayer, setOtherLayer,
   } = useLayersState();
+
+  const { count: liveCount, loading: countLoading } = useLiveCrashCount(staged);
 
   const handleApply = useCallback(() => {
     onApply(staged);
@@ -65,19 +67,6 @@ export default function FilterWizard({
 
   return (
     <div className="space-y-4">
-      {/* Header with Simple toggle */}
-      <div className="flex items-center justify-between pb-2 border-b border-outline-variant/15">
-        <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">Advanced Filters</span>
-        {onSwitchToSimple && (
-          <button
-            onClick={onSwitchToSimple}
-            className="text-[11px] font-semibold text-primary hover:text-primary/80 transition-colors"
-          >
-            Simple Mode
-          </button>
-        )}
-      </div>
-
       {/* County */}
       <div className="pb-4 border-b border-outline-variant/15">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
@@ -118,7 +107,7 @@ export default function FilterWizard({
       {/* Step content */}
       <div className="pb-4">
         {step === 0 && (
-          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} />
+          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} />
         )}
         {step === 1 && (
           <StepWhat
@@ -138,12 +127,15 @@ export default function FilterWizard({
           />
         )}
         {step === 3 && (
+          <StepConditions />
+        )}
+        {step === 4 && (
           <StepViewBy
             measure={measure}
             onSetMeasure={setMeasure}
           />
         )}
-        {step === 4 && (
+        {step === 5 && (
           <StepDisplay
             choroplethOn={choroplethOn}
             onToggleChoropleth={() => {
@@ -161,12 +153,16 @@ export default function FilterWizard({
             onSetPalette={setPalette}
             countyBoundaries={otherLayers.countyBoundaries}
             onToggleBoundaries={() => toggleOtherLayer("countyBoundaries")}
+            hospitalsOn={otherLayers.hospitals}
+            onToggleHospitals={() => toggleOtherLayer("hospitals")}
+            schoolsOn={otherLayers.schools}
+            onToggleSchools={() => toggleOtherLayer("schools")}
           />
         )}
       </div>
 
       {/* Navigation */}
-      <div className="flex items-center gap-3 pt-4 pb-2 border-t border-outline-variant/15 sticky bottom-0 bg-surface-container-lowest">
+      <div className="flex items-center gap-3 pt-4 pb-2 border-t border-outline-variant/15">
         {step > 0 && (
           <button
             onClick={() => setStep((s) => s - 1)}
@@ -194,7 +190,7 @@ export default function FilterWizard({
             onClick={handleApply}
             className="px-6 py-2.5 rounded-xl text-sm font-bold bg-primary text-on-primary hover:opacity-90 transition-opacity"
           >
-            Apply Filters
+            {countLoading ? "Loading..." : liveCount !== null ? `Show ${liveCount >= 1000000 ? `${(liveCount / 1000000).toFixed(1)}M` : liveCount >= 1000 ? `${Math.round(liveCount / 1000)}K` : liveCount.toLocaleString()} Crashes` : "Apply Filters"}
           </button>
         )}
       </div>

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -1,12 +1,15 @@
 import { useState, useCallback } from "react";
 import { CA_COUNTIES } from "../../../hooks/useFilterParams";
+import { useLayersState } from "../../../hooks/useLayersState";
 import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
 import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
 import StepWhen from "./StepWhen";
 import StepWhat from "./StepWhat";
 import StepWho from "./StepWho";
+import StepViewBy from "./StepViewBy";
+import StepDisplay from "./StepDisplay";
 
-const STEPS = ["When", "What", "Who"] as const;
+const STEPS = ["When", "What", "Who", "View", "Display"] as const;
 
 const countyOptions = [
   { value: "__all__", label: "All Counties (Statewide)" },
@@ -40,6 +43,13 @@ export default function FilterWizard({
     clearAll, has2016Plus,
   } = useStagedFilters(initial);
 
+  const {
+    choroplethOn, setChoroplethOn,
+    measure, setMeasure,
+    palette, setPalette,
+    otherLayers, toggleOtherLayer, setOtherLayer,
+  } = useLayersState();
+
   const handleApply = useCallback(() => {
     onApply(staged);
   }, [staged, onApply]);
@@ -49,10 +59,12 @@ export default function FilterWizard({
     onClear();
   }, [clearAll, onClear]);
 
+  const lastStep = STEPS.length - 1;
+
   return (
-    <div className="flex flex-col h-full">
+    <div className="space-y-4">
       {/* County — always visible */}
-      <div className="px-1 pb-4 border-b border-outline-variant/15">
+      <div className="pb-4 border-b border-outline-variant/15">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
           County
         </label>
@@ -69,17 +81,17 @@ export default function FilterWizard({
       </div>
 
       {/* Step dots */}
-      <div className="flex items-center justify-center gap-3 py-4">
+      <div className="flex items-center justify-center gap-2 py-3 flex-wrap">
         {STEPS.map((label, i) => (
           <button
             key={label}
             onClick={() => setStep(i)}
-            className="flex items-center gap-1.5"
+            className="flex items-center gap-1"
           >
             <div className={`w-2 h-2 rounded-full transition-all ${
               i === step ? "bg-primary scale-125" : i < step ? "bg-primary/50" : "bg-outline-variant/30"
             }`} />
-            <span className={`text-[10px] font-semibold transition-colors ${
+            <span className={`text-[9px] font-semibold transition-colors ${
               i === step ? "text-on-surface" : "text-on-surface-variant/50"
             }`}>
               {label}
@@ -89,7 +101,7 @@ export default function FilterWizard({
       </div>
 
       {/* Step content */}
-      <div className="flex-1 overflow-y-auto px-1 pb-4">
+      <div className="pb-4">
         {step === 0 && (
           <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} />
         )}
@@ -110,10 +122,36 @@ export default function FilterWizard({
             onSetDriverAge={setDriverAge}
           />
         )}
+        {step === 3 && (
+          <StepViewBy
+            measure={measure}
+            onSetMeasure={setMeasure}
+          />
+        )}
+        {step === 4 && (
+          <StepDisplay
+            choroplethOn={choroplethOn}
+            onToggleChoropleth={() => {
+              if (choroplethOn && !otherLayers.heatmapStatewide) return;
+              setChoroplethOn(!choroplethOn);
+              if (!choroplethOn) setOtherLayer("heatmapStatewide", false);
+            }}
+            heatmapOn={otherLayers.heatmapStatewide}
+            onToggleHeatmap={() => {
+              if (otherLayers.heatmapStatewide && !choroplethOn) return;
+              setOtherLayer("heatmapStatewide", !otherLayers.heatmapStatewide);
+              if (!otherLayers.heatmapStatewide) setChoroplethOn(false);
+            }}
+            palette={palette}
+            onSetPalette={setPalette}
+            countyBoundaries={otherLayers.countyBoundaries}
+            onToggleBoundaries={() => toggleOtherLayer("countyBoundaries")}
+          />
+        )}
       </div>
 
       {/* Navigation */}
-      <div className="flex items-center gap-3 pt-4 border-t border-outline-variant/15">
+      <div className="flex items-center gap-3 pt-4 pb-2 border-t border-outline-variant/15 sticky bottom-0 bg-surface-container-lowest">
         {step > 0 && (
           <button
             onClick={() => setStep((s) => s - 1)}
@@ -129,7 +167,7 @@ export default function FilterWizard({
           Clear All
         </button>
         <div className="flex-1" />
-        {step < 2 ? (
+        {step < lastStep ? (
           <button
             onClick={() => setStep((s) => s + 1)}
             className="px-6 py-2.5 rounded-xl text-sm font-bold bg-primary-container text-on-primary-container hover:opacity-90 transition-opacity"

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -1,0 +1,150 @@
+import { useState, useCallback } from "react";
+import { CA_COUNTIES } from "../../../hooks/useFilterParams";
+import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
+import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
+import StepWhen from "./StepWhen";
+import StepWhat from "./StepWhat";
+import StepWho from "./StepWho";
+
+const STEPS = ["When", "What", "Who"] as const;
+
+const countyOptions = [
+  { value: "__all__", label: "All Counties (Statewide)" },
+  ...CA_COUNTIES.map((c) => ({ value: c, label: c })),
+];
+const ALL_COUNTIES_SET = new Set(["__all__"]);
+
+interface FilterWizardProps {
+  initial: StagedFilters;
+  selectedCounties: Set<string>;
+  onToggleCounty: (county: string) => void;
+  onClearCounties: () => void;
+  onApply: (filters: StagedFilters) => void;
+  onClear: () => void;
+}
+
+export default function FilterWizard({
+  initial,
+  selectedCounties,
+  onToggleCounty,
+  onClearCounties,
+  onApply,
+  onClear,
+}: FilterWizardProps) {
+  const [step, setStep] = useState(0);
+  const {
+    staged, toggleYear, setAllYears,
+    toggleSeverity, clearSeverities,
+    toggleCause, clearCauses,
+    toggleInvolvement, setDriverAge,
+    clearAll, has2016Plus,
+  } = useStagedFilters(initial);
+
+  const handleApply = useCallback(() => {
+    onApply(staged);
+  }, [staged, onApply]);
+
+  const handleClear = useCallback(() => {
+    clearAll();
+    onClear();
+  }, [clearAll, onClear]);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* County — always visible */}
+      <div className="px-1 pb-4 border-b border-outline-variant/15">
+        <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
+          County
+        </label>
+        <SearchableMultiSelect
+          options={countyOptions}
+          selected={selectedCounties.size === 0 ? ALL_COUNTIES_SET : selectedCounties}
+          nonDismissableValues={ALL_COUNTIES_SET}
+          onToggle={(value) => {
+            if (value === "__all__") onClearCounties();
+            else onToggleCounty(value);
+          }}
+          placeholder="Search California Counties..."
+        />
+      </div>
+
+      {/* Step dots */}
+      <div className="flex items-center justify-center gap-3 py-4">
+        {STEPS.map((label, i) => (
+          <button
+            key={label}
+            onClick={() => setStep(i)}
+            className="flex items-center gap-1.5"
+          >
+            <div className={`w-2 h-2 rounded-full transition-all ${
+              i === step ? "bg-primary scale-125" : i < step ? "bg-primary/50" : "bg-outline-variant/30"
+            }`} />
+            <span className={`text-[10px] font-semibold transition-colors ${
+              i === step ? "text-on-surface" : "text-on-surface-variant/50"
+            }`}>
+              {label}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {/* Step content */}
+      <div className="flex-1 overflow-y-auto px-1 pb-4">
+        {step === 0 && (
+          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} />
+        )}
+        {step === 1 && (
+          <StepWhat
+            staged={staged}
+            onToggleCause={toggleCause}
+            onClearCauses={clearCauses}
+            onToggleSeverity={toggleSeverity}
+            onClearSeverities={clearSeverities}
+          />
+        )}
+        {step === 2 && (
+          <StepWho
+            staged={staged}
+            has2016Plus={has2016Plus}
+            onToggleInvolvement={toggleInvolvement}
+            onSetDriverAge={setDriverAge}
+          />
+        )}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex items-center gap-3 pt-4 border-t border-outline-variant/15">
+        {step > 0 && (
+          <button
+            onClick={() => setStep((s) => s - 1)}
+            className="px-4 py-2.5 rounded-xl text-sm font-semibold text-on-surface-variant hover:text-on-surface transition-colors"
+          >
+            Back
+          </button>
+        )}
+        <button
+          onClick={handleClear}
+          className="text-sm font-semibold text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          Clear All
+        </button>
+        <div className="flex-1" />
+        {step < 2 ? (
+          <button
+            onClick={() => setStep((s) => s + 1)}
+            className="px-6 py-2.5 rounded-xl text-sm font-bold bg-primary-container text-on-primary-container hover:opacity-90 transition-opacity"
+          >
+            Next
+          </button>
+        ) : (
+          <button
+            onClick={handleApply}
+            className="px-6 py-2.5 rounded-xl text-sm font-bold bg-primary text-on-primary hover:opacity-90 transition-opacity"
+          >
+            Apply Filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -24,6 +24,7 @@ interface FilterWizardProps {
   onClearCounties: () => void;
   onApply: (filters: StagedFilters) => void;
   onClear: () => void;
+  onSwitchToSimple?: () => void;
 }
 
 export default function FilterWizard({
@@ -33,6 +34,7 @@ export default function FilterWizard({
   onClearCounties,
   onApply,
   onClear,
+  onSwitchToSimple,
 }: FilterWizardProps) {
   const [step, setStep] = useState(0);
   const {
@@ -63,7 +65,20 @@ export default function FilterWizard({
 
   return (
     <div className="space-y-4">
-      {/* County — always visible */}
+      {/* Header with Simple toggle */}
+      <div className="flex items-center justify-between pb-2 border-b border-outline-variant/15">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">Advanced Filters</span>
+        {onSwitchToSimple && (
+          <button
+            onClick={onSwitchToSimple}
+            className="text-[11px] font-semibold text-primary hover:text-primary/80 transition-colors"
+          >
+            Simple Mode
+          </button>
+        )}
+      </div>
+
+      {/* County */}
       <div className="pb-4 border-b border-outline-variant/15">
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
           County
@@ -81,7 +96,7 @@ export default function FilterWizard({
       </div>
 
       {/* Step dots */}
-      <div className="flex items-center justify-center gap-2 py-3 flex-wrap">
+      <div className="flex items-center justify-center gap-2 py-2 flex-wrap">
         {STEPS.map((label, i) => (
           <button
             key={label}

--- a/frontend/src/components/map/filters/SimpleFilterPanel.tsx
+++ b/frontend/src/components/map/filters/SimpleFilterPanel.tsx
@@ -1,0 +1,174 @@
+import { useCallback } from "react";
+import { YEARS, CAUSES, SEVERITIES, CA_COUNTIES } from "../../../hooks/useFilterParams";
+import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
+import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
+import FilterChip from "./FilterChip";
+import FilterPresets from "./FilterPresets";
+
+const RECENT_YEARS = YEARS.filter((y) => y >= 2016).reverse();
+const TOP_CAUSES = CAUSES.filter((c) =>
+  ["dui", "speeding", "right-of-way", "turning", "following-too-close"].includes(c.value)
+);
+
+const countyOptions = [
+  { value: "__all__", label: "All Counties (Statewide)" },
+  ...CA_COUNTIES.map((c) => ({ value: c, label: c })),
+];
+const ALL_COUNTIES_SET = new Set(["__all__"]);
+
+interface SimpleFilterPanelProps {
+  initial: StagedFilters;
+  selectedCounties: Set<string>;
+  onToggleCounty: (county: string) => void;
+  onClearCounties: () => void;
+  onApply: (filters: StagedFilters) => void;
+  onClear: () => void;
+  onSwitchToAdvanced: () => void;
+}
+
+export default function SimpleFilterPanel({
+  initial,
+  selectedCounties,
+  onToggleCounty,
+  onClearCounties,
+  onApply,
+  onClear,
+  onSwitchToAdvanced,
+}: SimpleFilterPanelProps) {
+  const {
+    staged, toggleYear, setAllYears,
+    toggleSeverity, clearSeverities,
+    toggleCause, clearCauses,
+    clearAll, reset,
+  } = useStagedFilters(initial);
+
+  const handlePreset = useCallback((preset: Partial<StagedFilters>) => {
+    const base: StagedFilters = {
+      selectedYears: new Set(),
+      dateRange: null,
+      severities: new Set(),
+      causes: new Set(),
+      alcohol: false,
+      distracted: false,
+      pedestrian: false,
+      cyclist: false,
+      drug: false,
+      driverAge: null,
+    };
+    reset({ ...base, ...preset });
+    onApply({ ...base, ...preset });
+  }, [reset, onApply]);
+
+  const handleApply = useCallback(() => {
+    onApply(staged);
+  }, [staged, onApply]);
+
+  const handleClear = useCallback(() => {
+    clearAll();
+    onClear();
+  }, [clearAll, onClear]);
+
+  const allYears = staged.selectedYears.size === 0;
+  const allCauses = staged.causes.size === 0;
+  const allSeverities = staged.severities.size === 0;
+
+  return (
+    <div className="space-y-6">
+      {/* County */}
+      <div>
+        <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
+          County
+        </label>
+        <SearchableMultiSelect
+          options={countyOptions}
+          selected={selectedCounties.size === 0 ? ALL_COUNTIES_SET : selectedCounties}
+          nonDismissableValues={ALL_COUNTIES_SET}
+          onToggle={(value) => {
+            if (value === "__all__") onClearCounties();
+            else onToggleCounty(value);
+          }}
+          placeholder="Search California Counties..."
+        />
+      </div>
+
+      {/* Years */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-bold text-on-surface">Time Period</h3>
+        <p className="text-[11px] text-on-surface-variant">Recent years shown. Use Advanced for 2001-2015.</p>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Years" active={allYears} onClick={setAllYears} />
+          {RECENT_YEARS.map((year) => (
+            <FilterChip
+              key={year}
+              label={String(year)}
+              active={!allYears && staged.selectedYears.has(year)}
+              onClick={() => toggleYear(year)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Severity */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-bold text-on-surface">Severity</h3>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All" active={allSeverities} onClick={clearSeverities} />
+          {SEVERITIES.map((s) => (
+            <FilterChip
+              key={s}
+              label={s}
+              active={!allSeverities && staged.severities.has(s)}
+              onClick={() => toggleSeverity(s)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Top causes */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-bold text-on-surface">Common Causes</h3>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All" active={allCauses} onClick={clearCauses} />
+          {TOP_CAUSES.map((cause) => (
+            <FilterChip
+              key={cause.value}
+              label={cause.label}
+              icon={cause.icon}
+              active={!allCauses && staged.causes.has(cause.value)}
+              onClick={() => toggleCause(cause.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Presets */}
+      <FilterPresets onApplyPreset={handlePreset} />
+
+      {/* Advanced toggle */}
+      <button
+        onClick={onSwitchToAdvanced}
+        className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-colors text-sm font-semibold"
+      >
+        <span className="material-symbols-outlined text-[16px]">tune</span>
+        More Filters (Weather, Involvement, Display)
+      </button>
+
+      {/* Footer */}
+      <div className="flex items-center gap-3 pt-4 pb-2 border-t border-outline-variant/15 sticky bottom-0 bg-surface-container-lowest">
+        <button
+          onClick={handleClear}
+          className="text-sm font-semibold text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          Clear All
+        </button>
+        <div className="flex-1" />
+        <button
+          onClick={handleApply}
+          className="px-6 py-2.5 rounded-xl text-sm font-bold bg-primary text-on-primary hover:opacity-90 transition-opacity"
+        >
+          Apply Filters
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/SimpleFilterPanel.tsx
+++ b/frontend/src/components/map/filters/SimpleFilterPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { YEARS, CAUSES, SEVERITIES, CA_COUNTIES } from "../../../hooks/useFilterParams";
 import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
 import { useLiveCrashCount } from "../../../hooks/useLiveCrashCount";
+import { useFacetCounts } from "../../../hooks/useFacetCounts";
 import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
 import FilterChip from "./FilterChip";
 import FilterPresets from "./FilterPresets";
@@ -26,6 +27,12 @@ interface SimpleFilterPanelProps {
   onClear: () => void;
 }
 
+function fmtC(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
+}
+
 function fmtCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
@@ -48,6 +55,7 @@ export default function SimpleFilterPanel({
   } = useStagedFilters(initial);
 
   const { count: liveCount, loading: countLoading } = useLiveCrashCount(staged);
+  const facets = useFacetCounts(staged);
 
   const handlePreset = useCallback((preset: Partial<StagedFilters>) => {
     const merged: StagedFilters = {
@@ -103,14 +111,19 @@ export default function SimpleFilterPanel({
         <p className="text-[11px] text-on-surface-variant">Recent years shown. Use Advanced for 2001-2015.</p>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="All Years" active={allYears} onClick={setAllYears} />
-          {RECENT_YEARS.map((year) => (
-            <FilterChip
-              key={year}
-              label={String(year)}
-              active={!allYears && staged.selectedYears.has(year)}
-              onClick={() => toggleYear(year)}
-            />
-          ))}
+          {RECENT_YEARS.map((year) => {
+            const count = facets.years[year];
+            return (
+              <FilterChip
+                key={year}
+                label={String(year)}
+                count={count != null ? fmtC(count) : undefined}
+                active={!allYears && staged.selectedYears.has(year)}
+                disabled={count != null && count === 0}
+                onClick={() => toggleYear(year)}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -119,14 +132,19 @@ export default function SimpleFilterPanel({
         <h3 className="text-sm font-bold text-on-surface">Severity</h3>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="All" active={allSeverities} onClick={clearSeverities} />
-          {SEVERITIES.map((s) => (
-            <FilterChip
-              key={s}
-              label={s}
-              active={!allSeverities && staged.severities.has(s)}
-              onClick={() => toggleSeverity(s)}
-            />
-          ))}
+          {SEVERITIES.map((s) => {
+            const count = facets.severities[s];
+            return (
+              <FilterChip
+                key={s}
+                label={s}
+                count={count != null ? fmtC(count) : undefined}
+                active={!allSeverities && staged.severities.has(s)}
+                disabled={count != null && count === 0}
+                onClick={() => toggleSeverity(s)}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -135,15 +153,20 @@ export default function SimpleFilterPanel({
         <h3 className="text-sm font-bold text-on-surface">Common Causes</h3>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="All" active={allCauses} onClick={clearCauses} />
-          {TOP_CAUSES.map((cause) => (
-            <FilterChip
-              key={cause.value}
-              label={cause.label}
-              icon={cause.icon}
-              active={!allCauses && staged.causes.has(cause.value)}
-              onClick={() => toggleCause(cause.value)}
-            />
-          ))}
+          {TOP_CAUSES.map((cause) => {
+            const count = facets.causes[cause.value];
+            return (
+              <FilterChip
+                key={cause.value}
+                label={cause.label}
+                icon={cause.icon}
+                count={count != null ? fmtC(count) : undefined}
+                active={!allCauses && staged.causes.has(cause.value)}
+                disabled={count != null && count === 0}
+                onClick={() => toggleCause(cause.value)}
+              />
+            );
+          })}
         </div>
       </div>
 

--- a/frontend/src/components/map/filters/SimpleFilterPanel.tsx
+++ b/frontend/src/components/map/filters/SimpleFilterPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { YEARS, CAUSES, SEVERITIES, CA_COUNTIES } from "../../../hooks/useFilterParams";
 import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
+import { useLiveCrashCount } from "../../../hooks/useLiveCrashCount";
 import SearchableMultiSelect from "../../ui/SearchableMultiSelect";
 import FilterChip from "./FilterChip";
 import FilterPresets from "./FilterPresets";
@@ -23,7 +24,12 @@ interface SimpleFilterPanelProps {
   onClearCounties: () => void;
   onApply: (filters: StagedFilters) => void;
   onClear: () => void;
-  onSwitchToAdvanced: () => void;
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
 }
 
 export default function SimpleFilterPanel({
@@ -33,7 +39,6 @@ export default function SimpleFilterPanel({
   onClearCounties,
   onApply,
   onClear,
-  onSwitchToAdvanced,
 }: SimpleFilterPanelProps) {
   const {
     staged, toggleYear, setAllYears,
@@ -42,22 +47,23 @@ export default function SimpleFilterPanel({
     clearAll, reset,
   } = useStagedFilters(initial);
 
+  const { count: liveCount, loading: countLoading } = useLiveCrashCount(staged);
+
   const handlePreset = useCallback((preset: Partial<StagedFilters>) => {
-    const base: StagedFilters = {
-      selectedYears: new Set(),
-      dateRange: null,
-      severities: new Set(),
-      causes: new Set(),
-      alcohol: false,
-      distracted: false,
-      pedestrian: false,
-      cyclist: false,
-      drug: false,
-      driverAge: null,
+    const merged: StagedFilters = {
+      selectedYears: preset.selectedYears ?? new Set(),
+      dateRange: preset.dateRange ?? null,
+      severities: preset.severities ?? new Set(),
+      causes: preset.causes ?? new Set(),
+      alcohol: preset.alcohol ?? false,
+      distracted: preset.distracted ?? false,
+      pedestrian: preset.pedestrian ?? false,
+      cyclist: preset.cyclist ?? false,
+      drug: preset.drug ?? false,
+      driverAge: preset.driverAge ?? null,
     };
-    reset({ ...base, ...preset });
-    onApply({ ...base, ...preset });
-  }, [reset, onApply]);
+    reset(merged);
+  }, [reset]);
 
   const handleApply = useCallback(() => {
     onApply(staged);
@@ -73,7 +79,7 @@ export default function SimpleFilterPanel({
   const allSeverities = staged.severities.size === 0;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-4">
       {/* County */}
       <div>
         <label className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant mb-2 block">
@@ -142,19 +148,10 @@ export default function SimpleFilterPanel({
       </div>
 
       {/* Presets */}
-      <FilterPresets onApplyPreset={handlePreset} />
+      <FilterPresets staged={staged} onApplyPreset={handlePreset} />
 
-      {/* Advanced toggle */}
-      <button
-        onClick={onSwitchToAdvanced}
-        className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-colors text-sm font-semibold"
-      >
-        <span className="material-symbols-outlined text-[16px]">tune</span>
-        More Filters (Weather, Involvement, Display)
-      </button>
-
-      {/* Footer */}
-      <div className="flex items-center gap-3 pt-4 pb-2 border-t border-outline-variant/15 sticky bottom-0 bg-surface-container-lowest">
+      {/* Footer — at bottom of scroll content */}
+      <div className="flex items-center gap-3 pt-4 border-t border-outline-variant/15">
         <button
           onClick={handleClear}
           className="text-sm font-semibold text-on-surface-variant hover:text-on-surface transition-colors"
@@ -166,7 +163,7 @@ export default function SimpleFilterPanel({
           onClick={handleApply}
           className="px-6 py-2.5 rounded-xl text-sm font-bold bg-primary text-on-primary hover:opacity-90 transition-opacity"
         >
-          Apply Filters
+          {countLoading ? "Loading..." : liveCount !== null ? `Show ${fmtCount(liveCount)} Crashes` : "Apply Filters"}
         </button>
       </div>
     </div>

--- a/frontend/src/components/map/filters/SimpleFilters.tsx
+++ b/frontend/src/components/map/filters/SimpleFilters.tsx
@@ -1,0 +1,96 @@
+import { YEARS, CAUSES, SEVERITIES } from "../../../hooks/useFilterParams";
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import FilterChip from "./FilterChip";
+
+interface SimpleFiltersProps {
+  staged: StagedFilters;
+  onToggleYear: (year: number) => void;
+  onSetAllYears: () => void;
+  onToggleCause: (cause: string) => void;
+  onClearCauses: () => void;
+  onToggleSeverity: (severity: string) => void;
+  onClearSeverities: () => void;
+  onShowAdvanced: () => void;
+}
+
+const RECENT_YEARS = YEARS.filter((y) => y >= 2016).reverse();
+const TOP_CAUSES = CAUSES.filter((c) =>
+  ["dui", "speeding", "right-of-way", "turning", "following-too-close"].includes(c.value)
+);
+
+export default function SimpleFilters({
+  staged,
+  onToggleYear,
+  onSetAllYears,
+  onToggleCause,
+  onClearCauses,
+  onToggleSeverity,
+  onClearSeverities,
+  onShowAdvanced,
+}: SimpleFiltersProps) {
+  const allYears = staged.selectedYears.size === 0;
+  const allCauses = staged.causes.size === 0;
+  const allSeverities = staged.severities.size === 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Years */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-bold text-on-surface">Time Period</h3>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Years" active={allYears} onClick={onSetAllYears} />
+          {RECENT_YEARS.map((year) => (
+            <FilterChip
+              key={year}
+              label={String(year)}
+              active={!allYears && staged.selectedYears.has(year)}
+              onClick={() => onToggleYear(year)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Severity */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-bold text-on-surface">Severity</h3>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All" active={allSeverities} onClick={onClearSeverities} />
+          {SEVERITIES.map((s) => (
+            <FilterChip
+              key={s}
+              label={s}
+              active={!allSeverities && staged.severities.has(s)}
+              onClick={() => onToggleSeverity(s)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Top causes */}
+      <div className="space-y-2">
+        <h3 className="text-sm font-bold text-on-surface">Common Causes</h3>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All" active={allCauses} onClick={onClearCauses} />
+          {TOP_CAUSES.map((cause) => (
+            <FilterChip
+              key={cause.value}
+              label={cause.label}
+              icon={cause.icon}
+              active={!allCauses && staged.causes.has(cause.value)}
+              onClick={() => onToggleCause(cause.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Advanced toggle */}
+      <button
+        onClick={onShowAdvanced}
+        className="w-full flex items-center justify-center gap-2 py-3 rounded-xl bg-surface-container-high text-on-surface-variant hover:bg-surface-variant transition-colors text-sm font-semibold"
+      >
+        <span className="material-symbols-outlined text-[16px]">tune</span>
+        More Filters
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/StepConditions.tsx
+++ b/frontend/src/components/map/filters/StepConditions.tsx
@@ -1,0 +1,175 @@
+import { useState, useCallback } from "react";
+import FilterChip from "./FilterChip";
+
+const WEATHER = [
+  { value: "clear", label: "Clear" },
+  { value: "cloudy", label: "Cloudy" },
+  { value: "rain", label: "Rain" },
+  { value: "fog", label: "Fog" },
+  { value: "snow", label: "Snow" },
+  { value: "wind", label: "Wind" },
+];
+
+const LIGHTING = [
+  { value: "daylight", label: "Daylight" },
+  { value: "dark_lit", label: "Dark (Street Lights)" },
+  { value: "dark_unlit", label: "Dark (No Lights)" },
+  { value: "dusk_dawn", label: "Dusk / Dawn" },
+];
+
+const COLLISION_TYPES = [
+  { value: "rear_end", label: "Rear End" },
+  { value: "broadside", label: "Broadside" },
+  { value: "sideswipe", label: "Sideswipe" },
+  { value: "hit_object", label: "Hit Object" },
+  { value: "head_on", label: "Head On" },
+];
+
+const ROAD_TYPES = [
+  { value: "highway", label: "Highway" },
+  { value: "local", label: "Local Road" },
+];
+
+function toggleInSet(set: Set<string>, value: string): Set<string> {
+  const next = new Set(set);
+  if (next.has(value)) {
+    next.delete(value);
+  } else {
+    next.add(value);
+  }
+  return next;
+}
+
+export default function StepConditions() {
+  const [weather, setWeather] = useState<Set<string>>(new Set());
+  const [lighting, setLighting] = useState<Set<string>>(new Set());
+  const [collisionType, setCollisionType] = useState<Set<string>>(new Set());
+  const [roadType, setRoadType] = useState<string | null>(null);
+  const [hitRun, setHitRun] = useState(false);
+
+  const toggleWeather = useCallback((v: string) => {
+    setWeather((prev) => toggleInSet(prev, v));
+  }, []);
+
+  const toggleLighting = useCallback((v: string) => {
+    setLighting((prev) => toggleInSet(prev, v));
+  }, []);
+
+  const toggleCollisionType = useCallback((v: string) => {
+    setCollisionType((prev) => toggleInSet(prev, v));
+  }, []);
+
+  const toggleRoadType = useCallback((v: string) => {
+    setRoadType((prev) => (prev === v ? null : v));
+  }, []);
+
+  const allWeather = weather.size === 0;
+  const allLighting = lighting.size === 0;
+  const allCollisionTypes = collisionType.size === 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Weather */}
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">What were the conditions?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Weather at the time of the crash as recorded by the reporting officer. Empty means all conditions.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Weather" active={allWeather} onClick={() => setWeather(new Set())} />
+          {WEATHER.map((w) => (
+            <FilterChip
+              key={w.value}
+              label={w.label}
+              active={!allWeather && weather.has(w.value)}
+              onClick={() => toggleWeather(w.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Lighting */}
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">What was the lighting?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Lighting conditions at the crash site. Dark crashes with no street lights have higher fatality rates.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Lighting" active={allLighting} onClick={() => setLighting(new Set())} />
+          {LIGHTING.map((l) => (
+            <FilterChip
+              key={l.value}
+              label={l.label}
+              active={!allLighting && lighting.has(l.value)}
+              onClick={() => toggleLighting(l.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Collision Type */}
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">What type of collision?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            How the vehicles collided. Rear-end is the most common; head-on is the most deadly.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Types" active={allCollisionTypes} onClick={() => setCollisionType(new Set())} />
+          {COLLISION_TYPES.map((ct) => (
+            <FilterChip
+              key={ct.value}
+              label={ct.label}
+              active={!allCollisionTypes && collisionType.has(ct.value)}
+              onClick={() => toggleCollisionType(ct.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Road Type */}
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">Road type</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Highway (freeways, expressways, state routes) vs local roads (city streets, rural roads). Leave unselected for all.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Roads" active={roadType === null} onClick={() => setRoadType(null)} />
+          {ROAD_TYPES.map((rt) => (
+            <FilterChip
+              key={rt.value}
+              label={rt.label}
+              active={roadType === rt.value}
+              onClick={() => toggleRoadType(rt.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Hit-and-Run */}
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">Hit-and-run?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Show only crashes where a driver fled the scene (misdemeanor or felony hit-and-run).
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip
+            label="Hit-and-Run Only"
+            icon="warning"
+            active={hitRun}
+            onClick={() => setHitRun((prev) => !prev)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/StepDisplay.tsx
+++ b/frontend/src/components/map/filters/StepDisplay.tsx
@@ -10,6 +10,10 @@ interface StepDisplayProps {
   onSetPalette: (p: PaletteKey) => void;
   countyBoundaries: boolean;
   onToggleBoundaries: () => void;
+  hospitalsOn: boolean;
+  onToggleHospitals: () => void;
+  schoolsOn: boolean;
+  onToggleSchools: () => void;
 }
 
 const PALETTE_OPTIONS: { key: PaletteKey; label: string }[] = [
@@ -46,6 +50,10 @@ export default function StepDisplay({
   onSetPalette,
   countyBoundaries,
   onToggleBoundaries,
+  hospitalsOn,
+  onToggleHospitals,
+  schoolsOn,
+  onToggleSchools,
 }: StepDisplayProps) {
   const isDark = useIsDark();
 
@@ -62,6 +70,8 @@ export default function StepDisplay({
         <Toggle label="Choropleth (county colors)" enabled={choroplethOn} onToggle={onToggleChoropleth} />
         <Toggle label="Crash heatmap" enabled={heatmapOn} onToggle={onToggleHeatmap} />
         <Toggle label="County boundaries" enabled={countyBoundaries} onToggle={onToggleBoundaries} />
+        <Toggle label="Hospitals" enabled={hospitalsOn} onToggle={onToggleHospitals} />
+        <Toggle label="Schools" enabled={schoolsOn} onToggle={onToggleSchools} />
       </div>
 
       <div className="space-y-3">

--- a/frontend/src/components/map/filters/StepDisplay.tsx
+++ b/frontend/src/components/map/filters/StepDisplay.tsx
@@ -1,0 +1,99 @@
+import { getPalette, type PaletteKey } from "../../../lib/choropleth/palettes";
+import { useIsDark } from "../../../context/ThemeContext";
+
+interface StepDisplayProps {
+  choroplethOn: boolean;
+  onToggleChoropleth: () => void;
+  heatmapOn: boolean;
+  onToggleHeatmap: () => void;
+  palette: PaletteKey;
+  onSetPalette: (p: PaletteKey) => void;
+  countyBoundaries: boolean;
+  onToggleBoundaries: () => void;
+}
+
+const PALETTE_OPTIONS: { key: PaletteKey; label: string }[] = [
+  { key: "default", label: "Default" },
+  { key: "warm", label: "Warm" },
+  { key: "cool", label: "Cool" },
+  { key: "colorblind", label: "Colorblind Safe" },
+];
+
+function Toggle({ enabled, onToggle, label }: { enabled: boolean; onToggle: () => void; label: string }) {
+  return (
+    <button
+      onClick={onToggle}
+      className="flex items-center justify-between w-full py-2"
+    >
+      <span className="text-sm text-on-surface">{label}</span>
+      <div className={`w-10 h-5 rounded-full relative transition-colors ${
+        enabled ? "bg-primary" : "bg-surface-container-high"
+      }`}>
+        <div className={`absolute top-0.5 w-4 h-4 bg-surface-container-lowest rounded-full transition-all ${
+          enabled ? "right-0.5" : "left-0.5"
+        }`} />
+      </div>
+    </button>
+  );
+}
+
+export default function StepDisplay({
+  choroplethOn,
+  onToggleChoropleth,
+  heatmapOn,
+  onToggleHeatmap,
+  palette,
+  onSetPalette,
+  countyBoundaries,
+  onToggleBoundaries,
+}: StepDisplayProps) {
+  const isDark = useIsDark();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-sm font-bold text-on-surface mb-1">Map display settings</h3>
+        <p className="text-[11px] text-on-surface-variant leading-snug">
+          Control how the map looks. At least one of choropleth or heatmap must be on.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <Toggle label="Choropleth (county colors)" enabled={choroplethOn} onToggle={onToggleChoropleth} />
+        <Toggle label="Crash heatmap" enabled={heatmapOn} onToggle={onToggleHeatmap} />
+        <Toggle label="County boundaries" enabled={countyBoundaries} onToggle={onToggleBoundaries} />
+      </div>
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-bold text-on-surface">Color palette</h3>
+        <div className="space-y-2">
+          {PALETTE_OPTIONS.map((p) => {
+            const colors = getPalette(p.key, isDark);
+            return (
+              <button
+                key={p.key}
+                onClick={() => onSetPalette(p.key)}
+                className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all ${
+                  palette === p.key
+                    ? "bg-primary-container"
+                    : "bg-surface-container-high hover:bg-surface-variant"
+                }`}
+              >
+                <div className="flex gap-0.5">
+                  {colors.map((c, i) => (
+                    <div key={i} className="w-5 h-5 rounded-sm" style={{ backgroundColor: c }} />
+                  ))}
+                </div>
+                <span className={`text-xs font-semibold ${
+                  palette === p.key ? "text-on-primary-container" : "text-on-surface-variant"
+                }`}>
+                  {p.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/StepViewBy.tsx
+++ b/frontend/src/components/map/filters/StepViewBy.tsx
@@ -5,14 +5,40 @@ interface StepViewByProps {
   onSetMeasure: (m: MeasureKey) => void;
 }
 
-const MEASURE_LIST: { key: MeasureKey; label: string; description: string }[] = [
-  { key: "crashes_raw", label: "Total Crashes", description: "Raw crash count per county" },
-  { key: "crashes_per_100k", label: "Per 100K Residents", description: "Normalized by population — shows crash rate, not just volume" },
-  { key: "fatalities_per_100k", label: "Fatalities per 100K", description: "Fatal crashes normalized by population" },
-  { key: "injuries_per_100k", label: "Injuries per 100K", description: "Injury crashes normalized by population" },
-  { key: "fatality_rate", label: "Fatality Rate %", description: "What percentage of crashes are fatal" },
-  { key: "crashes_per_income", label: "Per $100K Income", description: "Crash rate relative to median household income" },
+const MEASURE_LIST: { key: MeasureKey; label: string; description: string; group?: string }[] = [
+  { key: "crashes_raw", label: "Total Crashes", description: "Raw crash count per county", group: "Crash Metrics" },
+  { key: "crashes_per_100k", label: "Per 100K Residents", description: "Normalized by population — shows crash rate, not just volume", group: "Crash Metrics" },
+  { key: "fatalities_per_100k", label: "Fatalities per 100K", description: "Fatal crashes normalized by population", group: "Crash Metrics" },
+  { key: "injuries_per_100k", label: "Injuries per 100K", description: "Injury crashes normalized by population", group: "Crash Metrics" },
+  { key: "fatality_rate", label: "Fatality Rate %", description: "What percentage of crashes are fatal", group: "Crash Metrics" },
+  { key: "crashes_per_income", label: "Per $100K Income", description: "Crash rate relative to median household income", group: "Crash Metrics" },
+  { key: "crashes_per_poverty", label: "Crashes per Poverty %", description: "Crash rate weighted by poverty — crashes per 1% poverty per 100K pop", group: "Crash + Demographics" },
+  { key: "poverty_rate", label: "Poverty Rate", description: "Average poverty rate by county", group: "Demographics" },
+  { key: "median_income", label: "Median Income", description: "Median household income by county", group: "Demographics" },
+  { key: "pct_no_vehicle", label: "No Vehicle %", description: "Percentage of households with no vehicle", group: "Demographics" },
+  { key: "pct_bachelors", label: "Bachelor's Degree %", description: "Percentage with bachelor's degree or higher", group: "Demographics" },
+  { key: "pct_65_plus", label: "Age 65+ %", description: "Percentage of population age 65 and older", group: "Demographics" },
 ];
+
+const DEMO_MEASURES: MeasureKey[] = [
+  "poverty_rate", "median_income", "pct_no_vehicle", "pct_bachelors",
+  "crashes_per_poverty", "pct_65_plus", "crashes_per_income",
+];
+
+const PER_CAPITA_MEASURES: MeasureKey[] = [
+  "crashes_per_100k", "fatalities_per_100k", "injuries_per_100k",
+];
+
+function needsDemoInfo(m: MeasureKey): boolean {
+  return PER_CAPITA_MEASURES.includes(m) || DEMO_MEASURES.includes(m);
+}
+
+function demoInfoText(m: MeasureKey): string {
+  if (DEMO_MEASURES.includes(m)) {
+    return "Demographic data available 2005-2023. Counties without data show as hatched.";
+  }
+  return "Population data available 2005-2023. Earlier years show as hatched.";
+}
 
 export default function StepViewBy({ measure, onSetMeasure }: StepViewByProps) {
   return (
@@ -25,33 +51,41 @@ export default function StepViewBy({ measure, onSetMeasure }: StepViewByProps) {
       </div>
 
       <div className="space-y-2">
-        {MEASURE_LIST.map((m) => (
-          <button
-            key={m.key}
-            onClick={() => onSetMeasure(m.key)}
-            className={`w-full text-left px-4 py-3 rounded-xl transition-all ${
-              measure === m.key
-                ? "bg-primary text-on-primary"
-                : "bg-surface-container-high text-on-surface hover:bg-surface-variant"
-            }`}
-          >
-            <p className="text-sm font-semibold">{m.label}</p>
-            <p className={`text-[10px] mt-0.5 ${
-              measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
-            }`}>
-              {m.description}
-            </p>
-          </button>
-        ))}
+        {MEASURE_LIST.map((m, i) => {
+          const prevGroup = i > 0 ? MEASURE_LIST[i - 1].group : undefined;
+          const showHeader = m.group && m.group !== prevGroup;
+          return (
+            <div key={m.key}>
+              {showHeader && (
+                <p className="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant mt-3 mb-1">
+                  {m.group}
+                </p>
+              )}
+              <button
+                onClick={() => onSetMeasure(m.key)}
+                className={`w-full text-left px-4 py-3 rounded-xl transition-all ${
+                  measure === m.key
+                    ? "bg-primary text-on-primary"
+                    : "bg-surface-container-high text-on-surface hover:bg-surface-variant"
+                }`}
+              >
+                <p className="text-sm font-semibold">{m.label}</p>
+                <p className={`text-[10px] mt-0.5 ${
+                  measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
+                }`}>
+                  {m.description}
+                </p>
+              </button>
+            </div>
+          );
+        })}
       </div>
 
-      {(measure === "crashes_per_100k" || measure === "fatalities_per_100k" || measure === "injuries_per_100k" || measure === "crashes_per_income") && (
+      {needsDemoInfo(measure) && (
         <div className="flex items-center gap-2 bg-tertiary-container/30 rounded-lg px-3 py-2">
           <span className="material-symbols-outlined text-[14px] text-tertiary">info</span>
           <p className="text-[10px] text-on-surface-variant">
-            {measure === "crashes_per_income"
-              ? "Income data available 2005-2023. Counties without income data show as hatched."
-              : "Population data available 2005-2023. Earlier years show as hatched."}
+            {demoInfoText(measure)}
           </p>
         </div>
       )}

--- a/frontend/src/components/map/filters/StepViewBy.tsx
+++ b/frontend/src/components/map/filters/StepViewBy.tsx
@@ -1,0 +1,60 @@
+import type { MeasureKey } from "../../../lib/choropleth/measures";
+
+interface StepViewByProps {
+  measure: MeasureKey;
+  onSetMeasure: (m: MeasureKey) => void;
+}
+
+const MEASURE_LIST: { key: MeasureKey; label: string; description: string }[] = [
+  { key: "crashes_raw", label: "Total Crashes", description: "Raw crash count per county" },
+  { key: "crashes_per_100k", label: "Per 100K Residents", description: "Normalized by population — shows crash rate, not just volume" },
+  { key: "fatalities_per_100k", label: "Fatalities per 100K", description: "Fatal crashes normalized by population" },
+  { key: "injuries_per_100k", label: "Injuries per 100K", description: "Injury crashes normalized by population" },
+  { key: "fatality_rate", label: "Fatality Rate %", description: "What percentage of crashes are fatal" },
+  { key: "crashes_per_income", label: "Per $100K Income", description: "Crash rate relative to median household income" },
+];
+
+export default function StepViewBy({ measure, onSetMeasure }: StepViewByProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-bold text-on-surface mb-1">How should the map display data?</h3>
+        <p className="text-[11px] text-on-surface-variant leading-snug">
+          Choose how to color the choropleth map. Per-capita measures normalize by population so small and large counties are comparable.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {MEASURE_LIST.map((m) => (
+          <button
+            key={m.key}
+            onClick={() => onSetMeasure(m.key)}
+            className={`w-full text-left px-4 py-3 rounded-xl transition-all ${
+              measure === m.key
+                ? "bg-primary text-on-primary"
+                : "bg-surface-container-high text-on-surface hover:bg-surface-variant"
+            }`}
+          >
+            <p className="text-sm font-semibold">{m.label}</p>
+            <p className={`text-[10px] mt-0.5 ${
+              measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
+            }`}>
+              {m.description}
+            </p>
+          </button>
+        ))}
+      </div>
+
+      {(measure === "crashes_per_100k" || measure === "fatalities_per_100k" || measure === "injuries_per_100k" || measure === "crashes_per_income") && (
+        <div className="flex items-center gap-2 bg-tertiary-container/30 rounded-lg px-3 py-2">
+          <span className="material-symbols-outlined text-[14px] text-tertiary">info</span>
+          <p className="text-[10px] text-on-surface-variant">
+            {measure === "crashes_per_income"
+              ? "Income data available 2005-2023. Counties without income data show as hatched."
+              : "Population data available 2005-2023. Earlier years show as hatched."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/StepViewBy.tsx
+++ b/frontend/src/components/map/filters/StepViewBy.tsx
@@ -18,6 +18,10 @@ const MEASURE_LIST: { key: MeasureKey; label: string; description: string; group
   { key: "pct_no_vehicle", label: "No Vehicle %", description: "Percentage of households with no vehicle", group: "Demographics" },
   { key: "pct_bachelors", label: "Bachelor's Degree %", description: "Percentage with bachelor's degree or higher", group: "Demographics" },
   { key: "pct_65_plus", label: "Age 65+ %", description: "Percentage of population age 65 and older", group: "Demographics" },
+  { key: "ces_score", label: "CES Composite Score", description: "CalEnviroScreen overall environmental burden score", group: "Environmental" },
+  { key: "pollution_burden", label: "Pollution Burden", description: "CalEnviroScreen pollution burden score", group: "Environmental" },
+  { key: "traffic_score", label: "Traffic Proximity", description: "CalEnviroScreen traffic proximity and volume score", group: "Environmental" },
+  { key: "unemployment_rate", label: "Unemployment Rate", description: "Average unemployment rate across selected period", group: "Economic" },
 ];
 
 const DEMO_MEASURES: MeasureKey[] = [
@@ -25,15 +29,25 @@ const DEMO_MEASURES: MeasureKey[] = [
   "crashes_per_poverty", "pct_65_plus", "crashes_per_income",
 ];
 
+const CONTEXT_MEASURES: MeasureKey[] = [
+  "ces_score", "pollution_burden", "traffic_score", "unemployment_rate",
+];
+
 const PER_CAPITA_MEASURES: MeasureKey[] = [
   "crashes_per_100k", "fatalities_per_100k", "injuries_per_100k",
 ];
 
 function needsDemoInfo(m: MeasureKey): boolean {
-  return PER_CAPITA_MEASURES.includes(m) || DEMO_MEASURES.includes(m);
+  return PER_CAPITA_MEASURES.includes(m) || DEMO_MEASURES.includes(m) || CONTEXT_MEASURES.includes(m);
 }
 
 function demoInfoText(m: MeasureKey): string {
+  if (m === "unemployment_rate") {
+    return "Unemployment data from EDD. Counties without data show as hatched.";
+  }
+  if (CONTEXT_MEASURES.includes(m)) {
+    return "CalEnviroScreen data averaged to county level. Counties without data show as hatched.";
+  }
   if (DEMO_MEASURES.includes(m)) {
     return "Demographic data available 2005-2023. Counties without data show as hatched.";
   }

--- a/frontend/src/components/map/filters/StepWhat.tsx
+++ b/frontend/src/components/map/filters/StepWhat.tsx
@@ -1,0 +1,61 @@
+import { CAUSES, SEVERITIES } from "../../../hooks/useFilterParams";
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import FilterChip from "./FilterChip";
+
+interface StepWhatProps {
+  staged: StagedFilters;
+  onToggleCause: (cause: string) => void;
+  onClearCauses: () => void;
+  onToggleSeverity: (severity: string) => void;
+  onClearSeverities: () => void;
+}
+
+export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggleSeverity, onClearSeverities }: StepWhatProps) {
+  const allCauses = staged.causes.size === 0;
+  const allSeverities = staged.severities.size === 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">What caused the crash?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            The primary factor determined by the reporting officer.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Causes" active={allCauses} onClick={onClearCauses} />
+          {CAUSES.map((cause) => (
+            <FilterChip
+              key={cause.value}
+              label={cause.label}
+              icon={cause.icon}
+              active={!allCauses && staged.causes.has(cause.value)}
+              onClick={() => onToggleCause(cause.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">How severe?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            The worst outcome of the crash.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="All Severities" active={allSeverities} onClick={onClearSeverities} />
+          {SEVERITIES.map((s) => (
+            <FilterChip
+              key={s}
+              label={s}
+              active={!allSeverities && staged.severities.has(s)}
+              onClick={() => onToggleSeverity(s)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/StepWhat.tsx
+++ b/frontend/src/components/map/filters/StepWhat.tsx
@@ -1,4 +1,5 @@
 import { CAUSES, SEVERITIES } from "../../../hooks/useFilterParams";
+import { useCauseCounts, useSeverityCounts, fmtCount } from "../../../hooks/useFilterCounts";
 import type { StagedFilters } from "../../../hooks/useStagedFilters";
 import FilterChip from "./FilterChip";
 
@@ -13,6 +14,8 @@ interface StepWhatProps {
 export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggleSeverity, onClearSeverities }: StepWhatProps) {
   const allCauses = staged.causes.size === 0;
   const allSeverities = staged.severities.size === 0;
+  const { data: causeCounts } = useCauseCounts();
+  const { data: severityCounts } = useSeverityCounts();
 
   return (
     <div className="space-y-6">
@@ -30,6 +33,7 @@ export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggl
               key={cause.value}
               label={cause.label}
               icon={cause.icon}
+              count={causeCounts?.[cause.value] ? fmtCount(causeCounts[cause.value]) : undefined}
               active={!allCauses && staged.causes.has(cause.value)}
               onClick={() => onToggleCause(cause.value)}
             />
@@ -50,6 +54,7 @@ export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggl
             <FilterChip
               key={s}
               label={s}
+              count={severityCounts?.[s] ? fmtCount(severityCounts[s]) : undefined}
               active={!allSeverities && staged.severities.has(s)}
               onClick={() => onToggleSeverity(s)}
             />

--- a/frontend/src/components/map/filters/StepWhat.tsx
+++ b/frontend/src/components/map/filters/StepWhat.tsx
@@ -1,5 +1,4 @@
 import { CAUSES, SEVERITIES } from "../../../hooks/useFilterParams";
-import { useCauseCounts, useSeverityCounts, fmtCount } from "../../../hooks/useFilterCounts";
 import type { StagedFilters } from "../../../hooks/useStagedFilters";
 import FilterChip from "./FilterChip";
 
@@ -9,13 +8,19 @@ interface StepWhatProps {
   onClearCauses: () => void;
   onToggleSeverity: (severity: string) => void;
   onClearSeverities: () => void;
+  causeCounts?: Record<string, number>;
+  severityCounts?: Record<string, number>;
 }
 
-export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggleSeverity, onClearSeverities }: StepWhatProps) {
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
+}
+
+export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggleSeverity, onClearSeverities, causeCounts, severityCounts }: StepWhatProps) {
   const allCauses = staged.causes.size === 0;
   const allSeverities = staged.severities.size === 0;
-  const { data: causeCounts } = useCauseCounts();
-  const { data: severityCounts } = useSeverityCounts();
 
   return (
     <div className="space-y-6">
@@ -28,16 +33,21 @@ export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggl
         </div>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="All Causes" active={allCauses} onClick={onClearCauses} />
-          {CAUSES.map((cause) => (
-            <FilterChip
-              key={cause.value}
-              label={cause.label}
-              icon={cause.icon}
-              count={causeCounts?.[cause.value] ? fmtCount(causeCounts[cause.value]) : undefined}
-              active={!allCauses && staged.causes.has(cause.value)}
-              onClick={() => onToggleCause(cause.value)}
-            />
-          ))}
+          {CAUSES.map((cause) => {
+            const count = causeCounts?.[cause.value];
+            const hasData = count === undefined || count > 0;
+            return (
+              <FilterChip
+                key={cause.value}
+                label={cause.label}
+                icon={cause.icon}
+                count={count != null ? fmtCount(count) : undefined}
+                active={!allCauses && staged.causes.has(cause.value)}
+                disabled={!hasData}
+                onClick={() => onToggleCause(cause.value)}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -50,15 +60,20 @@ export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggl
         </div>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="All Severities" active={allSeverities} onClick={onClearSeverities} />
-          {SEVERITIES.map((s) => (
-            <FilterChip
-              key={s}
-              label={s}
-              count={severityCounts?.[s] ? fmtCount(severityCounts[s]) : undefined}
-              active={!allSeverities && staged.severities.has(s)}
-              onClick={() => onToggleSeverity(s)}
-            />
-          ))}
+          {SEVERITIES.map((s) => {
+            const count = severityCounts?.[s];
+            const hasData = count === undefined || count > 0;
+            return (
+              <FilterChip
+                key={s}
+                label={s}
+                count={count != null ? fmtCount(count) : undefined}
+                active={!allSeverities && staged.severities.has(s)}
+                disabled={!hasData}
+                onClick={() => onToggleSeverity(s)}
+              />
+            );
+          })}
         </div>
       </div>
     </div>

--- a/frontend/src/components/map/filters/StepWhen.tsx
+++ b/frontend/src/components/map/filters/StepWhen.tsx
@@ -1,0 +1,51 @@
+import { YEARS } from "../../../hooks/useFilterParams";
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import FilterChip from "./FilterChip";
+
+interface StepWhenProps {
+  staged: StagedFilters;
+  onToggleYear: (year: number) => void;
+  onSetAllYears: () => void;
+}
+
+export default function StepWhen({ staged, onToggleYear, onSetAllYears }: StepWhenProps) {
+  const allSelected = staged.selectedYears.size === 0;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-bold text-on-surface mb-1">When did it happen?</h3>
+        <p className="text-[11px] text-on-surface-variant leading-snug">
+          Select one or more years. All years shown by default.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <FilterChip label="All Years" active={allSelected} onClick={onSetAllYears} />
+        {[...YEARS].reverse().map((year) => (
+          <FilterChip
+            key={year}
+            label={String(year)}
+            active={!allSelected && staged.selectedYears.has(year)}
+            onClick={() => onToggleYear(year)}
+          />
+        ))}
+      </div>
+
+      {!allSelected && staged.selectedYears.size > 0 && (
+        <p className="text-[11px] text-on-surface-variant">
+          {staged.selectedYears.size} year{staged.selectedYears.size > 1 ? "s" : ""} selected
+        </p>
+      )}
+
+      {(allSelected || [...staged.selectedYears].some((y) => y >= 2016)) && (
+        <div className="flex items-center gap-2 bg-tertiary-container/30 rounded-lg px-3 py-2">
+          <span className="material-symbols-outlined text-[14px] text-tertiary">info</span>
+          <p className="text-[10px] text-on-surface-variant">
+            2016+ years unlock involvement and driver age filters in Step 3.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/map/filters/StepWhen.tsx
+++ b/frontend/src/components/map/filters/StepWhen.tsx
@@ -1,44 +1,117 @@
+import { useState, useRef, useEffect } from "react";
 import { YEARS } from "../../../hooks/useFilterParams";
 import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import type { YearMonth } from "../../../hooks/useFilterParams";
 import FilterChip from "./FilterChip";
+
+const MONTHS = [
+  { value: 1, label: "Jan" }, { value: 2, label: "Feb" }, { value: 3, label: "Mar" },
+  { value: 4, label: "Apr" }, { value: 5, label: "May" }, { value: 6, label: "Jun" },
+  { value: 7, label: "Jul" }, { value: 8, label: "Aug" }, { value: 9, label: "Sep" },
+  { value: 10, label: "Oct" }, { value: 11, label: "Nov" }, { value: 12, label: "Dec" },
+];
 
 interface StepWhenProps {
   staged: StagedFilters;
   onToggleYear: (year: number) => void;
   onSetAllYears: () => void;
+  onSetDateRange?: (start: YearMonth | null, end: YearMonth | null) => void;
 }
 
-export default function StepWhen({ staged, onToggleYear, onSetAllYears }: StepWhenProps) {
-  const allSelected = staged.selectedYears.size === 0;
+export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDateRange }: StepWhenProps) {
+  const usingRange = !!staged.dateRange;
+  const usingYears = staged.selectedYears.size > 0;
+  const allSelected = !usingRange && !usingYears;
+  const [showMonthRange, setShowMonthRange] = useState(usingRange);
+
+  const start = staged.dateRange?.start ?? null;
+  const end = staged.dateRange?.end ?? null;
+
+  const handleToggleYear = (year: number) => {
+    if (onSetDateRange) onSetDateRange(null, null);
+    setShowMonthRange(false);
+    onToggleYear(year);
+  };
+
+  const handleAllYears = () => {
+    onSetAllYears();
+    if (onSetDateRange) onSetDateRange(null, null);
+    setShowMonthRange(false);
+  };
+
+  const handleSetRange = (s: YearMonth | null, e: YearMonth | null) => {
+    if (onSetDateRange) {
+      onSetAllYears();
+      onSetDateRange(s, e);
+    }
+  };
 
   return (
     <div className="space-y-4">
       <div>
         <h3 className="text-sm font-bold text-on-surface mb-1">When did it happen?</h3>
         <p className="text-[11px] text-on-surface-variant leading-snug">
-          Select one or more years. All years shown by default.
+          Select years or use the month range for precision. They don't overlap.
         </p>
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <FilterChip label="All Years" active={allSelected} onClick={onSetAllYears} />
+        <FilterChip label="All Years" active={allSelected} onClick={handleAllYears} />
         {[...YEARS].reverse().map((year) => (
           <FilterChip
             key={year}
             label={String(year)}
-            active={!allSelected && staged.selectedYears.has(year)}
-            onClick={() => onToggleYear(year)}
+            active={usingYears && staged.selectedYears.has(year)}
+            onClick={() => handleToggleYear(year)}
           />
         ))}
       </div>
 
-      {!allSelected && staged.selectedYears.size > 0 && (
+      {usingYears && (
         <p className="text-[11px] text-on-surface-variant">
           {staged.selectedYears.size} year{staged.selectedYears.size > 1 ? "s" : ""} selected
         </p>
       )}
 
-      {(allSelected || [...staged.selectedYears].some((y) => y >= 2016)) && (
+      {usingRange && (
+        <p className="text-[11px] text-primary font-semibold">
+          Using month range — year chips disabled
+        </p>
+      )}
+
+      {onSetDateRange && (
+        <div className="space-y-3">
+          <button
+            onClick={() => setShowMonthRange((v) => !v)}
+            className="text-[11px] font-semibold text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+          >
+            <span className="material-symbols-outlined text-[14px]">
+              {showMonthRange ? "expand_less" : "expand_more"}
+            </span>
+            {showMonthRange ? "Hide month range" : "Set specific month range"}
+          </button>
+
+          {showMonthRange && (
+            <div className="space-y-3 bg-surface-container rounded-xl p-3">
+              <p className="text-[10px] text-on-surface-variant font-semibold uppercase tracking-widest">Month Range</p>
+              <div className="space-y-2">
+                <MonthYearRow label="From" value={start} onChange={(v) => handleSetRange(v, end)} />
+                <MonthYearRow label="To" value={end} onChange={(v) => handleSetRange(start, v)} />
+              </div>
+              {(start || end) && (
+                <button
+                  onClick={handleAllYears}
+                  className="text-[10px] font-semibold text-on-surface-variant hover:text-on-surface"
+                >
+                  Clear range
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {(allSelected || (usingYears && [...staged.selectedYears].some((y) => y >= 2016))) && (
         <div className="flex items-center gap-2 bg-tertiary-container/30 rounded-lg px-3 py-2">
           <span className="material-symbols-outlined text-[14px] text-tertiary">info</span>
           <p className="text-[10px] text-on-surface-variant">
@@ -46,6 +119,100 @@ export default function StepWhen({ staged, onToggleYear, onSetAllYears }: StepWh
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+function InlineSelect({ ariaLabel, value, placeholder, options, onChange }: {
+  ariaLabel: string;
+  value: string;
+  placeholder: string;
+  options: { value: string; label: string }[];
+  onChange: (v: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative flex-1 min-w-0">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-3 py-3 rounded-lg text-sm bg-surface-container-lowest text-on-surface border-none text-left"
+      >
+        <span className={selected ? "text-on-surface" : "text-on-surface-variant"}>
+          {selected?.label ?? placeholder}
+        </span>
+        <span className="material-symbols-outlined text-[14px] text-on-surface-variant ml-1 shrink-0">expand_more</span>
+      </button>
+      {open && (
+        <div className="absolute z-50 left-0 right-0 max-h-40 overflow-y-auto bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15 bottom-full mb-1">
+          <button
+            type="button"
+            onClick={() => { onChange(""); setOpen(false); }}
+            className="w-full px-3 py-2 text-sm text-left text-on-surface-variant hover:bg-surface-container transition-colors"
+          >
+            {placeholder}
+          </button>
+          {options.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => { onChange(o.value); setOpen(false); }}
+              className={`w-full px-3 py-2 text-sm text-left hover:bg-surface-container transition-colors ${
+                o.value === value ? "text-primary font-semibold" : "text-on-surface"
+              }`}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MonthYearRow({ label, value, onChange }: {
+  label: string;
+  value: YearMonth | null;
+  onChange: (v: YearMonth | null) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-10 shrink-0 text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+        {label}
+      </span>
+      <InlineSelect
+        ariaLabel={`${label} month`}
+        value={value?.month?.toString() ?? ""}
+        placeholder="Month"
+        options={MONTHS.map((m) => ({ value: m.value.toString(), label: m.label }))}
+        onChange={(v) => {
+          if (v === "") { onChange(null); return; }
+          onChange({ year: value?.year ?? YEARS[YEARS.length - 1], month: Number(v) });
+        }}
+      />
+      <InlineSelect
+        ariaLabel={`${label} year`}
+        value={value?.year?.toString() ?? ""}
+        placeholder="Year"
+        options={[...YEARS].reverse().map((y) => ({ value: y.toString(), label: y.toString() }))}
+        onChange={(v) => {
+          if (v === "") { onChange(null); return; }
+          onChange({ year: Number(v), month: value?.month ?? 1 });
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/map/filters/StepWhen.tsx
+++ b/frontend/src/components/map/filters/StepWhen.tsx
@@ -16,9 +16,16 @@ interface StepWhenProps {
   onToggleYear: (year: number) => void;
   onSetAllYears: () => void;
   onSetDateRange?: (start: YearMonth | null, end: YearMonth | null) => void;
+  yearCounts?: Record<number, number>;
 }
 
-export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDateRange }: StepWhenProps) {
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
+}
+
+export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDateRange, yearCounts }: StepWhenProps) {
   const usingRange = !!staged.dateRange;
   const usingYears = staged.selectedYears.size > 0;
   const allSelected = !usingRange && !usingYears;
@@ -57,14 +64,20 @@ export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDat
 
       <div className="flex flex-wrap gap-2">
         <FilterChip label="All Years" active={allSelected} onClick={handleAllYears} />
-        {[...YEARS].reverse().map((year) => (
-          <FilterChip
-            key={year}
-            label={String(year)}
-            active={usingYears && staged.selectedYears.has(year)}
-            onClick={() => handleToggleYear(year)}
-          />
-        ))}
+        {[...YEARS].reverse().map((year) => {
+          const count = yearCounts?.[year];
+          const hasData = count === undefined || count > 0;
+          return (
+            <FilterChip
+              key={year}
+              label={String(year)}
+              count={count != null ? fmtCount(count) : undefined}
+              active={usingYears && staged.selectedYears.has(year)}
+              disabled={!hasData}
+              onClick={() => handleToggleYear(year)}
+            />
+          );
+        })}
       </div>
 
       {usingYears && (

--- a/frontend/src/components/map/filters/StepWho.tsx
+++ b/frontend/src/components/map/filters/StepWho.tsx
@@ -28,7 +28,7 @@ export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSe
           </p>
         </div>
         <div className="bg-surface-container rounded-xl px-4 py-6 text-center">
-          <span className="material-symbols-outlined text-[32px] text-on-surface-variant/40 mb-2">lock</span>
+          <span className="material-symbols-outlined text-[32px] text-on-surface-variant/40 block mb-2">info</span>
           <p className="text-sm text-on-surface-variant">
             Select at least one year from 2016 or later in Step 1 to unlock these filters.
           </p>

--- a/frontend/src/components/map/filters/StepWho.tsx
+++ b/frontend/src/components/map/filters/StepWho.tsx
@@ -7,6 +7,13 @@ interface StepWhoProps {
   has2016Plus: boolean;
   onToggleInvolvement: (key: "alcohol" | "distracted" | "pedestrian" | "cyclist" | "drug") => void;
   onSetDriverAge: (bracket: string | null) => void;
+  involvementCounts?: Record<string, number>;
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
 }
 
 const INV_KEYS: Record<string, keyof Pick<StagedFilters, "alcohol" | "distracted" | "pedestrian" | "cyclist" | "drug">> = {
@@ -17,7 +24,7 @@ const INV_KEYS: Record<string, keyof Pick<StagedFilters, "alcohol" | "distracted
   drug: "drug",
 };
 
-export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSetDriverAge }: StepWhoProps) {
+export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSetDriverAge, involvementCounts }: StepWhoProps) {
   if (!has2016Plus) {
     return (
       <div className="space-y-4">
@@ -47,15 +54,20 @@ export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSe
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          {INVOLVEMENTS.map((inv) => (
-            <FilterChip
-              key={inv.value}
-              label={inv.label}
-              icon={inv.icon}
-              active={staged[INV_KEYS[inv.value]]}
-              onClick={() => onToggleInvolvement(INV_KEYS[inv.value])}
-            />
-          ))}
+          {INVOLVEMENTS.map((inv) => {
+            const count = involvementCounts?.[inv.value];
+            return (
+              <FilterChip
+                key={inv.value}
+                label={inv.label}
+                icon={inv.icon}
+                count={count != null ? fmtCount(count) : undefined}
+                active={staged[INV_KEYS[inv.value]]}
+                disabled={count != null && count === 0}
+                onClick={() => onToggleInvolvement(INV_KEYS[inv.value])}
+              />
+            );
+          })}
         </div>
       </div>
 

--- a/frontend/src/components/map/filters/StepWho.tsx
+++ b/frontend/src/components/map/filters/StepWho.tsx
@@ -1,0 +1,90 @@
+import { INVOLVEMENTS, DRIVER_AGE_BRACKETS } from "../../../hooks/useFilterParams";
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
+import FilterChip from "./FilterChip";
+
+interface StepWhoProps {
+  staged: StagedFilters;
+  has2016Plus: boolean;
+  onToggleInvolvement: (key: "alcohol" | "distracted" | "pedestrian" | "cyclist" | "drug") => void;
+  onSetDriverAge: (bracket: string | null) => void;
+}
+
+const INV_KEYS: Record<string, keyof Pick<StagedFilters, "alcohol" | "distracted" | "pedestrian" | "cyclist" | "drug">> = {
+  alcohol: "alcohol",
+  distracted: "distracted",
+  pedestrian: "pedestrian",
+  cyclist: "cyclist",
+  drug: "drug",
+};
+
+export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSetDriverAge }: StepWhoProps) {
+  if (!has2016Plus) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">Who was involved?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Involvement and driver age data is only available for 2016+ crashes (CCRS).
+          </p>
+        </div>
+        <div className="bg-surface-container rounded-xl px-4 py-6 text-center">
+          <span className="material-symbols-outlined text-[32px] text-on-surface-variant/40 mb-2">lock</span>
+          <p className="text-sm text-on-surface-variant">
+            Select at least one year from 2016 or later in Step 1 to unlock these filters.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">Who was involved?</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Whether a specific party type was present, regardless of who was at fault. Multiple can be selected.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {INVOLVEMENTS.map((inv) => (
+            <FilterChip
+              key={inv.value}
+              label={inv.label}
+              icon={inv.icon}
+              active={staged[INV_KEYS[inv.value]]}
+              onClick={() => onToggleInvolvement(INV_KEYS[inv.value])}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-sm font-bold text-on-surface mb-1">At-fault driver age</h3>
+          <p className="text-[11px] text-on-surface-variant leading-snug">
+            Age of the driver determined to be at fault. One bracket at a time.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <FilterChip label="Any Age" active={staged.driverAge === null} onClick={() => onSetDriverAge(null)} />
+          {DRIVER_AGE_BRACKETS.map((b) => (
+            <FilterChip
+              key={b.value}
+              label={b.label}
+              active={staged.driverAge === b.value}
+              onClick={() => onSetDriverAge(staged.driverAge === b.value ? null : b.value)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 bg-tertiary-container/30 rounded-lg px-3 py-2">
+        <span className="material-symbols-outlined text-[14px] text-tertiary">info</span>
+        <p className="text-[10px] text-on-surface-variant">
+          These filters use 2016+ CCRS data only. Pre-2016 crashes (SWITRS) don't have party-level details.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useChoroplethData.ts
+++ b/frontend/src/hooks/useChoroplethData.ts
@@ -2,11 +2,14 @@ import { useMemo } from "react";
 import { useQueries } from "@tanstack/react-query";
 import {
   computeMeasureValue,
+  MEASURES,
+  type ContextValues,
   type CountyStats,
   type CountyYearDemo,
   type MeasureKey,
   type MeasureResult,
 } from "../lib/choropleth/measures";
+import type { CalEnviroScreenData, UnemploymentData } from "./useContextData";
 import {
   CA_COUNTIES,
   SEVERITIES,
@@ -164,13 +167,38 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
           return res.json();
         },
       },
+      {
+        queryKey: ["calenviroscreen"],
+        staleTime: Infinity,
+        enabled: MEASURES[measure]?.kind === "context" && measure !== "unemployment_rate",
+        queryFn: async (): Promise<CalEnviroScreenData[]> => {
+          const res = await fetch(`${API_BASE}/api/calenviroscreen`);
+          if (!res.ok) throw new Error(`calenviroscreen ${res.status}`);
+          return res.json();
+        },
+      },
+      {
+        queryKey: ["unemployment", dateKey],
+        staleTime: 5 * 60 * 1000,
+        enabled: measure === "unemployment_rate",
+        queryFn: async (): Promise<UnemploymentData[]> => {
+          const p = new URLSearchParams();
+          appendDateRange(p, filters.dateRange);
+          const qs = p.toString();
+          const res = await fetch(`${API_BASE}/api/unemployment${qs ? `?${qs}` : ""}`);
+          if (!res.ok) throw new Error(`unemployment ${res.status}`);
+          return res.json();
+        },
+      },
     ],
   });
 
-  const [statsQ, demoQ, yearStatsQ] = queries;
+  const [statsQ, demoQ, yearStatsQ, cesQ, unempQ] = queries;
   const stats = statsQ.data;
   const demos = demoQ.data;
   const yearStats = yearStatsQ.data;
+  const cesData = cesQ.data as CalEnviroScreenData[] | undefined;
+  const unempData = unempQ.data as UnemploymentData[] | undefined;
 
   const { byCountyCode, nameToCode } = useMemo(() => {
     if (!stats) return { byCountyCode: {} as Record<number, ChoroplethPoint>, nameToCode: {} as Record<string, number> };
@@ -180,15 +208,50 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
       arr.push(d);
       demoByCounty.set(d.county_code, arr);
     }
+
+    // Build context lookup maps for external datasets.
+    const cesByCounty = new Map<number, CalEnviroScreenData>();
+    for (const row of cesData ?? []) {
+      cesByCounty.set(row.county_code, row);
+    }
+
+    // Average unemployment rate per county across available months.
+    const unempByCounty = new Map<number, number>();
+    if (unempData && unempData.length > 0) {
+      const accum = new Map<number, { sum: number; count: number }>();
+      for (const row of unempData) {
+        if (row.unemployment_rate == null) continue;
+        const prev = accum.get(row.county_code) ?? { sum: 0, count: 0 };
+        prev.sum += row.unemployment_rate;
+        prev.count += 1;
+        accum.set(row.county_code, prev);
+      }
+      for (const [code, { sum, count }] of accum) {
+        unempByCounty.set(code, sum / count);
+      }
+    }
+
     const out: Record<number, ChoroplethPoint> = {};
     const ntc: Record<string, number> = {};
     for (const s of stats) {
-      const result = computeMeasureValue(measure, s, demoByCounty.get(s.county_code) ?? []);
+      // Build context values for this county.
+      const ctx: ContextValues = {};
+      const ces = cesByCounty.get(s.county_code);
+      if (ces) {
+        ctx.ces_score = ces.ces_score;
+        ctx.pollution_burden = ces.pollution_burden;
+        ctx.traffic_score = ces.traffic_score;
+      }
+      if (unempByCounty.has(s.county_code)) {
+        ctx.unemployment_rate = unempByCounty.get(s.county_code)!;
+      }
+
+      const result = computeMeasureValue(measure, s, demoByCounty.get(s.county_code) ?? [], { context: ctx });
       out[s.county_code] = { ...result, rawCount: s.crash_count, totalKilled: s.total_killed, totalInjured: s.total_injured };
       ntc[s.county_name] = s.county_code;
     }
     return { byCountyCode: out, nameToCode: ntc };
-  }, [stats, demos, measure]);
+  }, [stats, demos, measure, cesData, unempData]);
 
   const dataSummary = useMemo<DataSummary>(() => {
     const totalCrashes = yearStats?.reduce((s, r) => s + r.crash_count, 0) ?? 0;
@@ -221,13 +284,13 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
     return { totalCrashes, missingDemoYears, partialDemoYears, sparseYears };
   }, [filters.dateRange, demos, yearStats]);
 
-  const rawError = (statsQ.error ?? demoQ.error ?? yearStatsQ.error) as (Error & { status?: number }) | null;
+  const rawError = (statsQ.error ?? demoQ.error ?? yearStatsQ.error ?? cesQ.error ?? unempQ.error) as (Error & { status?: number }) | null;
 
   return {
     byCountyCode,
     nameToCode,
-    isLoading: statsQ.isLoading || demoQ.isLoading || yearStatsQ.isLoading,
-    isError: statsQ.isError || demoQ.isError,
+    isLoading: statsQ.isLoading || demoQ.isLoading || yearStatsQ.isLoading || cesQ.isLoading || unempQ.isLoading,
+    isError: statsQ.isError || demoQ.isError || cesQ.isError || unempQ.isError,
     is422: rawError?.status === 422,
     error: rawError,
     demographicsAvailable: !demoQ.isError && (demos?.length ?? 0) > 0,

--- a/frontend/src/hooks/useContextData.ts
+++ b/frontend/src/hooks/useContextData.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+export interface CalEnviroScreenData {
+  county_code: number;
+  ces_score: number | null;
+  ces_percentile: number | null;
+  pollution_burden: number | null;
+  traffic_score: number | null;
+  poverty_pct: number | null;
+}
+
+export interface UnemploymentData {
+  county_code: number;
+  year: number;
+  month: number;
+  unemployment_rate: number | null;
+}
+
+export function useCalEnviroScreen() {
+  return useQuery<CalEnviroScreenData[]>({
+    queryKey: ["calenviroscreen"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/calenviroscreen`);
+      if (!res.ok) throw new Error(`calenviroscreen ${res.status}`);
+      return res.json();
+    },
+    staleTime: Infinity,
+  });
+}
+
+export function useUnemployment(year?: number) {
+  return useQuery<UnemploymentData[]>({
+    queryKey: ["unemployment", year],
+    queryFn: async () => {
+      const params = year ? `?year=${year}` : "";
+      const res = await fetch(`${API_BASE}/api/unemployment${params}`);
+      if (!res.ok) throw new Error(`unemployment ${res.status}`);
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/useFacetCounts.ts
+++ b/frontend/src/hooks/useFacetCounts.ts
@@ -114,7 +114,24 @@ export function useFacetCounts(staged: StagedFilters): FacetCounts {
       if (timerRef.current) clearTimeout(timerRef.current);
       if (abortRef.current) abortRef.current.abort();
     };
-  }, [staged]);
+  }, [
+    staged.selectedYears.size,
+    [...staged.selectedYears].join(","),
+    staged.severities.size,
+    [...staged.severities].join(","),
+    staged.causes.size,
+    [...staged.causes].join(","),
+    staged.alcohol,
+    staged.distracted,
+    staged.pedestrian,
+    staged.cyclist,
+    staged.drug,
+    staged.driverAge,
+    staged.dateRange?.start?.year,
+    staged.dateRange?.start?.month,
+    staged.dateRange?.end?.year,
+    staged.dateRange?.end?.month,
+  ]);
 
   return counts;
 }

--- a/frontend/src/hooks/useFacetCounts.ts
+++ b/frontend/src/hooks/useFacetCounts.ts
@@ -92,7 +92,11 @@ export function useFacetCounts(staged: StagedFilters): FacetCounts {
         for (const r of sevData) severities[r.severity] = r.crash_count;
 
         const causes: Record<string, number> = {};
-        for (const r of causeData) causes[r.canonical_cause] = r.crash_count;
+        for (const r of causeData) {
+          const slug = (r.canonical_cause ?? "").replace(/_/g, "-");
+          causes[slug] = r.crash_count;
+          causes[r.canonical_cause] = r.crash_count;
+        }
 
         const involvement: Record<string, number> = {
           alcohol: alcCount,

--- a/frontend/src/hooks/useFacetCounts.ts
+++ b/frontend/src/hooks/useFacetCounts.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState, useRef } from "react";
+import { API_BASE } from "../config";
+import type { StagedFilters } from "./useStagedFilters";
+
+export interface FacetCounts {
+  years: Record<number, number>;
+  severities: Record<string, number>;
+  causes: Record<string, number>;
+  involvement: Record<string, number>;
+  loading: boolean;
+}
+
+function buildParams(staged: StagedFilters, exclude: string): string {
+  const p = new URLSearchParams();
+
+  if (exclude !== "year" && staged.selectedYears.size > 0) {
+    const years = [...staged.selectedYears].sort();
+    p.set("start", `${years[0]}-01`);
+    p.set("end", `${years[years.length - 1]}-12`);
+  }
+  if (exclude !== "severity" && staged.severities.size > 0) {
+    p.set("severity", [...staged.severities].map((s) => s.toLowerCase().replace(/ /g, "-")).join(","));
+  }
+  if (exclude !== "cause" && staged.causes.size > 0) {
+    p.set("cause", [...staged.causes].join(","));
+  }
+  if (exclude !== "alcohol" && staged.alcohol) p.set("alcohol", "true");
+  if (exclude !== "distracted" && staged.distracted) p.set("distracted", "true");
+  if (exclude !== "pedestrian" && staged.pedestrian) p.set("pedestrian", "true");
+  if (exclude !== "cyclist" && staged.cyclist) p.set("cyclist", "true");
+  if (exclude !== "drug" && staged.drug) p.set("drug", "true");
+  if (exclude !== "driverAge" && staged.driverAge) p.set("driver_age", staged.driverAge);
+
+  return p.toString();
+}
+
+async function fetchCount(url: string, signal: AbortSignal): Promise<number> {
+  try {
+    const r = await fetch(url, { signal });
+    if (!r.ok) return 0;
+    const data = await r.json();
+    return data.total_crashes ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function useFacetCounts(staged: StagedFilters): FacetCounts {
+  const [counts, setCounts] = useState<FacetCounts>({
+    years: {},
+    severities: {},
+    causes: {},
+    involvement: {},
+    loading: false,
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    timerRef.current = setTimeout(() => {
+      const abort = new AbortController();
+      abortRef.current = abort;
+      setCounts((prev) => ({ ...prev, loading: true }));
+
+      const yearParams = buildParams(staged, "year");
+      const sevParams = buildParams(staged, "severity");
+      const causeParams = buildParams(staged, "cause");
+      const baseParams = buildParams(staged, "");
+
+      Promise.all([
+        fetch(`${API_BASE}/api/stats?group_by=year&${yearParams}`, { signal: abort.signal })
+          .then((r) => r.ok ? r.json() : []).catch(() => []),
+        fetch(`${API_BASE}/api/stats?group_by=severity&${sevParams}`, { signal: abort.signal })
+          .then((r) => r.ok ? r.json() : []).catch(() => []),
+        fetch(`${API_BASE}/api/stats?group_by=cause&${causeParams}`, { signal: abort.signal })
+          .then((r) => r.ok ? r.json() : []).catch(() => []),
+        fetchCount(`${API_BASE}/api/stats?${baseParams}&alcohol=true`, abort.signal),
+        fetchCount(`${API_BASE}/api/stats?${baseParams}&distracted=true`, abort.signal),
+        fetchCount(`${API_BASE}/api/stats?${baseParams}&pedestrian=true`, abort.signal),
+        fetchCount(`${API_BASE}/api/stats?${baseParams}&cyclist=true`, abort.signal),
+        fetchCount(`${API_BASE}/api/stats?${baseParams}&drug=true`, abort.signal),
+      ]).then(([yearData, sevData, causeData, alcCount, distCount, pedCount, cycCount, drugCount]) => {
+        if (abort.signal.aborted) return;
+
+        const years: Record<number, number> = {};
+        for (const r of yearData) years[r.year] = r.crash_count;
+
+        const severities: Record<string, number> = {};
+        for (const r of sevData) severities[r.severity] = r.crash_count;
+
+        const causes: Record<string, number> = {};
+        for (const r of causeData) causes[r.canonical_cause] = r.crash_count;
+
+        const involvement: Record<string, number> = {
+          alcohol: alcCount,
+          distracted: distCount,
+          pedestrian: pedCount,
+          cyclist: cycCount,
+          drug: drugCount,
+        };
+
+        setCounts({ years, severities, causes, involvement, loading: false });
+      });
+    }, 300);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [staged]);
+
+  return counts;
+}

--- a/frontend/src/hooks/useFilterCounts.ts
+++ b/frontend/src/hooks/useFilterCounts.ts
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+interface CauseCount {
+  canonical_cause: string;
+  crash_count: number;
+}
+
+interface SeverityCount {
+  severity: string;
+  crash_count: number;
+}
+
+export function useCauseCounts() {
+  return useQuery<Record<string, number>>({
+    queryKey: ["filter-counts", "cause"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/stats?group_by=cause`);
+      if (!res.ok) return {};
+      const data: CauseCount[] = await res.json();
+      const map: Record<string, number> = {};
+      for (const d of data) {
+        map[d.canonical_cause] = d.crash_count;
+      }
+      return map;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useSeverityCounts() {
+  return useQuery<Record<string, number>>({
+    queryKey: ["filter-counts", "severity"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/stats?group_by=severity`);
+      if (!res.ok) return {};
+      const data: SeverityCount[] = await res.json();
+      const map: Record<string, number> = {};
+      for (const d of data) {
+        map[d.severity] = d.crash_count;
+      }
+      return map;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
+}

--- a/frontend/src/hooks/useFilterParams.ts
+++ b/frontend/src/hooks/useFilterParams.ts
@@ -47,7 +47,7 @@ export const CAUSES = [
   { value: "turning", label: "Improper Turn", icon: "turn_right" },
   { value: "following-too-close", label: "Tailgating", icon: "car_crash" },
   { value: "signal-violation", label: "Signal Violation", icon: "traffic" },
-  { value: "pedestrian-violation", label: "Pedestrian", icon: "directions_walk" },
+  { value: "pedestrian-violation", label: "Ped. Violation", icon: "directions_walk" },
   { value: "unsafe-backing", label: "Unsafe Backing", icon: "keyboard_return" },
   { value: "other", label: "Other", icon: "more_horiz" },
 ] as const;
@@ -58,7 +58,7 @@ export const CAUSES = [
 export const INVOLVEMENTS = [
   { value: "alcohol", label: "Alcohol", icon: "local_bar" },
   { value: "distracted", label: "Distracted", icon: "phonelink_ring" },
-  { value: "pedestrian", label: "Pedestrian", icon: "directions_walk" },
+  { value: "pedestrian", label: "Ped. Involved", icon: "directions_walk" },
   { value: "cyclist", label: "Cyclist", icon: "pedal_bike" },
   { value: "drug", label: "Drug-Involved", icon: "medication" },
 ] as const;

--- a/frontend/src/hooks/useFilterParams.ts
+++ b/frontend/src/hooks/useFilterParams.ts
@@ -458,6 +458,44 @@ export function useFilterParams() {
     }, { replace: true });
   }, [setSearchParams]);
 
+  const setAllFilters = useCallback((overrides: {
+    start?: { year: number; month: number } | null;
+    end?: { year: number; month: number } | null;
+    severities?: Set<string>;
+    causes?: Set<string>;
+    alcohol?: boolean;
+    distracted?: boolean;
+    pedestrian?: boolean;
+    cyclist?: boolean;
+    drug?: boolean;
+    driverAge?: string | null;
+  }) => {
+    setSearchParams((prev) => {
+      const params = buildNextParams(prev, {
+        severities: overrides.severities ?? new Set(),
+        causes: overrides.causes ?? new Set(),
+        alcohol: overrides.alcohol ?? false,
+        distracted: overrides.distracted ?? false,
+        pedestrian: overrides.pedestrian ?? false,
+        cyclist: overrides.cyclist ?? false,
+        drug: overrides.drug ?? false,
+        driverAge: overrides.driverAge ?? null,
+      });
+      if (overrides.start) {
+        params.set("start", formatYearMonth(overrides.start));
+      } else {
+        params.delete("start");
+      }
+      if (overrides.end) {
+        params.set("end", formatYearMonth(overrides.end));
+      } else {
+        params.delete("end");
+      }
+      params.delete("year");
+      return params;
+    }, { replace: true });
+  }, [setSearchParams]);
+
   const clearPanel = useCallback(() => {
     setSearchParams((prev) => {
       prev.delete("panel");
@@ -497,6 +535,7 @@ export function useFilterParams() {
     toggleDrug,
     setDriverAge,
     clearFilters,
+    setAllFilters,
     panel,
     clearPanel,
   };

--- a/frontend/src/hooks/useLayersState.tsx
+++ b/frontend/src/hooks/useLayersState.tsx
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import { DEFAULT_MEASURE, MEASURES, type MeasureKey } from "../lib/choropleth/measures";
 import { PALETTES, type PaletteKey } from "../lib/choropleth/palettes";
 
-export type OtherLayerKey = "heatmapStatewide" | "heatmapCounty" | "coordMismatches" | "coordIncludeRivers" | "incidents" | "countyBoundaries" | "roadTypes" | "schoolZones" | "hospitals";
+export type OtherLayerKey = "heatmapStatewide" | "heatmapCounty" | "coordMismatches" | "coordIncludeRivers" | "incidents" | "countyBoundaries" | "roadTypes" | "schools" | "hospitals";
 export type HeatmapResolution = "raw" | "low" | "medium" | "high";
 
 const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
@@ -13,7 +13,7 @@ const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
   incidents: false,
   countyBoundaries: true,
   roadTypes: false,
-  schoolZones: false,
+  schools: false,
   hospitals: false,
 };
 

--- a/frontend/src/hooks/useLiveCrashCount.ts
+++ b/frontend/src/hooks/useLiveCrashCount.ts
@@ -1,0 +1,62 @@
+import { useState, useEffect, useRef } from "react";
+import { API_BASE } from "../config";
+import type { StagedFilters } from "./useStagedFilters";
+
+function buildCountUrl(staged: StagedFilters): string {
+  const p = new URLSearchParams();
+  if (staged.selectedYears.size > 0) {
+    const years = [...staged.selectedYears].sort();
+    p.set("start", `${years[0]}-01`);
+    p.set("end", `${years[years.length - 1]}-12`);
+  }
+  if (staged.severities.size > 0) {
+    p.set("severity", [...staged.severities].map((s) => s.toLowerCase().replace(/ /g, "-")).join(","));
+  }
+  if (staged.causes.size > 0) {
+    p.set("cause", [...staged.causes].join(","));
+  }
+  if (staged.alcohol) p.set("alcohol", "true");
+  if (staged.distracted) p.set("distracted", "true");
+  if (staged.pedestrian) p.set("pedestrian", "true");
+  if (staged.cyclist) p.set("cyclist", "true");
+  if (staged.drug) p.set("drug", "true");
+  if (staged.driverAge) p.set("driver_age", staged.driverAge);
+  return `${API_BASE}/api/stats?${p}`;
+}
+
+export function useLiveCrashCount(staged: StagedFilters) {
+  const [count, setCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    timerRef.current = setTimeout(() => {
+      const abort = new AbortController();
+      abortRef.current = abort;
+      setLoading(true);
+
+      fetch(buildCountUrl(staged), { signal: abort.signal })
+        .then((r) => r.json())
+        .then((data) => {
+          if (!abort.signal.aborted) {
+            setCount(data.total_crashes ?? 0);
+            setLoading(false);
+          }
+        })
+        .catch(() => {
+          if (!abort.signal.aborted) setLoading(false);
+        });
+    }, 500);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [staged]);
+
+  return { count, loading };
+}

--- a/frontend/src/hooks/useLiveCrashCount.ts
+++ b/frontend/src/hooks/useLiveCrashCount.ts
@@ -56,7 +56,24 @@ export function useLiveCrashCount(staged: StagedFilters) {
       if (timerRef.current) clearTimeout(timerRef.current);
       if (abortRef.current) abortRef.current.abort();
     };
-  }, [staged]);
+  }, [
+    staged.selectedYears.size,
+    [...staged.selectedYears].join(","),
+    staged.severities.size,
+    [...staged.severities].join(","),
+    staged.causes.size,
+    [...staged.causes].join(","),
+    staged.alcohol,
+    staged.distracted,
+    staged.pedestrian,
+    staged.cyclist,
+    staged.drug,
+    staged.driverAge,
+    staged.dateRange?.start?.year,
+    staged.dateRange?.start?.month,
+    staged.dateRange?.end?.year,
+    staged.dateRange?.end?.month,
+  ]);
 
   return { count, loading };
 }

--- a/frontend/src/hooks/useMapOverlays.ts
+++ b/frontend/src/hooks/useMapOverlays.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+export interface Hospital {
+  facility_id: string;
+  facility_name: string;
+  facility_type: string;
+  county_code: number;
+  city: string;
+  latitude: number | null;
+  longitude: number | null;
+  trauma_center: string | null;
+  status: string | null;
+}
+
+export interface School {
+  cds_code: string;
+  school_name: string;
+  county_code: number;
+  city: string;
+  latitude: number | null;
+  longitude: number | null;
+  school_type: string | null;
+  status: string | null;
+}
+
+export function useHospitals(enabled: boolean) {
+  return useQuery<Hospital[]>({
+    queryKey: ["hospitals"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/hospitals`);
+      if (!res.ok) throw new Error(`hospitals ${res.status}`);
+      return res.json();
+    },
+    enabled,
+    staleTime: Infinity,
+  });
+}
+
+export function useSchools(enabled: boolean) {
+  return useQuery<School[]>({
+    queryKey: ["schools"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/schools`);
+      if (!res.ok) throw new Error(`schools ${res.status}`);
+      return res.json();
+    },
+    enabled,
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/hooks/usePrefetchFacets.ts
+++ b/frontend/src/hooks/usePrefetchFacets.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+export function usePrefetchFacets() {
+  useQuery({
+    queryKey: ["prefetch-facets", "year"],
+    queryFn: () => fetch(`${API_BASE}/api/stats?group_by=year`).then((r) => r.json()),
+    staleTime: 10 * 60 * 1000,
+  });
+  useQuery({
+    queryKey: ["prefetch-facets", "severity"],
+    queryFn: () => fetch(`${API_BASE}/api/stats?group_by=severity`).then((r) => r.json()),
+    staleTime: 10 * 60 * 1000,
+  });
+  useQuery({
+    queryKey: ["prefetch-facets", "cause"],
+    queryFn: () => fetch(`${API_BASE}/api/stats?group_by=cause`).then((r) => r.json()),
+    staleTime: 10 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/usePresetCounts.ts
+++ b/frontend/src/hooks/usePresetCounts.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+interface PresetCount {
+  label: string;
+  url: string;
+}
+
+const PRESET_QUERIES: PresetCount[] = [
+  { label: "Fatal DUI Crashes", url: "/api/stats?cause=dui&severity=fatal" },
+  { label: "Pedestrian Safety", url: "/api/stats?pedestrian=true" },
+  { label: "Teen Drivers", url: "/api/stats?driver_age=16-21" },
+  { label: "Senior Drivers", url: "/api/stats?driver_age=65%2B" },
+  { label: "Cyclist Crashes", url: "/api/stats?cyclist=true" },
+  { label: "Fatal Crashes Only", url: "/api/stats?severity=fatal" },
+];
+
+async function fetchAllCounts(): Promise<Record<string, number>> {
+  const results: Record<string, number> = {};
+  const responses = await Promise.all(
+    PRESET_QUERIES.map((p) =>
+      fetch(`${API_BASE}${p.url}`)
+        .then((r) => r.ok ? r.json() : null)
+        .then((data) => ({ label: p.label, total: data?.total_crashes ?? 0 }))
+        .catch(() => ({ label: p.label, total: 0 }))
+    )
+  );
+  for (const r of responses) {
+    results[r.label] = r.total;
+  }
+  return results;
+}
+
+export function usePresetCounts() {
+  return useQuery<Record<string, number>>({
+    queryKey: ["preset-counts"],
+    queryFn: fetchAllCounts,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/hooks/useStagedFilters.ts
+++ b/frontend/src/hooks/useStagedFilters.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { DateRangeFilter } from "./useFilterParams";
 
 export interface StagedFilters {
@@ -29,6 +29,14 @@ const EMPTY: StagedFilters = {
 
 export function useStagedFilters(initial: StagedFilters) {
   const [staged, setStaged] = useState<StagedFilters>(initial);
+  const prevInitialRef = useRef(initial);
+
+  useEffect(() => {
+    if (prevInitialRef.current !== initial) {
+      setStaged(initial);
+      prevInitialRef.current = initial;
+    }
+  }, [initial]);
 
   const toggleYear = useCallback((year: number) => {
     setStaged((prev) => {
@@ -73,6 +81,13 @@ export function useStagedFilters(initial: StagedFilters) {
     setStaged((prev) => ({ ...prev, [key]: !prev[key] }));
   }, []);
 
+  const setDateRange = useCallback((start: { year: number; month: number } | null, end: { year: number; month: number } | null) => {
+    setStaged((prev) => ({
+      ...prev,
+      dateRange: start || end ? { start, end } : null,
+    }));
+  }, []);
+
   const setDriverAge = useCallback((bracket: string | null) => {
     setStaged((prev) => ({ ...prev, driverAge: bracket }));
   }, []);
@@ -92,8 +107,14 @@ export function useStagedFilters(initial: StagedFilters) {
     || staged.alcohol || staged.distracted || staged.pedestrian
     || staged.cyclist || staged.drug || staged.driverAge !== null;
 
-  const has2016Plus = staged.selectedYears.size === 0
-    || [...staged.selectedYears].some((y) => y >= 2016);
+  const has2016Plus = (() => {
+    if (staged.dateRange) {
+      const endYear = staged.dateRange.end?.year ?? new Date().getFullYear();
+      return endYear >= 2016;
+    }
+    if (staged.selectedYears.size === 0) return true;
+    return [...staged.selectedYears].some((y) => y >= 2016);
+  })();
 
   return {
     staged,
@@ -104,6 +125,7 @@ export function useStagedFilters(initial: StagedFilters) {
     toggleCause,
     clearCauses,
     toggleInvolvement,
+    setDateRange,
     setDriverAge,
     clearAll,
     reset,

--- a/frontend/src/hooks/useStagedFilters.ts
+++ b/frontend/src/hooks/useStagedFilters.ts
@@ -1,0 +1,113 @@
+import { useState, useCallback } from "react";
+import type { DateRangeFilter } from "./useFilterParams";
+
+export interface StagedFilters {
+  selectedYears: Set<number>;
+  dateRange: DateRangeFilter | null;
+  severities: Set<string>;
+  causes: Set<string>;
+  alcohol: boolean;
+  distracted: boolean;
+  pedestrian: boolean;
+  cyclist: boolean;
+  drug: boolean;
+  driverAge: string | null;
+}
+
+const EMPTY: StagedFilters = {
+  selectedYears: new Set(),
+  dateRange: null,
+  severities: new Set(),
+  causes: new Set(),
+  alcohol: false,
+  distracted: false,
+  pedestrian: false,
+  cyclist: false,
+  drug: false,
+  driverAge: null,
+};
+
+export function useStagedFilters(initial: StagedFilters) {
+  const [staged, setStaged] = useState<StagedFilters>(initial);
+
+  const toggleYear = useCallback((year: number) => {
+    setStaged((prev) => {
+      const next = new Set(prev.selectedYears);
+      if (next.has(year)) next.delete(year);
+      else next.add(year);
+      return { ...prev, selectedYears: next };
+    });
+  }, []);
+
+  const setAllYears = useCallback(() => {
+    setStaged((prev) => ({ ...prev, selectedYears: new Set() }));
+  }, []);
+
+  const toggleSeverity = useCallback((s: string) => {
+    setStaged((prev) => {
+      const next = new Set(prev.severities);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return { ...prev, severities: next };
+    });
+  }, []);
+
+  const clearSeverities = useCallback(() => {
+    setStaged((prev) => ({ ...prev, severities: new Set() }));
+  }, []);
+
+  const toggleCause = useCallback((c: string) => {
+    setStaged((prev) => {
+      const next = new Set(prev.causes);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return { ...prev, causes: next };
+    });
+  }, []);
+
+  const clearCauses = useCallback(() => {
+    setStaged((prev) => ({ ...prev, causes: new Set() }));
+  }, []);
+
+  const toggleInvolvement = useCallback((key: keyof Pick<StagedFilters, "alcohol" | "distracted" | "pedestrian" | "cyclist" | "drug">) => {
+    setStaged((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const setDriverAge = useCallback((bracket: string | null) => {
+    setStaged((prev) => ({ ...prev, driverAge: bracket }));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setStaged(EMPTY);
+  }, []);
+
+  const reset = useCallback((to: StagedFilters) => {
+    setStaged(to);
+  }, []);
+
+  const hasAnyFilter = staged.selectedYears.size > 0
+    || staged.dateRange !== null
+    || staged.severities.size > 0
+    || staged.causes.size > 0
+    || staged.alcohol || staged.distracted || staged.pedestrian
+    || staged.cyclist || staged.drug || staged.driverAge !== null;
+
+  const has2016Plus = staged.selectedYears.size === 0
+    || [...staged.selectedYears].some((y) => y >= 2016);
+
+  return {
+    staged,
+    toggleYear,
+    setAllYears,
+    toggleSeverity,
+    clearSeverities,
+    toggleCause,
+    clearCauses,
+    toggleInvolvement,
+    setDriverAge,
+    clearAll,
+    reset,
+    hasAnyFilter,
+    has2016Plus,
+  };
+}

--- a/frontend/src/lib/choropleth/measures.test.ts
+++ b/frontend/src/lib/choropleth/measures.test.ts
@@ -68,9 +68,9 @@ describe("computeMeasureValue", () => {
     expect(MIN_CRASHES_FOR_RATE).toBe(5);
   });
 
-  it("MEASURES exposes 6 measures including default", () => {
+  it("MEASURES exposes 16 measures including default", () => {
     const keys: MeasureKey[] = Object.keys(MEASURES) as MeasureKey[];
-    expect(keys).toHaveLength(6);
+    expect(keys).toHaveLength(16);
     expect(keys).toContain("crashes_per_100k");
     expect(keys).toContain("crashes_per_income");
   });

--- a/frontend/src/lib/choropleth/measures.ts
+++ b/frontend/src/lib/choropleth/measures.ts
@@ -16,13 +16,19 @@ export type MeasureKey =
   | "pct_no_vehicle"
   | "pct_bachelors"
   | "crashes_per_poverty"
-  | "pct_65_plus";
+  | "pct_65_plus"
+  | "ces_score"
+  | "pollution_burden"
+  | "traffic_score"
+  | "unemployment_rate";
 
 export type Measure = {
   key: MeasureKey;
   label: string;
-  /** "perCapita" needs demographics; "raw" and "rate" do not. */
-  kind: "perCapita" | "raw" | "rate" | "perIncome" | "demographic" | "crashDemographic";
+  /** "perCapita" needs demographics; "raw" and "rate" do not.
+   *  "context" measures are sourced from external datasets
+   *  (CalEnviroScreen, unemployment) rather than crash/demo queries. */
+  kind: "perCapita" | "raw" | "rate" | "perIncome" | "demographic" | "crashDemographic" | "context";
   formatLabel: (n: number) => string;
 };
 
@@ -99,6 +105,30 @@ export const MEASURES: Record<MeasureKey, Measure> = {
     kind: "demographic",
     formatLabel: (n) => `${n.toFixed(1)}%`,
   },
+  ces_score: {
+    key: "ces_score",
+    label: "CalEnviroScreen score",
+    kind: "context",
+    formatLabel: (n) => n.toFixed(1),
+  },
+  pollution_burden: {
+    key: "pollution_burden",
+    label: "Pollution burden score",
+    kind: "context",
+    formatLabel: (n) => n.toFixed(1),
+  },
+  traffic_score: {
+    key: "traffic_score",
+    label: "Traffic proximity score",
+    kind: "context",
+    formatLabel: (n) => n.toFixed(1),
+  },
+  unemployment_rate: {
+    key: "unemployment_rate",
+    label: "Average unemployment rate",
+    kind: "context",
+    formatLabel: (n) => `${n.toFixed(1)}%`,
+  },
 };
 
 export const DEFAULT_MEASURE: MeasureKey = "crashes_per_100k";
@@ -131,6 +161,11 @@ export type MeasureResult = {
   hasEnoughData: boolean;
 };
 
+/** Pre-computed context values from external datasets (CalEnviroScreen,
+ *  unemployment) that don't come from the crash stats or demographics
+ *  endpoints. Keyed by the context MeasureKey. */
+export type ContextValues = Partial<Record<MeasureKey, number | null>>;
+
 type ComputeOpts = {
   /** Per-year breakdowns for correct multi-year per-capita math.
    *  When provided, each year's crashes are divided by that year's
@@ -139,6 +174,8 @@ type ComputeOpts = {
   perYearCrashes?: Map<number, number>;
   perYearFatalities?: Map<number, number>;
   perYearInjuries?: Map<number, number>;
+  /** External dataset values for "context" kind measures. */
+  context?: ContextValues;
 };
 
 export function computeMeasureValue(
@@ -147,6 +184,14 @@ export function computeMeasureValue(
   demographics: CountyYearDemo[],
   opts: ComputeOpts = {},
 ): MeasureResult {
+  // Context measures are pre-computed from external datasets and passed
+  // through opts.context — no crash stats or demographics needed.
+  if (MEASURES[measure]?.kind === "context") {
+    const v = opts.context?.[measure];
+    if (v == null) return { value: null, hasEnoughData: false };
+    return { value: v, hasEnoughData: true };
+  }
+
   if (measure === "crashes_raw") {
     return { value: stats.crash_count, hasEnoughData: true };
   }

--- a/frontend/src/lib/choropleth/measures.ts
+++ b/frontend/src/lib/choropleth/measures.ts
@@ -10,13 +10,19 @@ export type MeasureKey =
   | "injuries_per_100k"
   | "crashes_raw"
   | "fatality_rate"
-  | "crashes_per_income";
+  | "crashes_per_income"
+  | "poverty_rate"
+  | "median_income"
+  | "pct_no_vehicle"
+  | "pct_bachelors"
+  | "crashes_per_poverty"
+  | "pct_65_plus";
 
 export type Measure = {
   key: MeasureKey;
   label: string;
   /** "perCapita" needs demographics; "raw" and "rate" do not. */
-  kind: "perCapita" | "raw" | "rate" | "perIncome";
+  kind: "perCapita" | "raw" | "rate" | "perIncome" | "demographic" | "crashDemographic";
   formatLabel: (n: number) => string;
 };
 
@@ -57,6 +63,42 @@ export const MEASURES: Record<MeasureKey, Measure> = {
     kind: "perIncome",
     formatLabel: (n) => n.toFixed(1),
   },
+  poverty_rate: {
+    key: "poverty_rate",
+    label: "Poverty rate %",
+    kind: "demographic",
+    formatLabel: (n) => `${n.toFixed(1)}%`,
+  },
+  median_income: {
+    key: "median_income",
+    label: "Median household income",
+    kind: "demographic",
+    formatLabel: (n) => `$${compact(n)}`,
+  },
+  pct_no_vehicle: {
+    key: "pct_no_vehicle",
+    label: "% households with no vehicle",
+    kind: "demographic",
+    formatLabel: (n) => `${n.toFixed(1)}%`,
+  },
+  pct_bachelors: {
+    key: "pct_bachelors",
+    label: "% bachelor's degree or higher",
+    kind: "demographic",
+    formatLabel: (n) => `${n.toFixed(1)}%`,
+  },
+  crashes_per_poverty: {
+    key: "crashes_per_poverty",
+    label: "Crashes per 1% poverty per 100K",
+    kind: "crashDemographic",
+    formatLabel: (n) => n.toFixed(1),
+  },
+  pct_65_plus: {
+    key: "pct_65_plus",
+    label: "% population age 65+",
+    kind: "demographic",
+    formatLabel: (n) => `${n.toFixed(1)}%`,
+  },
 };
 
 export const DEFAULT_MEASURE: MeasureKey = "crashes_per_100k";
@@ -78,6 +120,10 @@ export type CountyYearDemo = {
   year: number;
   population: number | null;
   median_income?: number | null;
+  poverty_rate?: number | null;
+  pct_no_vehicle?: number | null;
+  pct_bachelors_or_higher?: number | null;
+  pct_65_plus?: number | null;
 };
 
 export type MeasureResult = {
@@ -121,6 +167,47 @@ export function computeMeasureValue(
     return { value: (stats.crash_count / avgIncome) * 100_000, hasEnoughData: true };
   }
 
+  // Pure demographic measures — return the average across selected years.
+  if (measure === "poverty_rate") {
+    const vals = demographics.filter((d) => d.poverty_rate != null);
+    if (vals.length === 0) return { value: null, hasEnoughData: false };
+    return { value: vals.reduce((s, d) => s + d.poverty_rate!, 0) / vals.length, hasEnoughData: true };
+  }
+  if (measure === "median_income") {
+    const vals = demographics.filter((d) => d.median_income != null && d.median_income > 0);
+    if (vals.length === 0) return { value: null, hasEnoughData: false };
+    return { value: vals.reduce((s, d) => s + d.median_income!, 0) / vals.length, hasEnoughData: true };
+  }
+  if (measure === "pct_no_vehicle") {
+    const vals = demographics.filter((d) => d.pct_no_vehicle != null);
+    if (vals.length === 0) return { value: null, hasEnoughData: false };
+    return { value: vals.reduce((s, d) => s + d.pct_no_vehicle!, 0) / vals.length, hasEnoughData: true };
+  }
+  if (measure === "pct_bachelors") {
+    const vals = demographics.filter((d) => d.pct_bachelors_or_higher != null);
+    if (vals.length === 0) return { value: null, hasEnoughData: false };
+    return { value: vals.reduce((s, d) => s + d.pct_bachelors_or_higher!, 0) / vals.length, hasEnoughData: true };
+  }
+  if (measure === "pct_65_plus") {
+    const vals = demographics.filter((d) => d.pct_65_plus != null);
+    if (vals.length === 0) return { value: null, hasEnoughData: false };
+    return { value: vals.reduce((s, d) => s + d.pct_65_plus!, 0) / vals.length, hasEnoughData: true };
+  }
+
+  // Crash-demographic hybrid: crashes per 1% poverty per 100K pop.
+  if (measure === "crashes_per_poverty") {
+    if (stats.crash_count < MIN_CRASHES_FOR_RATE) {
+      return { value: null, hasEnoughData: false };
+    }
+    const vals = demographics.filter(
+      (d) => d.poverty_rate != null && d.poverty_rate > 0 && d.population != null && d.population > 0,
+    );
+    if (vals.length === 0) return { value: null, hasEnoughData: false };
+    const avgPoverty = vals.reduce((s, d) => s + d.poverty_rate!, 0) / vals.length;
+    const avgPop = vals.reduce((s, d) => s + d.population!, 0) / vals.length;
+    return { value: (stats.crash_count / avgPoverty / avgPop) * 100_000, hasEnoughData: true };
+  }
+
   // Per-capita branches need population.
   if (stats.crash_count < MIN_CRASHES_FOR_RATE) {
     return { value: null, hasEnoughData: false };
@@ -129,11 +216,11 @@ export function computeMeasureValue(
     return { value: null, hasEnoughData: false };
   }
 
-  const numeratorBy = {
+  const numeratorBy = ({
     crashes_per_100k: opts.perYearCrashes,
     fatalities_per_100k: opts.perYearFatalities,
     injuries_per_100k: opts.perYearInjuries,
-  }[measure];
+  } as Record<string, Map<number, number> | undefined>)[measure];
 
   if (numeratorBy && numeratorBy.size > 0) {
     let total = 0;

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -11,9 +11,8 @@ import { MEASURES } from "../lib/choropleth/measures";
 import KeyboardHelpModal from "../components/map/KeyboardHelpModal";
 import IconRail from "../components/map/IconRail";
 import SidePanel from "../components/map/SidePanel";
-import FiltersPanel, {
-  FiltersPanelFooter,
-} from "../components/map/FiltersPanel";
+import FilterWizard from "../components/map/filters/FilterWizard";
+import type { StagedFilters } from "../hooks/useStagedFilters";
 import LayersPanel, {
   LayersPanelFooter,
 } from "../components/map/LayersPanel";
@@ -30,6 +29,7 @@ import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import { useCoordCoverage } from "../hooks/useCoordCoverage";
 import { useCountyInsight } from "../hooks/useCountyInsight";
 import { useRandomInsight } from "../hooks/useRandomInsight";
+import ActiveFiltersBanner from "../components/map/ActiveFiltersBanner";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
   filters: { title: "Filters", subtitle: "Secondary Parameters" },
@@ -75,16 +75,12 @@ function MapPageInner() {
     selectedDriverAge,
     setDateRange,
     clearDateRange,
-    toggleSeverity,
     toggleCounty,
     setCounty,
     clearCounties,
-    toggleCause,
     setCauses,
-    setAllCauses,
     clearCauses,
     setSeverities,
-    setAllSeverities,
     clearSeverities,
     toggleAlcohol,
     toggleDistracted,
@@ -101,7 +97,6 @@ function MapPageInner() {
   const [showInsight, setShowInsight] = useState(true);
   const [showMobileFilters, setShowMobileFilters] = useState(false);
   const [mobileSearchExpanded, setMobileSearchExpanded] = useState(false);
-  const [resetKey, setResetKey] = useState(0);
   const [focusedCounty, setFocusedCounty] = useState<string | null>(null);
   const [compareCounty, setCompareCounty] = useState<string | null>(null);
   const [compareMode, setCompareMode] = useState(false);
@@ -270,7 +265,6 @@ function MapPageInner() {
 
   function handleClearAll() {
     clearFilters();
-    setResetKey((k) => k + 1);
   }
 
   const handleCloseOverlay = useCallback(() => {
@@ -314,42 +308,73 @@ function MapPageInner() {
 
   const meta = activePanel ? PANEL_META[activePanel] : null;
 
-  const filtersPanelProps = {
-    selectedDateRange,
-    selectedSeverities,
-    selectedCounties,
-    selectedCauses,
-    selectedAlcohol,
-    selectedDistracted,
-    selectedPedestrian,
-    selectedCyclist,
-    selectedDrug,
-    selectedDriverAge,
-    onSetDateRange: setDateRange,
-    onClearDateRange: clearDateRange,
-    onToggleSeverity: toggleSeverity,
-    onSetSeverities: setSeverities,
-    onSetAllSeverities: setAllSeverities,
-    onClearSeverities: clearSeverities,
-    onToggleCounty: toggleCounty,
-    onClearCounties: clearCounties,
-    onToggleCause: toggleCause,
-    onSetCauses: setCauses,
-    onSetAllCauses: setAllCauses,
-    onClearCauses: clearCauses,
-    onToggleAlcohol: toggleAlcohol,
-    onToggleDistracted: toggleDistracted,
-    onTogglePedestrian: togglePedestrian,
-    onToggleCyclist: toggleCyclist,
-    onToggleDrug: toggleDrug,
-    onSetDriverAge: setDriverAge,
-    resetKey,
-  };
+  const initialStagedFilters: StagedFilters = useMemo(() => ({
+    selectedYears: new Set(selectedYears),
+    dateRange: selectedDateRange,
+    severities: new Set(selectedSeverities),
+    causes: new Set(selectedCauses),
+    alcohol: selectedAlcohol,
+    distracted: selectedDistracted,
+    pedestrian: selectedPedestrian,
+    cyclist: selectedCyclist,
+    drug: selectedDrug,
+    driverAge: selectedDriverAge,
+  }), [selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug, selectedDriverAge, selectedYears]);
+
+  const handleApplyFilters = useCallback((filters: StagedFilters) => {
+    // Years -> date range
+    if (filters.selectedYears.size > 0) {
+      const years = [...filters.selectedYears].sort();
+      setDateRange(
+        { year: years[0], month: 1 },
+        { year: years[years.length - 1], month: 12 },
+      );
+    } else {
+      clearDateRange();
+    }
+
+    // Severities
+    if (filters.severities.size > 0) {
+      setSeverities(filters.severities);
+    } else {
+      clearSeverities();
+    }
+
+    // Causes
+    if (filters.causes.size > 0) {
+      setCauses(filters.causes);
+    } else {
+      clearCauses();
+    }
+
+    // Involvement — only toggle if different from current state
+    if (filters.alcohol !== selectedAlcohol) toggleAlcohol();
+    if (filters.distracted !== selectedDistracted) toggleDistracted();
+    if (filters.pedestrian !== selectedPedestrian) togglePedestrian();
+    if (filters.cyclist !== selectedCyclist) toggleCyclist();
+    if (filters.drug !== selectedDrug) toggleDrug();
+
+    // Driver age
+    setDriverAge(filters.driverAge);
+
+    // Close panels
+    setShowMobileFilters(false);
+    setActivePanel(null);
+  }, [setDateRange, clearDateRange, setSeverities, clearSeverities, setCauses, clearCauses, toggleAlcohol, toggleDistracted, togglePedestrian, toggleCyclist, toggleDrug, setDriverAge, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug]);
 
   function renderPanelContent() {
     switch (activePanel) {
       case "filters":
-        return <FiltersPanel {...filtersPanelProps} />;
+        return (
+          <FilterWizard
+            initial={initialStagedFilters}
+            selectedCounties={selectedCounties}
+            onToggleCounty={toggleCounty}
+            onClearCounties={clearCounties}
+            onApply={handleApplyFilters}
+            onClear={handleClearAll}
+          />
+        );
       case "layers":
         return <LayersPanel />;
       case "export":
@@ -361,8 +386,6 @@ function MapPageInner() {
 
   function renderPanelFooter() {
     switch (activePanel) {
-      case "filters":
-        return <FiltersPanelFooter onClear={handleClearAll} />;
       case "layers":
         return <LayersPanelFooter />;
       case "export":
@@ -380,7 +403,7 @@ function MapPageInner() {
         <IconRail activePanel={activePanel} onPanelToggle={handleToggle} />
         <div
           className="transition-all duration-300 overflow-hidden"
-          style={{ width: activePanel && meta ? 300 : 0 }}
+          style={{ width: activePanel && meta ? (activePanel === "filters" ? 400 : 300) : 0 }}
         >
           {activePanel && meta && (
             <SidePanel
@@ -439,6 +462,22 @@ function MapPageInner() {
             map={mapRef.current}
           />
         )}
+
+        <ActiveFiltersBanner
+          dateRange={selectedDateRange}
+          severities={selectedSeverities}
+          causes={selectedCauses}
+          alcohol={selectedAlcohol}
+          distracted={selectedDistracted}
+          pedestrian={selectedPedestrian}
+          cyclist={selectedCyclist}
+          drug={selectedDrug}
+          driverAge={selectedDriverAge}
+          totalCrashes={choroplethData.dataSummary.totalCrashes}
+          isLoading={choroplethData.isLoading}
+          onClear={handleClearAll}
+          searchOpen={mobileSearchExpanded}
+        />
 
         {!choroplethData.isLoading
           && !choroplethData.isError
@@ -560,7 +599,14 @@ function MapPageInner() {
             label: "Filters",
             icon: "filter_list",
             content: (
-              <FiltersPanel {...filtersPanelProps} />
+              <FilterWizard
+                initial={initialStagedFilters}
+                selectedCounties={selectedCounties}
+                onToggleCounty={toggleCounty}
+                onClearCounties={clearCounties}
+                onApply={handleApplyFilters}
+                onClear={handleClearAll}
+              />
             ),
           },
           {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -11,7 +11,7 @@ import { MEASURES } from "../lib/choropleth/measures";
 import KeyboardHelpModal from "../components/map/KeyboardHelpModal";
 import IconRail from "../components/map/IconRail";
 import SidePanel from "../components/map/SidePanel";
-import FilterWizard from "../components/map/filters/FilterWizard";
+import FilterPanelRouter from "../components/map/filters/FilterPanelRouter";
 import type { StagedFilters } from "../hooks/useStagedFilters";
 import LayersPanel, {
   LayersPanelFooter,
@@ -30,6 +30,7 @@ import { useCoordCoverage } from "../hooks/useCoordCoverage";
 import { useCountyInsight } from "../hooks/useCountyInsight";
 import { useRandomInsight } from "../hooks/useRandomInsight";
 import ActiveFiltersBanner from "../components/map/ActiveFiltersBanner";
+import FilteredUrlPrompt from "../components/map/FilteredUrlPrompt";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
   filters: { title: "Filters", subtitle: "Secondary Parameters" },
@@ -103,6 +104,14 @@ function MapPageInner() {
   const [showHelp, setShowHelp] = useState(false);
   const [insightCounty, setInsightCounty] = useState("Fresno");
   const [showStatewide, setShowStatewide] = useState(true);
+  const [showFilterPrompt, setShowFilterPrompt] = useState(() => {
+    const hasFilters = selectedDateRange !== null
+      || selectedSeverities.size > 0
+      || selectedCauses.size > 0
+      || selectedAlcohol || selectedDistracted || selectedPedestrian
+      || selectedCyclist || selectedDrug || selectedDriverAge !== null;
+    return hasFilters;
+  });
   const mapRef = useRef<LeafletMap | null>(null);
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
@@ -366,7 +375,7 @@ function MapPageInner() {
     switch (activePanel) {
       case "filters":
         return (
-          <FilterWizard
+          <FilterPanelRouter
             initial={initialStagedFilters}
             selectedCounties={selectedCounties}
             onToggleCounty={toggleCounty}
@@ -484,12 +493,42 @@ function MapPageInner() {
           && choroplethData.dataSummary.totalCrashes === 0
           && (
           <div className="absolute inset-0 z-30 flex items-center justify-center pointer-events-none p-4">
-            <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-xl px-6 py-5 ambient-shadow pointer-events-auto max-w-xs">
+            <div className="bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-xl px-6 py-5 ambient-shadow pointer-events-auto max-w-sm space-y-4">
               <EmptyState
                 icon="filter_list_off"
                 title="No matching crashes"
-                description="Adjust your filters to see data on the map."
+                description="Your filters are too restrictive. Try removing some:"
               />
+              <div className="flex flex-wrap gap-2 justify-center">
+                {selectedSeverities.size > 0 && (
+                  <button onClick={clearSeverities} className="text-[11px] font-semibold bg-primary-container text-on-primary-container px-2.5 py-1 rounded-full flex items-center gap-1 hover:opacity-80">
+                    {[...selectedSeverities].join(", ")} <span className="text-[10px]">×</span>
+                  </button>
+                )}
+                {selectedCauses.size > 0 && (
+                  <button onClick={() => clearCauses()} className="text-[11px] font-semibold bg-primary-container text-on-primary-container px-2.5 py-1 rounded-full flex items-center gap-1 hover:opacity-80">
+                    {selectedCauses.size} causes <span className="text-[10px]">×</span>
+                  </button>
+                )}
+                {selectedAlcohol && (
+                  <button onClick={toggleAlcohol} className="text-[11px] font-semibold bg-tertiary-container text-on-tertiary-container px-2.5 py-1 rounded-full flex items-center gap-1 hover:opacity-80">
+                    Alcohol <span className="text-[10px]">×</span>
+                  </button>
+                )}
+                {selectedPedestrian && (
+                  <button onClick={togglePedestrian} className="text-[11px] font-semibold bg-tertiary-container text-on-tertiary-container px-2.5 py-1 rounded-full flex items-center gap-1 hover:opacity-80">
+                    Pedestrian <span className="text-[10px]">×</span>
+                  </button>
+                )}
+                {selectedDriverAge && (
+                  <button onClick={() => setDriverAge(null)} className="text-[11px] font-semibold bg-tertiary-container text-on-tertiary-container px-2.5 py-1 rounded-full flex items-center gap-1 hover:opacity-80">
+                    Age {selectedDriverAge} <span className="text-[10px]">×</span>
+                  </button>
+                )}
+              </div>
+              <button onClick={handleClearAll} className="w-full text-sm font-semibold text-primary hover:underline">
+                Clear All Filters
+              </button>
             </div>
           </div>
         )}
@@ -600,7 +639,7 @@ function MapPageInner() {
             icon: "filter_list",
             hideFooter: true,
             content: (
-              <FilterWizard
+              <FilterPanelRouter
                 initial={initialStagedFilters}
                 selectedCounties={selectedCounties}
                 onToggleCounty={toggleCounty}
@@ -623,6 +662,24 @@ function MapPageInner() {
         isOpen={showHelp}
         onClose={() => setShowHelp(false)}
       />
+
+      {showFilterPrompt && (
+        <FilteredUrlPrompt
+          filters={[
+            ...(selectedDateRange ? [`${selectedDateRange.start?.year ?? "earliest"}–${selectedDateRange.end?.year ?? "latest"}`] : []),
+            ...(selectedSeverities.size > 0 ? [...selectedSeverities] : []),
+            ...(selectedCauses.size > 0 ? [`${selectedCauses.size} cause${selectedCauses.size > 1 ? "s" : ""}`] : []),
+            ...(selectedAlcohol ? ["Alcohol"] : []),
+            ...(selectedDistracted ? ["Distracted"] : []),
+            ...(selectedPedestrian ? ["Pedestrian"] : []),
+            ...(selectedCyclist ? ["Cyclist"] : []),
+            ...(selectedDrug ? ["Drug"] : []),
+            ...(selectedDriverAge ? [`Age ${selectedDriverAge}`] : []),
+          ]}
+          onViewFiltered={() => setShowFilterPrompt(false)}
+          onShowAll={() => { clearFilters(); setShowFilterPrompt(false); }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -30,6 +30,7 @@ import { useCoordCoverage } from "../hooks/useCoordCoverage";
 import { useCountyInsight } from "../hooks/useCountyInsight";
 import { useRandomInsight } from "../hooks/useRandomInsight";
 import ActiveFiltersBanner from "../components/map/ActiveFiltersBanner";
+import { usePrefetchFacets } from "../hooks/usePrefetchFacets";
 import FilteredUrlPrompt from "../components/map/FilteredUrlPrompt";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
@@ -110,6 +111,7 @@ function MapPageInner() {
   const mapRef = useRef<LeafletMap | null>(null);
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
+  usePrefetchFacets();
 
   const { measure, otherLayers, heatmapResolution, palette, choroplethOn } = useLayersState();
 

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -74,22 +74,16 @@ function MapPageInner() {
     selectedCyclist,
     selectedDrug,
     selectedDriverAge,
-    setDateRange,
-    clearDateRange,
     toggleCounty,
     setCounty,
     clearCounties,
-    setCauses,
     clearCauses,
-    setSeverities,
     clearSeverities,
     toggleAlcohol,
-    toggleDistracted,
     togglePedestrian,
-    toggleCyclist,
-    toggleDrug,
     setDriverAge,
     clearFilters,
+    setAllFilters,
     panel: panelParam,
     clearPanel,
   } = useFilterParams();
@@ -331,45 +325,34 @@ function MapPageInner() {
   }), [selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug, selectedDriverAge, selectedYears]);
 
   const handleApplyFilters = useCallback((filters: StagedFilters) => {
-    // Years -> date range
-    if (filters.selectedYears.size > 0) {
+    let start: { year: number; month: number } | null = null;
+    let end: { year: number; month: number } | null = null;
+
+    if (filters.dateRange) {
+      start = filters.dateRange.start;
+      end = filters.dateRange.end;
+    } else if (filters.selectedYears.size > 0) {
       const years = [...filters.selectedYears].sort();
-      setDateRange(
-        { year: years[0], month: 1 },
-        { year: years[years.length - 1], month: 12 },
-      );
-    } else {
-      clearDateRange();
+      start = { year: years[0], month: 1 };
+      end = { year: years[years.length - 1], month: 12 };
     }
 
-    // Severities
-    if (filters.severities.size > 0) {
-      setSeverities(filters.severities);
-    } else {
-      clearSeverities();
-    }
+    setAllFilters({
+      start,
+      end,
+      severities: filters.severities,
+      causes: filters.causes,
+      alcohol: filters.alcohol,
+      distracted: filters.distracted,
+      pedestrian: filters.pedestrian,
+      cyclist: filters.cyclist,
+      drug: filters.drug,
+      driverAge: filters.driverAge,
+    });
 
-    // Causes
-    if (filters.causes.size > 0) {
-      setCauses(filters.causes);
-    } else {
-      clearCauses();
-    }
-
-    // Involvement — only toggle if different from current state
-    if (filters.alcohol !== selectedAlcohol) toggleAlcohol();
-    if (filters.distracted !== selectedDistracted) toggleDistracted();
-    if (filters.pedestrian !== selectedPedestrian) togglePedestrian();
-    if (filters.cyclist !== selectedCyclist) toggleCyclist();
-    if (filters.drug !== selectedDrug) toggleDrug();
-
-    // Driver age
-    setDriverAge(filters.driverAge);
-
-    // Close panels
     setShowMobileFilters(false);
     setActivePanel(null);
-  }, [setDateRange, clearDateRange, setSeverities, clearSeverities, setCauses, clearCauses, toggleAlcohol, toggleDistracted, togglePedestrian, toggleCyclist, toggleDrug, setDriverAge, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug]);
+  }, [setAllFilters]);
 
   function renderPanelContent() {
     switch (activePanel) {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -99,6 +99,7 @@ function MapPageInner() {
   const [insightCounty, setInsightCounty] = useState("Fresno");
   const [showStatewide, setShowStatewide] = useState(true);
   const [showFilterPrompt, setShowFilterPrompt] = useState(() => {
+    if (sessionStorage.getItem("calsight-filter-prompt-dismissed")) return false;
     const hasFilters = selectedDateRange !== null
       || selectedSeverities.size > 0
       || selectedCauses.size > 0
@@ -659,8 +660,8 @@ function MapPageInner() {
             ...(selectedDrug ? ["Drug"] : []),
             ...(selectedDriverAge ? [`Age ${selectedDriverAge}`] : []),
           ]}
-          onViewFiltered={() => setShowFilterPrompt(false)}
-          onShowAll={() => { clearFilters(); setShowFilterPrompt(false); }}
+          onViewFiltered={() => { sessionStorage.setItem("calsight-filter-prompt-dismissed", "1"); setShowFilterPrompt(false); }}
+          onShowAll={() => { sessionStorage.setItem("calsight-filter-prompt-dismissed", "1"); clearFilters(); setShowFilterPrompt(false); }}
         />
       )}
     </>

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -598,6 +598,7 @@ function MapPageInner() {
             key: "filters",
             label: "Filters",
             icon: "filter_list",
+            hideFooter: true,
             content: (
               <FilterWizard
                 initial={initialStagedFilters}


### PR DESCRIPTION
 ## What does this PR do?

  Complete filter system redesign — replaces the monolithic 6-section filter panel with a guided
  Simple/Advanced mode system.

  **Simple Mode (default):** Year chips, severity, top causes, quick presets (Fatal DUI, Pedestrian
  Safety, etc.), one-tap apply.

  **Advanced Mode (6-step wizard):** When → What → Who → Conditions → View → Display. Dynamic faceted
  counts on every chip. Month/year range picker. Involvement + driver age filters with 2016+ gate.

  **New backend infrastructure:**
  - 4 canonical columns (weather, lighting, road condition, collision type) with Alembic migration +
  backfill script + ETL pipeline job
  - Backend filter support for weather/lighting/collision_type/road_type/hit_run on crashes + heatmap
  endpoints
  - setAllFilters — single atomic URL param write (fixes filters not persisting)

  **New choropleth measures:** Poverty rate, median income, no-vehicle %, bachelor's %, 65+ %, crashes
  per poverty, CalEnviroScreen score, pollution burden, traffic score, unemployment rate.

  **New map overlays:** 560 hospitals + 9,932 schools as toggleable pin markers.

  **UX improvements:**
  - Airbnb-style "Show X Crashes" live count on Apply button
  - Dynamic faceted counts (DUI (842K)) update as you toggle filters, disable at zero
  - Filter presets with highlight + count prefetch
  - FilteredUrlPrompt for shared links (once per session)
  - Zero results with removable filter suggestions
  - ActiveFiltersBanner on desktop

  Closes #190

  ## Dependencies

  Depends on #189

  ## How to test
  - [ ] Simple mode: select Fatal, click Apply — map updates, URL has ?severity=fatal
  - [ ] Advanced mode: step through all 6 steps, verify counts update dynamically
  - [ ] Presets: click Fatal DUI — chips highlight, Apply shows ~17K crashes
  - [ ] Switch Simple/Advanced — mode persists, filters carry over
  - [ ] Mobile: filter sheet scrolls, footer visible, dropdowns don't overflow
  - [ ] Measure dropdown: scrollable on mobile, all 12+ measures accessible
  - [ ] Shared URL: navigate to /?severity=fatal — prompt appears once per session
  - [ ] Zero results: apply impossible filter combo — shows removable chip suggestions
  - [ ] After deploy: verify backfill_conditions runs automatically, canonical columns populated

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
