### PR TITLE
feat(#192): condition filter counts, loading skeletons, deploy pipeline fix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,11 @@ jobs:
       - name: Run database migrations
         run: docker compose -f docker-compose.prod.yml exec -T backend alembic upgrade head
 
-      - name: Backfill canonical condition columns (idempotent, skips existing)
+      - name: Backfill derived fields (severity, flags, driver age, canonical cause)
+        run: docker compose -f docker-compose.prod.yml exec -T backend python -m etl.backfill_derived
+        timeout-minutes: 240
+
+      - name: Backfill canonical condition columns (weather, lighting, collision, road)
         run: docker compose -f docker-compose.prod.yml exec -T backend python -m etl.backfill_conditions
         timeout-minutes: 240
 

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -11,10 +11,15 @@ from app.filters import (
     build_crash_predicates,
     parse_bool_flag,
     parse_cause,
+    parse_collision_type,
     parse_county_codes,
     parse_date_range,
     parse_driver_age,
+    parse_hit_run,
+    parse_lighting,
+    parse_road_type,
     parse_severity,
+    parse_weather,
     parse_year,
     years_from_date_range,
 )
@@ -169,9 +174,14 @@ def stats(
     cyclist: str | None = Query(None),
     drug: str | None = Query(None),
     driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
     group_by: str | None = Query(
         None,
-        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|at_fault_gender|at_fault_age_bracket|rate)$",
+        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|at_fault_gender|at_fault_age_bracket|rate|weather|lighting|collision_type)$",
     ),
     db: Session = Depends(get_db),
 ):
@@ -206,8 +216,17 @@ def stats(
     cyclist_v = parse_bool_flag(cyclist, "cyclist")
     drug_v = parse_bool_flag(drug, "drug")
     driver_age_v = parse_driver_age(driver_age)
+    weather_v = parse_weather(weather)
+    lighting_v = parse_lighting(lighting)
+    collision_type_v = parse_collision_type(collision_type)
+    road_type_v = parse_road_type(road_type)
+    hit_run_v = parse_hit_run(hit_run)
 
-    has_involvement = any(v is not None for v in [alcohol_v, distracted_v, pedestrian_v, cyclist_v, drug_v, driver_age_v])
+    has_involvement = any(v is not None for v in [
+        alcohol_v, distracted_v, pedestrian_v, cyclist_v, drug_v, driver_age_v,
+        weather_v, lighting_v, collision_type_v, road_type_v, hit_run_v,
+    ])
+    has_condition_group = group_by in ("weather", "lighting", "collision_type")
 
     date_range = parse_date_range(start, end)
     years = years_from_date_range(date_range) if date_range is not None else parse_year(year)
@@ -227,6 +246,11 @@ def stats(
             cyclist=cyclist_v,
             drug=drug_v,
             driver_age=driver_age_v,
+            weather=weather_v,
+            lighting=lighting_v,
+            collision_type=collision_type_v,
+            road_type=road_type_v,
+            hit_run=hit_run_v,
         )
 
     if has_involvement and group_by in ("gender", "age_bracket", "at_fault_gender", "at_fault_age_bracket"):
@@ -245,9 +269,10 @@ def stats(
 
     view = _pick_view(group_by, has_cause_filter=bool(causes))
 
-    # When involvement/age filters are active, query the raw crashes table
-    # instead of materialized views (which don't carry those columns).
-    if has_involvement:
+    # When involvement/age/condition filters are active, or grouping by
+    # condition columns, query the raw crashes table instead of materialized
+    # views (which don't carry those columns).
+    if has_involvement or has_condition_group:
         preds = _raw_preds()
 
         def _raw_query(stmt):
@@ -357,6 +382,42 @@ def stats(
             )
             rows = db.execute(stmt).all()
             return [SeverityRow(severity=r.severity, crash_count=r.crash_count, total_killed=r.total_killed, total_injured=r.total_injured).model_dump() for r in rows]
+
+        if group_by == "weather":
+            stmt = _raw_query(
+                select(
+                    func.coalesce(Crash.canonical_weather, "unknown").label("value"),
+                    func.count().label("crash_count"),
+                )
+                .group_by(Crash.canonical_weather)
+                .order_by(func.count().desc())
+            )
+            rows = db.execute(stmt).all()
+            return [{"value": r.value, "crash_count": r.crash_count} for r in rows]
+
+        if group_by == "lighting":
+            stmt = _raw_query(
+                select(
+                    func.coalesce(Crash.canonical_lighting, "unknown").label("value"),
+                    func.count().label("crash_count"),
+                )
+                .group_by(Crash.canonical_lighting)
+                .order_by(func.count().desc())
+            )
+            rows = db.execute(stmt).all()
+            return [{"value": r.value, "crash_count": r.crash_count} for r in rows]
+
+        if group_by == "collision_type":
+            stmt = _raw_query(
+                select(
+                    func.coalesce(Crash.canonical_collision_type, "unknown").label("value"),
+                    func.count().label("crash_count"),
+                )
+                .group_by(Crash.canonical_collision_type)
+                .order_by(func.count().desc())
+            )
+            rows = db.execute(stmt).all()
+            return [{"value": r.value, "crash_count": r.crash_count} for r in rows]
 
         if group_by == "rate":
             raise FilterError("involvement", "Involvement filters are not supported with group_by=rate.")

--- a/frontend/src/components/map/ActiveFiltersBanner.tsx
+++ b/frontend/src/components/map/ActiveFiltersBanner.tsx
@@ -11,6 +11,11 @@ interface ActiveFiltersBannerProps {
   cyclist: boolean;
   drug: boolean;
   driverAge: string | null;
+  weather: Set<string>;
+  lighting: Set<string>;
+  collisionType: Set<string>;
+  roadType: string | null;
+  hitRun: boolean;
   totalCrashes: number;
   isLoading: boolean;
   onClear: () => void;
@@ -33,6 +38,11 @@ export default function ActiveFiltersBanner({
   cyclist,
   drug,
   driverAge,
+  weather,
+  lighting,
+  collisionType,
+  roadType,
+  hitRun,
   totalCrashes,
   isLoading,
   onClear,
@@ -57,6 +67,11 @@ export default function ActiveFiltersBanner({
   if (cyclist) chips.push("Cyclist");
   if (drug) chips.push("Drug");
   if (driverAge) chips.push(`Age ${driverAge}`);
+  if (weather.size > 0) chips.push(`${weather.size} weather`);
+  if (lighting.size > 0) chips.push(`${lighting.size} lighting`);
+  if (collisionType.size > 0) chips.push(`${collisionType.size} collision`);
+  if (roadType) chips.push(roadType === "highway" ? "Highway" : "Local");
+  if (hitRun) chips.push("Hit-and-Run");
 
   const hasInvolvement = alcohol || distracted || pedestrian || cyclist || drug || !!driverAge;
 

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -207,6 +207,8 @@ export default function FilterWizard({
             measure={measure}
             onSetMeasure={setMeasure}
             staged={staged}
+            crashCount={liveCount}
+            crashCountLoading={countLoading}
           />
         )}
         {step === 5 && (

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -138,7 +138,7 @@ export default function FilterWizard({
       {/* Step content */}
       <div className="pb-4">
         {step === 0 && (
-          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} yearCounts={facets.years} />
+          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} yearCounts={facets.years} loading={!facets.loaded} />
         )}
         {step === 1 && (
           <StepWhat
@@ -149,6 +149,7 @@ export default function FilterWizard({
             onClearSeverities={clearSeverities}
             causeCounts={facets.causes}
             severityCounts={facets.severities}
+            loading={!facets.loaded}
           />
         )}
         {step === 2 && (
@@ -158,6 +159,8 @@ export default function FilterWizard({
             onToggleInvolvement={toggleInvolvement}
             onSetDriverAge={setDriverAge}
             involvementCounts={facets.involvement}
+            driverAgeCounts={facets.driverAge}
+            loading={!facets.loaded}
           />
         )}
         {step === 3 && (
@@ -176,6 +179,7 @@ export default function FilterWizard({
             onSetRoadType={setRoadType}
             onToggleHitRun={toggleHitRun}
             conditionCounts={facets.conditions}
+            loading={!facets.loaded}
           />
         )}
         {step === 4 && (

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -186,6 +186,7 @@ export default function FilterWizard({
           <StepViewBy
             measure={measure}
             onSetMeasure={setMeasure}
+            staged={staged}
           />
         )}
         {step === 5 && (

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -43,6 +43,10 @@ export default function FilterWizard({
     toggleSeverity, clearSeverities,
     toggleCause, clearCauses,
     toggleInvolvement, setDateRange, setDriverAge,
+    toggleWeather, clearWeather,
+    toggleLighting, clearLighting,
+    toggleCollisionType, clearCollisionType,
+    setRoadType, toggleHitRun,
     clearAll, has2016Plus,
   } = useStagedFilters(initial);
 
@@ -157,7 +161,22 @@ export default function FilterWizard({
           />
         )}
         {step === 3 && (
-          <StepConditions />
+          <StepConditions
+            weather={staged.weather}
+            lighting={staged.lighting}
+            collisionType={staged.collisionType}
+            roadType={staged.roadType}
+            hitRun={staged.hitRun}
+            onToggleWeather={toggleWeather}
+            onClearWeather={clearWeather}
+            onToggleLighting={toggleLighting}
+            onClearLighting={clearLighting}
+            onToggleCollisionType={toggleCollisionType}
+            onClearCollisionType={clearCollisionType}
+            onSetRoadType={setRoadType}
+            onToggleHitRun={toggleHitRun}
+            conditionCounts={facets.conditions}
+          />
         )}
         {step === 4 && (
           <StepViewBy

--- a/frontend/src/components/map/filters/FilterWizard.tsx
+++ b/frontend/src/components/map/filters/FilterWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import { CA_COUNTIES } from "../../../hooks/useFilterParams";
 import { useLayersState } from "../../../hooks/useLayersState";
 import { useStagedFilters, type StagedFilters } from "../../../hooks/useStagedFilters";
@@ -59,6 +59,26 @@ export default function FilterWizard({
 
   const { count: liveCount, loading: countLoading } = useLiveCrashCount(staged);
   const facets = useFacetCounts(staged);
+
+  const prevStepRef = useRef(step);
+  const [waitingForCounts, setWaitingForCounts] = useState(!facets.loaded);
+
+  useEffect(() => {
+    if (step !== prevStepRef.current) {
+      prevStepRef.current = step;
+      if (facets.loading) {
+        setWaitingForCounts(true);
+      }
+    }
+  }, [step, facets.loading]);
+
+  useEffect(() => {
+    if (waitingForCounts && !facets.loading) {
+      setWaitingForCounts(false);
+    }
+  }, [waitingForCounts, facets.loading]);
+
+  const stepLoading = waitingForCounts || !facets.loaded;
 
   const handleApply = useCallback(() => {
     onApply(staged);
@@ -138,7 +158,7 @@ export default function FilterWizard({
       {/* Step content */}
       <div className="pb-4">
         {step === 0 && (
-          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} yearCounts={facets.years} loading={!facets.loaded} />
+          <StepWhen staged={staged} onToggleYear={toggleYear} onSetAllYears={setAllYears} onSetDateRange={setDateRange} yearCounts={facets.years} loading={stepLoading} />
         )}
         {step === 1 && (
           <StepWhat
@@ -149,7 +169,7 @@ export default function FilterWizard({
             onClearSeverities={clearSeverities}
             causeCounts={facets.causes}
             severityCounts={facets.severities}
-            loading={!facets.loaded}
+            loading={stepLoading}
           />
         )}
         {step === 2 && (
@@ -160,7 +180,7 @@ export default function FilterWizard({
             onSetDriverAge={setDriverAge}
             involvementCounts={facets.involvement}
             driverAgeCounts={facets.driverAge}
-            loading={!facets.loaded}
+            loading={stepLoading}
           />
         )}
         {step === 3 && (
@@ -179,7 +199,7 @@ export default function FilterWizard({
             onSetRoadType={setRoadType}
             onToggleHitRun={toggleHitRun}
             conditionCounts={facets.conditions}
-            loading={!facets.loaded}
+            loading={stepLoading}
           />
         )}
         {step === 4 && (

--- a/frontend/src/components/map/filters/SimpleFilterPanel.tsx
+++ b/frontend/src/components/map/filters/SimpleFilterPanel.tsx
@@ -69,6 +69,11 @@ export default function SimpleFilterPanel({
       cyclist: preset.cyclist ?? false,
       drug: preset.drug ?? false,
       driverAge: preset.driverAge ?? null,
+      weather: preset.weather ?? new Set(),
+      lighting: preset.lighting ?? new Set(),
+      collisionType: preset.collisionType ?? new Set(),
+      roadType: preset.roadType ?? null,
+      hitRun: preset.hitRun ?? false,
     };
     reset(merged);
   }, [reset]);

--- a/frontend/src/components/map/filters/StepConditions.tsx
+++ b/frontend/src/components/map/filters/StepConditions.tsx
@@ -1,4 +1,3 @@
-import { useState, useCallback } from "react";
 import FilterChip from "./FilterChip";
 
 const WEATHER = [
@@ -30,39 +29,51 @@ const ROAD_TYPES = [
   { value: "local", label: "Local Road" },
 ];
 
-function toggleInSet(set: Set<string>, value: string): Set<string> {
-  const next = new Set(set);
-  if (next.has(value)) {
-    next.delete(value);
-  } else {
-    next.add(value);
-  }
-  return next;
+interface ConditionCounts {
+  weather?: Record<string, number>;
+  lighting?: Record<string, number>;
+  collisionType?: Record<string, number>;
 }
 
-export default function StepConditions() {
-  const [weather, setWeather] = useState<Set<string>>(new Set());
-  const [lighting, setLighting] = useState<Set<string>>(new Set());
-  const [collisionType, setCollisionType] = useState<Set<string>>(new Set());
-  const [roadType, setRoadType] = useState<string | null>(null);
-  const [hitRun, setHitRun] = useState(false);
+interface StepConditionsProps {
+  weather: Set<string>;
+  lighting: Set<string>;
+  collisionType: Set<string>;
+  roadType: string | null;
+  hitRun: boolean;
+  onToggleWeather: (v: string) => void;
+  onClearWeather: () => void;
+  onToggleLighting: (v: string) => void;
+  onClearLighting: () => void;
+  onToggleCollisionType: (v: string) => void;
+  onClearCollisionType: () => void;
+  onSetRoadType: (v: string | null) => void;
+  onToggleHitRun: () => void;
+  conditionCounts?: ConditionCounts;
+}
 
-  const toggleWeather = useCallback((v: string) => {
-    setWeather((prev) => toggleInSet(prev, v));
-  }, []);
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString();
+}
 
-  const toggleLighting = useCallback((v: string) => {
-    setLighting((prev) => toggleInSet(prev, v));
-  }, []);
-
-  const toggleCollisionType = useCallback((v: string) => {
-    setCollisionType((prev) => toggleInSet(prev, v));
-  }, []);
-
-  const toggleRoadType = useCallback((v: string) => {
-    setRoadType((prev) => (prev === v ? null : v));
-  }, []);
-
+export default function StepConditions({
+  weather,
+  lighting,
+  collisionType,
+  roadType,
+  hitRun,
+  onToggleWeather,
+  onClearWeather,
+  onToggleLighting,
+  onClearLighting,
+  onToggleCollisionType,
+  onClearCollisionType,
+  onSetRoadType,
+  onToggleHitRun,
+  conditionCounts,
+}: StepConditionsProps) {
   const allWeather = weather.size === 0;
   const allLighting = lighting.size === 0;
   const allCollisionTypes = collisionType.size === 0;
@@ -78,15 +89,19 @@ export default function StepConditions() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <FilterChip label="All Weather" active={allWeather} onClick={() => setWeather(new Set())} />
-          {WEATHER.map((w) => (
-            <FilterChip
-              key={w.value}
-              label={w.label}
-              active={!allWeather && weather.has(w.value)}
-              onClick={() => toggleWeather(w.value)}
-            />
-          ))}
+          <FilterChip label="All Weather" active={allWeather} onClick={onClearWeather} />
+          {WEATHER.map((w) => {
+            const count = conditionCounts?.weather?.[w.value];
+            return (
+              <FilterChip
+                key={w.value}
+                label={count != null ? `${w.label} (${fmt(count)})` : w.label}
+                active={!allWeather && weather.has(w.value)}
+                onClick={() => onToggleWeather(w.value)}
+                disabled={count === 0}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -99,15 +114,19 @@ export default function StepConditions() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <FilterChip label="All Lighting" active={allLighting} onClick={() => setLighting(new Set())} />
-          {LIGHTING.map((l) => (
-            <FilterChip
-              key={l.value}
-              label={l.label}
-              active={!allLighting && lighting.has(l.value)}
-              onClick={() => toggleLighting(l.value)}
-            />
-          ))}
+          <FilterChip label="All Lighting" active={allLighting} onClick={onClearLighting} />
+          {LIGHTING.map((l) => {
+            const count = conditionCounts?.lighting?.[l.value];
+            return (
+              <FilterChip
+                key={l.value}
+                label={count != null ? `${l.label} (${fmt(count)})` : l.label}
+                active={!allLighting && lighting.has(l.value)}
+                onClick={() => onToggleLighting(l.value)}
+                disabled={count === 0}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -120,15 +139,19 @@ export default function StepConditions() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <FilterChip label="All Types" active={allCollisionTypes} onClick={() => setCollisionType(new Set())} />
-          {COLLISION_TYPES.map((ct) => (
-            <FilterChip
-              key={ct.value}
-              label={ct.label}
-              active={!allCollisionTypes && collisionType.has(ct.value)}
-              onClick={() => toggleCollisionType(ct.value)}
-            />
-          ))}
+          <FilterChip label="All Types" active={allCollisionTypes} onClick={onClearCollisionType} />
+          {COLLISION_TYPES.map((ct) => {
+            const count = conditionCounts?.collisionType?.[ct.value];
+            return (
+              <FilterChip
+                key={ct.value}
+                label={count != null ? `${ct.label} (${fmt(count)})` : ct.label}
+                active={!allCollisionTypes && collisionType.has(ct.value)}
+                onClick={() => onToggleCollisionType(ct.value)}
+                disabled={count === 0}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -141,13 +164,13 @@ export default function StepConditions() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <FilterChip label="All Roads" active={roadType === null} onClick={() => setRoadType(null)} />
+          <FilterChip label="All Roads" active={roadType === null} onClick={() => onSetRoadType(null)} />
           {ROAD_TYPES.map((rt) => (
             <FilterChip
               key={rt.value}
               label={rt.label}
               active={roadType === rt.value}
-              onClick={() => toggleRoadType(rt.value)}
+              onClick={() => onSetRoadType(roadType === rt.value ? null : rt.value)}
             />
           ))}
         </div>
@@ -166,7 +189,7 @@ export default function StepConditions() {
             label="Hit-and-Run Only"
             icon="warning"
             active={hitRun}
-            onClick={() => setHitRun((prev) => !prev)}
+            onClick={onToggleHitRun}
           />
         </div>
       </div>

--- a/frontend/src/components/map/filters/StepConditions.tsx
+++ b/frontend/src/components/map/filters/StepConditions.tsx
@@ -33,6 +33,8 @@ interface ConditionCounts {
   weather?: Record<string, number>;
   lighting?: Record<string, number>;
   collisionType?: Record<string, number>;
+  roadType?: Record<string, number>;
+  hitRun?: number;
 }
 
 interface StepConditionsProps {
@@ -50,6 +52,7 @@ interface StepConditionsProps {
   onSetRoadType: (v: string | null) => void;
   onToggleHitRun: () => void;
   conditionCounts?: ConditionCounts;
+  loading?: boolean;
 }
 
 function fmt(n: number): string {
@@ -73,10 +76,29 @@ export default function StepConditions({
   onSetRoadType,
   onToggleHitRun,
   conditionCounts,
+  loading,
 }: StepConditionsProps) {
   const allWeather = weather.size === 0;
   const allLighting = lighting.size === 0;
   const allCollisionTypes = collisionType.size === 0;
+
+  if (loading) {
+    return (
+      <div className="space-y-6 animate-pulse">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="space-y-3">
+            <div className="h-4 bg-surface-container-high rounded w-48" />
+            <div className="h-3 bg-surface-container-high rounded w-64" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: i === 4 ? 3 : i === 5 ? 1 : 5 }, (_, j) => (
+                <div key={j} className="h-8 bg-surface-container-high rounded-full w-20" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -165,14 +187,18 @@ export default function StepConditions({
         </div>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="All Roads" active={roadType === null} onClick={() => onSetRoadType(null)} />
-          {ROAD_TYPES.map((rt) => (
-            <FilterChip
-              key={rt.value}
-              label={rt.label}
-              active={roadType === rt.value}
-              onClick={() => onSetRoadType(roadType === rt.value ? null : rt.value)}
-            />
-          ))}
+          {ROAD_TYPES.map((rt) => {
+            const count = conditionCounts?.roadType?.[rt.value];
+            return (
+              <FilterChip
+                key={rt.value}
+                label={count != null ? `${rt.label} (${fmt(count)})` : rt.label}
+                active={roadType === rt.value}
+                disabled={count === 0}
+                onClick={() => onSetRoadType(roadType === rt.value ? null : rt.value)}
+              />
+            );
+          })}
         </div>
       </div>
 
@@ -186,9 +212,10 @@ export default function StepConditions({
         </div>
         <div className="flex flex-wrap gap-2">
           <FilterChip
-            label="Hit-and-Run Only"
+            label={conditionCounts?.hitRun != null ? `Hit-and-Run Only (${fmt(conditionCounts.hitRun)})` : "Hit-and-Run Only"}
             icon="warning"
             active={hitRun}
+            disabled={conditionCounts?.hitRun === 0}
             onClick={onToggleHitRun}
           />
         </div>

--- a/frontend/src/components/map/filters/StepViewBy.tsx
+++ b/frontend/src/components/map/filters/StepViewBy.tsx
@@ -5,6 +5,8 @@ interface StepViewByProps {
   measure: MeasureKey;
   onSetMeasure: (m: MeasureKey) => void;
   staged?: StagedFilters;
+  crashCount?: number | null;
+  crashCountLoading?: boolean;
 }
 
 const MEASURE_LIST: { key: MeasureKey; label: string; description: string; group?: string }[] = [
@@ -24,6 +26,11 @@ const MEASURE_LIST: { key: MeasureKey; label: string; description: string; group
   { key: "pollution_burden", label: "Pollution Burden", description: "CalEnviroScreen pollution burden score", group: "Environmental" },
   { key: "traffic_score", label: "Traffic Proximity", description: "CalEnviroScreen traffic proximity and volume score", group: "Environmental" },
   { key: "unemployment_rate", label: "Unemployment Rate", description: "Average unemployment rate across selected period", group: "Economic" },
+];
+
+const CRASH_MEASURES: MeasureKey[] = [
+  "crashes_raw", "crashes_per_100k", "fatalities_per_100k", "injuries_per_100k",
+  "fatality_rate", "crashes_per_income", "crashes_per_poverty",
 ];
 
 const DEMO_MEASURES: MeasureKey[] = [
@@ -56,6 +63,12 @@ function demoInfoText(m: MeasureKey): string {
   return "Population data available 2005-2023. Earlier years show as hatched.";
 }
 
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return n.toLocaleString();
+}
+
 function getSelectedYearRange(staged?: StagedFilters): { min: number; max: number } | null {
   if (!staged) return null;
   if (staged.dateRange) {
@@ -71,15 +84,17 @@ function getSelectedYearRange(staged?: StagedFilters): { min: number; max: numbe
   return null;
 }
 
-function isMeasureAvailable(key: MeasureKey, staged?: StagedFilters): { available: boolean; reason?: string } {
+function hasDemoOverlap(range: { min: number; max: number } | null): boolean {
+  if (!range) return true;
+  return range.max >= 2005 && range.min <= 2023;
+}
+
+function isMeasureAvailable(key: MeasureKey, staged?: StagedFilters, crashCount?: number | null): { available: boolean; reason?: string } {
   const range = getSelectedYearRange(staged);
 
   if (PER_CAPITA_MEASURES.includes(key) || DEMO_MEASURES.includes(key)) {
-    if (range && range.max < 2005) {
-      return { available: false, reason: "Demographics data starts at 2005" };
-    }
-    if (range && range.min > 2023) {
-      return { available: false, reason: "Demographics data ends at 2023" };
+    if (!hasDemoOverlap(range)) {
+      return { available: false, reason: "No demographics data for selected years (available 2005–2023)" };
     }
   }
 
@@ -89,10 +104,57 @@ function isMeasureAvailable(key: MeasureKey, staged?: StagedFilters): { availabl
     }
   }
 
+  if (CRASH_MEASURES.includes(key) && crashCount != null && crashCount === 0) {
+    return { available: false, reason: "No crashes match current filters" };
+  }
+
+  const hasCrashFilters = staged && (
+    staged.severities.size > 0 || staged.causes.size > 0
+    || staged.alcohol || staged.distracted || staged.pedestrian
+    || staged.cyclist || staged.drug || staged.driverAge !== null
+    || staged.weather.size > 0 || staged.lighting.size > 0
+    || staged.collisionType.size > 0 || staged.roadType !== null
+    || staged.hitRun
+  );
+
+  const isPureDemoOrContext = (DEMO_MEASURES.includes(key) || CONTEXT_MEASURES.includes(key))
+    && !CRASH_MEASURES.includes(key);
+
+  if (hasCrashFilters && isPureDemoOrContext) {
+    return { available: false, reason: "Not relevant with crash filters active" };
+  }
+
   return { available: true };
 }
 
-export default function StepViewBy({ measure, onSetMeasure, staged }: StepViewByProps) {
+function getMeasureSubtext(key: MeasureKey, m: { description: string }, available: boolean, reason: string | undefined, crashCount: number | null | undefined, staged?: StagedFilters): string {
+  if (!available) return reason ?? "";
+
+  const range = getSelectedYearRange(staged);
+
+  if (CRASH_MEASURES.includes(key) && crashCount != null) {
+    const base = `${fmt(crashCount)} crashes`;
+    if ((PER_CAPITA_MEASURES.includes(key) || DEMO_MEASURES.includes(key)) && range && !hasDemoOverlap(range)) {
+      return base;
+    }
+    if (PER_CAPITA_MEASURES.includes(key) || DEMO_MEASURES.includes(key)) {
+      return `${base} · 58 counties with demographics`;
+    }
+    return base;
+  }
+
+  if (DEMO_MEASURES.includes(key) && !CRASH_MEASURES.includes(key)) {
+    return "58 counties · Census ACS data";
+  }
+
+  if (CONTEXT_MEASURES.includes(key)) {
+    return key === "unemployment_rate" ? "58 counties · EDD data" : "58 counties · CalEnviroScreen";
+  }
+
+  return m.description;
+}
+
+export default function StepViewBy({ measure, onSetMeasure, staged, crashCount, crashCountLoading }: StepViewByProps) {
   return (
     <div className="space-y-4">
       <div>
@@ -103,40 +165,49 @@ export default function StepViewBy({ measure, onSetMeasure, staged }: StepViewBy
       </div>
 
       <div className="space-y-2">
-        {MEASURE_LIST.map((m, i) => {
-          const prevGroup = i > 0 ? MEASURE_LIST[i - 1].group : undefined;
-          const showHeader = m.group && m.group !== prevGroup;
-          const { available, reason } = isMeasureAvailable(m.key, staged);
-          return (
-            <div key={m.key}>
-              {showHeader && (
-                <p className="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant mt-3 mb-1">
-                  {m.group}
-                </p>
-              )}
-              <button
-                onClick={available ? () => onSetMeasure(m.key) : undefined}
-                disabled={!available}
-                className={`w-full text-left px-4 py-3 rounded-xl transition-all ${
-                  !available
-                    ? "bg-surface-container-high/50 text-on-surface-variant/40 cursor-not-allowed"
-                    : measure === m.key
+        {(() => {
+          const visible = MEASURE_LIST.filter((m) => isMeasureAvailable(m.key, staged, crashCount).available);
+          const visibleGroups = new Set(visible.map((m) => m.group));
+          let lastGroup: string | undefined;
+
+          return visible.map((m) => {
+            const showHeader = m.group && m.group !== lastGroup && visibleGroups.has(m.group);
+            if (m.group) lastGroup = m.group;
+            const subtext = getMeasureSubtext(m.key, m, true, undefined, crashCount, staged);
+            return (
+              <div key={m.key}>
+                {showHeader && (
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-on-surface-variant mt-3 mb-1">
+                    {m.group}
+                  </p>
+                )}
+                <button
+                  onClick={() => onSetMeasure(m.key)}
+                  className={`w-full text-left px-4 py-3 rounded-xl transition-all ${
+                    measure === m.key
                       ? "bg-primary text-on-primary"
                       : "bg-surface-container-high text-on-surface hover:bg-surface-variant"
-                }`}
-              >
-                <p className="text-sm font-semibold">{m.label}</p>
-                <p className={`text-[10px] mt-0.5 ${
-                  !available
-                    ? "text-on-surface-variant/30"
-                    : measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
-                }`}>
-                  {available ? m.description : reason}
-                </p>
-              </button>
-            </div>
-          );
-        })}
+                  }`}
+                >
+                  <p className="text-sm font-semibold">
+                    {m.label}
+                    {CRASH_MEASURES.includes(m.key) && crashCount != null && !crashCountLoading && (
+                      <span className="text-xs font-normal ml-2 opacity-70">({fmt(crashCount)})</span>
+                    )}
+                    {CRASH_MEASURES.includes(m.key) && crashCountLoading && (
+                      <span className="text-xs font-normal ml-2 opacity-50 animate-pulse">…</span>
+                    )}
+                  </p>
+                  <p className={`text-[10px] mt-0.5 ${
+                    measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
+                  }`}>
+                    {subtext}
+                  </p>
+                </button>
+              </div>
+            );
+          });
+        })()}
       </div>
 
       {needsDemoInfo(measure) && (

--- a/frontend/src/components/map/filters/StepViewBy.tsx
+++ b/frontend/src/components/map/filters/StepViewBy.tsx
@@ -1,8 +1,10 @@
 import type { MeasureKey } from "../../../lib/choropleth/measures";
+import type { StagedFilters } from "../../../hooks/useStagedFilters";
 
 interface StepViewByProps {
   measure: MeasureKey;
   onSetMeasure: (m: MeasureKey) => void;
+  staged?: StagedFilters;
 }
 
 const MEASURE_LIST: { key: MeasureKey; label: string; description: string; group?: string }[] = [
@@ -54,7 +56,43 @@ function demoInfoText(m: MeasureKey): string {
   return "Population data available 2005-2023. Earlier years show as hatched.";
 }
 
-export default function StepViewBy({ measure, onSetMeasure }: StepViewByProps) {
+function getSelectedYearRange(staged?: StagedFilters): { min: number; max: number } | null {
+  if (!staged) return null;
+  if (staged.dateRange) {
+    return {
+      min: staged.dateRange.start?.year ?? 2001,
+      max: staged.dateRange.end?.year ?? new Date().getFullYear(),
+    };
+  }
+  if (staged.selectedYears.size > 0) {
+    const years = [...staged.selectedYears];
+    return { min: Math.min(...years), max: Math.max(...years) };
+  }
+  return null;
+}
+
+function isMeasureAvailable(key: MeasureKey, staged?: StagedFilters): { available: boolean; reason?: string } {
+  const range = getSelectedYearRange(staged);
+
+  if (PER_CAPITA_MEASURES.includes(key) || DEMO_MEASURES.includes(key)) {
+    if (range && range.max < 2005) {
+      return { available: false, reason: "Demographics data starts at 2005" };
+    }
+    if (range && range.min > 2023) {
+      return { available: false, reason: "Demographics data ends at 2023" };
+    }
+  }
+
+  if (key === "unemployment_rate") {
+    if (range && range.max < 2005) {
+      return { available: false, reason: "Unemployment data starts at 2005" };
+    }
+  }
+
+  return { available: true };
+}
+
+export default function StepViewBy({ measure, onSetMeasure, staged }: StepViewByProps) {
   return (
     <div className="space-y-4">
       <div>
@@ -68,6 +106,7 @@ export default function StepViewBy({ measure, onSetMeasure }: StepViewByProps) {
         {MEASURE_LIST.map((m, i) => {
           const prevGroup = i > 0 ? MEASURE_LIST[i - 1].group : undefined;
           const showHeader = m.group && m.group !== prevGroup;
+          const { available, reason } = isMeasureAvailable(m.key, staged);
           return (
             <div key={m.key}>
               {showHeader && (
@@ -76,18 +115,23 @@ export default function StepViewBy({ measure, onSetMeasure }: StepViewByProps) {
                 </p>
               )}
               <button
-                onClick={() => onSetMeasure(m.key)}
+                onClick={available ? () => onSetMeasure(m.key) : undefined}
+                disabled={!available}
                 className={`w-full text-left px-4 py-3 rounded-xl transition-all ${
-                  measure === m.key
-                    ? "bg-primary text-on-primary"
-                    : "bg-surface-container-high text-on-surface hover:bg-surface-variant"
+                  !available
+                    ? "bg-surface-container-high/50 text-on-surface-variant/40 cursor-not-allowed"
+                    : measure === m.key
+                      ? "bg-primary text-on-primary"
+                      : "bg-surface-container-high text-on-surface hover:bg-surface-variant"
                 }`}
               >
                 <p className="text-sm font-semibold">{m.label}</p>
                 <p className={`text-[10px] mt-0.5 ${
-                  measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
+                  !available
+                    ? "text-on-surface-variant/30"
+                    : measure === m.key ? "text-on-primary/80" : "text-on-surface-variant"
                 }`}>
-                  {m.description}
+                  {available ? m.description : reason}
                 </p>
               </button>
             </div>

--- a/frontend/src/components/map/filters/StepWhat.tsx
+++ b/frontend/src/components/map/filters/StepWhat.tsx
@@ -10,6 +10,7 @@ interface StepWhatProps {
   onClearSeverities: () => void;
   causeCounts?: Record<string, number>;
   severityCounts?: Record<string, number>;
+  loading?: boolean;
 }
 
 function fmtCount(n: number): string {
@@ -18,9 +19,27 @@ function fmtCount(n: number): string {
   return n.toLocaleString();
 }
 
-export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggleSeverity, onClearSeverities, causeCounts, severityCounts }: StepWhatProps) {
+export default function StepWhat({ staged, onToggleCause, onClearCauses, onToggleSeverity, onClearSeverities, causeCounts, severityCounts, loading }: StepWhatProps) {
   const allCauses = staged.causes.size === 0;
   const allSeverities = staged.severities.size === 0;
+
+  if (loading) {
+    return (
+      <div className="space-y-6 animate-pulse">
+        {[1, 2].map((i) => (
+          <div key={i} className="space-y-3">
+            <div className="h-4 bg-surface-container-high rounded w-44" />
+            <div className="h-3 bg-surface-container-high rounded w-60" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: i === 1 ? 10 : 4 }, (_, j) => (
+                <div key={j} className="h-8 bg-surface-container-high rounded-full w-24" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/components/map/filters/StepWhen.tsx
+++ b/frontend/src/components/map/filters/StepWhen.tsx
@@ -17,6 +17,7 @@ interface StepWhenProps {
   onSetAllYears: () => void;
   onSetDateRange?: (start: YearMonth | null, end: YearMonth | null) => void;
   yearCounts?: Record<number, number>;
+  loading?: boolean;
 }
 
 function fmtCount(n: number): string {
@@ -25,7 +26,7 @@ function fmtCount(n: number): string {
   return n.toLocaleString();
 }
 
-export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDateRange, yearCounts }: StepWhenProps) {
+export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDateRange, yearCounts, loading }: StepWhenProps) {
   const usingRange = !!staged.dateRange;
   const usingYears = staged.selectedYears.size > 0;
   const allSelected = !usingRange && !usingYears;
@@ -52,6 +53,20 @@ export default function StepWhen({ staged, onToggleYear, onSetAllYears, onSetDat
       onSetDateRange(s, e);
     }
   };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 animate-pulse">
+        <div className="h-4 bg-surface-container-high rounded w-40" />
+        <div className="h-3 bg-surface-container-high rounded w-64" />
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 12 }, (_, j) => (
+            <div key={j} className="h-8 bg-surface-container-high rounded-full w-16" />
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/map/filters/StepWho.tsx
+++ b/frontend/src/components/map/filters/StepWho.tsx
@@ -8,6 +8,8 @@ interface StepWhoProps {
   onToggleInvolvement: (key: "alcohol" | "distracted" | "pedestrian" | "cyclist" | "drug") => void;
   onSetDriverAge: (bracket: string | null) => void;
   involvementCounts?: Record<string, number>;
+  driverAgeCounts?: Record<string, number>;
+  loading?: boolean;
 }
 
 function fmtCount(n: number): string {
@@ -24,7 +26,7 @@ const INV_KEYS: Record<string, keyof Pick<StagedFilters, "alcohol" | "distracted
   drug: "drug",
 };
 
-export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSetDriverAge, involvementCounts }: StepWhoProps) {
+export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSetDriverAge, involvementCounts, driverAgeCounts, loading }: StepWhoProps) {
   if (!has2016Plus) {
     return (
       <div className="space-y-4">
@@ -40,6 +42,24 @@ export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSe
             Select at least one year from 2016 or later in Step 1 to unlock these filters.
           </p>
         </div>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6 animate-pulse">
+        {[1, 2].map((i) => (
+          <div key={i} className="space-y-3">
+            <div className="h-4 bg-surface-container-high rounded w-40" />
+            <div className="h-3 bg-surface-container-high rounded w-56" />
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: i === 1 ? 5 : 6 }, (_, j) => (
+                <div key={j} className="h-8 bg-surface-container-high rounded-full w-20" />
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
@@ -80,14 +100,19 @@ export default function StepWho({ staged, has2016Plus, onToggleInvolvement, onSe
         </div>
         <div className="flex flex-wrap gap-2">
           <FilterChip label="Any Age" active={staged.driverAge === null} onClick={() => onSetDriverAge(null)} />
-          {DRIVER_AGE_BRACKETS.map((b) => (
-            <FilterChip
-              key={b.value}
-              label={b.label}
-              active={staged.driverAge === b.value}
-              onClick={() => onSetDriverAge(staged.driverAge === b.value ? null : b.value)}
-            />
-          ))}
+          {DRIVER_AGE_BRACKETS.map((b) => {
+            const count = driverAgeCounts?.[b.value];
+            return (
+              <FilterChip
+                key={b.value}
+                label={b.label}
+                count={count != null ? fmtCount(count) : undefined}
+                active={staged.driverAge === b.value}
+                disabled={count === 0}
+                onClick={() => onSetDriverAge(staged.driverAge === b.value ? null : b.value)}
+              />
+            );
+          })}
         </div>
       </div>
 

--- a/frontend/src/hooks/useChoroplethData.ts
+++ b/frontend/src/hooks/useChoroplethData.ts
@@ -30,6 +30,11 @@ export type ChoroplethFilters = {
   cyclist?: boolean;
   drug?: boolean;
   driverAge?: string | null;
+  weather?: string[];
+  lighting?: string[];
+  collisionType?: string[];
+  roadType?: string | null;
+  hitRun?: boolean;
 };
 
 export type ChoroplethPoint = MeasureResult & {
@@ -74,6 +79,11 @@ function normalizeFilters(filters: ChoroplethFilters): ChoroplethFilters {
     cyclist: filters.cyclist,
     drug: filters.drug,
     driverAge: filters.driverAge,
+    weather: filters.weather,
+    lighting: filters.lighting,
+    collisionType: filters.collisionType,
+    roadType: filters.roadType,
+    hitRun: filters.hitRun,
   };
 }
 
@@ -94,6 +104,11 @@ function appendInvolvement(p: URLSearchParams, filters: ChoroplethFilters) {
   if (filters.cyclist) p.set("cyclist", "true");
   if (filters.drug) p.set("drug", "true");
   if (filters.driverAge) p.set("driver_age", filters.driverAge);
+  if (filters.weather?.length) p.set("weather", filters.weather.join(","));
+  if (filters.lighting?.length) p.set("lighting", filters.lighting.join(","));
+  if (filters.collisionType?.length) p.set("collision_type", filters.collisionType.join(","));
+  if (filters.roadType) p.set("road_type", filters.roadType);
+  if (filters.hitRun) p.set("hit_run", "true");
 }
 
 function buildStatsUrl(filters: ChoroplethFilters): string {

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -23,6 +23,11 @@ interface HeatmapParams {
   cyclist?: boolean | null;
   drug?: boolean | null;
   driverAge?: string | null;
+  weather?: string[];
+  lighting?: string[];
+  collisionType?: string[];
+  roadType?: string | null;
+  hitRun?: boolean;
   resolution: HeatmapResolution;
   mismatchOnly?: boolean;
   includeRivers?: boolean;
@@ -56,6 +61,11 @@ function buildUrl(params: HeatmapParams): string {
   if (params.cyclist != null) sp.set("cyclist", String(params.cyclist));
   if (params.drug != null) sp.set("drug", String(params.drug));
   if (params.driverAge) sp.set("driver_age", params.driverAge);
+  if (params.weather?.length) sp.set("weather", params.weather.join(","));
+  if (params.lighting?.length) sp.set("lighting", params.lighting.join(","));
+  if (params.collisionType?.length) sp.set("collision_type", params.collisionType.join(","));
+  if (params.roadType) sp.set("road_type", params.roadType);
+  if (params.hitRun) sp.set("hit_run", "true");
   sp.set("resolution", params.resolution);
   if (params.mismatchOnly) sp.set("mismatch_only", "true");
   if (params.includeRivers) sp.set("include_rivers", "true");

--- a/frontend/src/hooks/useFacetCounts.ts
+++ b/frontend/src/hooks/useFacetCounts.ts
@@ -2,11 +2,21 @@ import { useEffect, useState, useRef } from "react";
 import { API_BASE } from "../config";
 import type { StagedFilters } from "./useStagedFilters";
 
+export interface ConditionCounts {
+  weather?: Record<string, number>;
+  lighting?: Record<string, number>;
+  collisionType?: Record<string, number>;
+  roadType?: Record<string, number>;
+  hitRun?: number;
+}
+
 export interface FacetCounts {
   years: Record<number, number>;
   severities: Record<string, number>;
   causes: Record<string, number>;
   involvement: Record<string, number>;
+  driverAge: Record<string, number>;
+  conditions: ConditionCounts;
   loading: boolean;
 }
 
@@ -30,6 +40,11 @@ function buildParams(staged: StagedFilters, exclude: string): string {
   if (exclude !== "cyclist" && staged.cyclist) p.set("cyclist", "true");
   if (exclude !== "drug" && staged.drug) p.set("drug", "true");
   if (exclude !== "driverAge" && staged.driverAge) p.set("driver_age", staged.driverAge);
+  if (exclude !== "weather" && staged.weather.size > 0) p.set("weather", [...staged.weather].join(","));
+  if (exclude !== "lighting" && staged.lighting.size > 0) p.set("lighting", [...staged.lighting].join(","));
+  if (exclude !== "collisionType" && staged.collisionType.size > 0) p.set("collision_type", [...staged.collisionType].join(","));
+  if (exclude !== "roadType" && staged.roadType) p.set("road_type", staged.roadType);
+  if (exclude !== "hitRun" && staged.hitRun) p.set("hit_run", "true");
 
   return p.toString();
 }
@@ -51,6 +66,7 @@ export function useFacetCounts(staged: StagedFilters): FacetCounts {
     severities: {},
     causes: {},
     involvement: {},
+    conditions: {},
     loading: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -69,20 +85,26 @@ export function useFacetCounts(staged: StagedFilters): FacetCounts {
       const sevParams = buildParams(staged, "severity");
       const causeParams = buildParams(staged, "cause");
       const baseParams = buildParams(staged, "");
+      const weatherParams = buildParams(staged, "weather");
+      const lightingParams = buildParams(staged, "lighting");
+      const collisionParams = buildParams(staged, "collisionType");
+
+      const fetchJson = (url: string) =>
+        fetch(url, { signal: abort.signal }).then((r) => r.ok ? r.json() : []).catch(() => []);
 
       Promise.all([
-        fetch(`${API_BASE}/api/stats?group_by=year&${yearParams}`, { signal: abort.signal })
-          .then((r) => r.ok ? r.json() : []).catch(() => []),
-        fetch(`${API_BASE}/api/stats?group_by=severity&${sevParams}`, { signal: abort.signal })
-          .then((r) => r.ok ? r.json() : []).catch(() => []),
-        fetch(`${API_BASE}/api/stats?group_by=cause&${causeParams}`, { signal: abort.signal })
-          .then((r) => r.ok ? r.json() : []).catch(() => []),
+        fetchJson(`${API_BASE}/api/stats?group_by=year&${yearParams}`),
+        fetchJson(`${API_BASE}/api/stats?group_by=severity&${sevParams}`),
+        fetchJson(`${API_BASE}/api/stats?group_by=cause&${causeParams}`),
         fetchCount(`${API_BASE}/api/stats?${baseParams}&alcohol=true`, abort.signal),
         fetchCount(`${API_BASE}/api/stats?${baseParams}&distracted=true`, abort.signal),
         fetchCount(`${API_BASE}/api/stats?${baseParams}&pedestrian=true`, abort.signal),
         fetchCount(`${API_BASE}/api/stats?${baseParams}&cyclist=true`, abort.signal),
         fetchCount(`${API_BASE}/api/stats?${baseParams}&drug=true`, abort.signal),
-      ]).then(([yearData, sevData, causeData, alcCount, distCount, pedCount, cycCount, drugCount]) => {
+        fetchJson(`${API_BASE}/api/stats?group_by=weather&${weatherParams}`),
+        fetchJson(`${API_BASE}/api/stats?group_by=lighting&${lightingParams}`),
+        fetchJson(`${API_BASE}/api/stats?group_by=collision_type&${collisionParams}`),
+      ]).then(([yearData, sevData, causeData, alcCount, distCount, pedCount, cycCount, drugCount, weatherData, lightingData, collisionData]) => {
         if (abort.signal.aborted) return;
 
         const years: Record<number, number> = {};
@@ -106,7 +128,22 @@ export function useFacetCounts(staged: StagedFilters): FacetCounts {
           drug: drugCount,
         };
 
-        setCounts({ years, severities, causes, involvement, loading: false });
+        const weatherCounts: Record<string, number> = {};
+        for (const r of weatherData) if (r.value !== "unknown") weatherCounts[r.value] = r.crash_count;
+
+        const lightingCounts: Record<string, number> = {};
+        for (const r of lightingData) if (r.value !== "unknown") lightingCounts[r.value] = r.crash_count;
+
+        const collisionCounts: Record<string, number> = {};
+        for (const r of collisionData) if (r.value !== "unknown") collisionCounts[r.value] = r.crash_count;
+
+        const conditions: ConditionCounts = {
+          weather: weatherCounts,
+          lighting: lightingCounts,
+          collisionType: collisionCounts,
+        };
+
+        setCounts({ years, severities, causes, involvement, conditions, loading: false });
       });
     }, 300);
 
@@ -127,6 +164,14 @@ export function useFacetCounts(staged: StagedFilters): FacetCounts {
     staged.cyclist,
     staged.drug,
     staged.driverAge,
+    staged.weather.size,
+    [...staged.weather].join(","),
+    staged.lighting.size,
+    [...staged.lighting].join(","),
+    staged.collisionType.size,
+    [...staged.collisionType].join(","),
+    staged.roadType,
+    staged.hitRun,
     staged.dateRange?.start?.year,
     staged.dateRange?.start?.month,
     staged.dateRange?.end?.year,

--- a/frontend/src/hooks/useFacetCounts.ts
+++ b/frontend/src/hooks/useFacetCounts.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { API_BASE } from "../config";
 import type { StagedFilters } from "./useStagedFilters";
 
@@ -10,14 +10,18 @@ export interface ConditionCounts {
   hitRun?: number;
 }
 
-export interface FacetCounts {
+interface FacetData {
   years: Record<number, number>;
   severities: Record<string, number>;
   causes: Record<string, number>;
   involvement: Record<string, number>;
   driverAge: Record<string, number>;
   conditions: ConditionCounts;
+}
+
+export interface FacetCounts extends FacetData {
   loading: boolean;
+  loaded: boolean;
 }
 
 function buildParams(staged: StagedFilters, exclude: string): string {
@@ -49,9 +53,9 @@ function buildParams(staged: StagedFilters, exclude: string): string {
   return p.toString();
 }
 
-async function fetchCount(url: string, signal: AbortSignal): Promise<number> {
+async function fetchCount(url: string): Promise<number> {
   try {
-    const r = await fetch(url, { signal });
+    const r = await fetch(url);
     if (!r.ok) return 0;
     const data = await r.json();
     return data.total_crashes ?? 0;
@@ -60,123 +64,136 @@ async function fetchCount(url: string, signal: AbortSignal): Promise<number> {
   }
 }
 
-export function useFacetCounts(staged: StagedFilters): FacetCounts {
-  const [counts, setCounts] = useState<FacetCounts>({
-    years: {},
-    severities: {},
-    causes: {},
-    involvement: {},
-    conditions: {},
-    loading: false,
-  });
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
+function serializeStaged(staged: StagedFilters): string[] {
+  return [
+    [...staged.selectedYears].sort().join(","),
+    [...staged.severities].sort().join(","),
+    [...staged.causes].sort().join(","),
+    staged.alcohol ? "1" : "0",
+    staged.distracted ? "1" : "0",
+    staged.pedestrian ? "1" : "0",
+    staged.cyclist ? "1" : "0",
+    staged.drug ? "1" : "0",
+    staged.driverAge ?? "",
+    [...staged.weather].sort().join(","),
+    [...staged.lighting].sort().join(","),
+    [...staged.collisionType].sort().join(","),
+    staged.roadType ?? "",
+    staged.hitRun ? "1" : "0",
+    staged.dateRange?.start?.year?.toString() ?? "",
+    staged.dateRange?.start?.month?.toString() ?? "",
+    staged.dateRange?.end?.year?.toString() ?? "",
+    staged.dateRange?.end?.month?.toString() ?? "",
+  ];
+}
 
-  useEffect(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    if (abortRef.current) abortRef.current.abort();
+async function fetchAllFacets(staged: StagedFilters): Promise<FacetData> {
+  const yearParams = buildParams(staged, "year");
+  const sevParams = buildParams(staged, "severity");
+  const causeParams = buildParams(staged, "cause");
+  const baseParams = buildParams(staged, "");
+  const weatherParams = buildParams(staged, "weather");
+  const lightingParams = buildParams(staged, "lighting");
+  const collisionParams = buildParams(staged, "collisionType");
+  const driverAgeParams = buildParams(staged, "driverAge");
+  const roadTypeParams = buildParams(staged, "roadType");
+  const hitRunParams = buildParams(staged, "hitRun");
 
-    timerRef.current = setTimeout(() => {
-      const abort = new AbortController();
-      abortRef.current = abort;
-      setCounts((prev) => ({ ...prev, loading: true }));
+  const fetchJson = (url: string) =>
+    fetch(url).then((r) => r.ok ? r.json() : []).catch(() => []);
 
-      const yearParams = buildParams(staged, "year");
-      const sevParams = buildParams(staged, "severity");
-      const causeParams = buildParams(staged, "cause");
-      const baseParams = buildParams(staged, "");
-      const weatherParams = buildParams(staged, "weather");
-      const lightingParams = buildParams(staged, "lighting");
-      const collisionParams = buildParams(staged, "collisionType");
-
-      const fetchJson = (url: string) =>
-        fetch(url, { signal: abort.signal }).then((r) => r.ok ? r.json() : []).catch(() => []);
-
-      Promise.all([
-        fetchJson(`${API_BASE}/api/stats?group_by=year&${yearParams}`),
-        fetchJson(`${API_BASE}/api/stats?group_by=severity&${sevParams}`),
-        fetchJson(`${API_BASE}/api/stats?group_by=cause&${causeParams}`),
-        fetchCount(`${API_BASE}/api/stats?${baseParams}&alcohol=true`, abort.signal),
-        fetchCount(`${API_BASE}/api/stats?${baseParams}&distracted=true`, abort.signal),
-        fetchCount(`${API_BASE}/api/stats?${baseParams}&pedestrian=true`, abort.signal),
-        fetchCount(`${API_BASE}/api/stats?${baseParams}&cyclist=true`, abort.signal),
-        fetchCount(`${API_BASE}/api/stats?${baseParams}&drug=true`, abort.signal),
-        fetchJson(`${API_BASE}/api/stats?group_by=weather&${weatherParams}`),
-        fetchJson(`${API_BASE}/api/stats?group_by=lighting&${lightingParams}`),
-        fetchJson(`${API_BASE}/api/stats?group_by=collision_type&${collisionParams}`),
-      ]).then(([yearData, sevData, causeData, alcCount, distCount, pedCount, cycCount, drugCount, weatherData, lightingData, collisionData]) => {
-        if (abort.signal.aborted) return;
-
-        const years: Record<number, number> = {};
-        for (const r of yearData) years[r.year] = r.crash_count;
-
-        const severities: Record<string, number> = {};
-        for (const r of sevData) severities[r.severity] = r.crash_count;
-
-        const causes: Record<string, number> = {};
-        for (const r of causeData) {
-          const slug = (r.canonical_cause ?? "").replace(/_/g, "-");
-          causes[slug] = r.crash_count;
-          causes[r.canonical_cause] = r.crash_count;
-        }
-
-        const involvement: Record<string, number> = {
-          alcohol: alcCount,
-          distracted: distCount,
-          pedestrian: pedCount,
-          cyclist: cycCount,
-          drug: drugCount,
-        };
-
-        const weatherCounts: Record<string, number> = {};
-        for (const r of weatherData) if (r.value !== "unknown") weatherCounts[r.value] = r.crash_count;
-
-        const lightingCounts: Record<string, number> = {};
-        for (const r of lightingData) if (r.value !== "unknown") lightingCounts[r.value] = r.crash_count;
-
-        const collisionCounts: Record<string, number> = {};
-        for (const r of collisionData) if (r.value !== "unknown") collisionCounts[r.value] = r.crash_count;
-
-        const conditions: ConditionCounts = {
-          weather: weatherCounts,
-          lighting: lightingCounts,
-          collisionType: collisionCounts,
-        };
-
-        setCounts({ years, severities, causes, involvement, conditions, loading: false });
-      });
-    }, 300);
-
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (abortRef.current) abortRef.current.abort();
-    };
-  }, [
-    staged.selectedYears.size,
-    [...staged.selectedYears].join(","),
-    staged.severities.size,
-    [...staged.severities].join(","),
-    staged.causes.size,
-    [...staged.causes].join(","),
-    staged.alcohol,
-    staged.distracted,
-    staged.pedestrian,
-    staged.cyclist,
-    staged.drug,
-    staged.driverAge,
-    staged.weather.size,
-    [...staged.weather].join(","),
-    staged.lighting.size,
-    [...staged.lighting].join(","),
-    staged.collisionType.size,
-    [...staged.collisionType].join(","),
-    staged.roadType,
-    staged.hitRun,
-    staged.dateRange?.start?.year,
-    staged.dateRange?.start?.month,
-    staged.dateRange?.end?.year,
-    staged.dateRange?.end?.month,
+  const [
+    yearData, sevData, causeData,
+    alcCount, distCount, pedCount, cycCount, drugCount,
+    weatherData, lightingData, collisionData,
+    age1621, age2234, age3549, age5064, age65p,
+    roadHighway, roadLocal, hitRunCount,
+  ] = await Promise.all([
+    fetchJson(`${API_BASE}/api/stats?group_by=year&${yearParams}`),
+    fetchJson(`${API_BASE}/api/stats?group_by=severity&${sevParams}`),
+    fetchJson(`${API_BASE}/api/stats?group_by=cause&${causeParams}`),
+    fetchCount(`${API_BASE}/api/stats?${baseParams}&alcohol=true`),
+    fetchCount(`${API_BASE}/api/stats?${baseParams}&distracted=true`),
+    fetchCount(`${API_BASE}/api/stats?${baseParams}&pedestrian=true`),
+    fetchCount(`${API_BASE}/api/stats?${baseParams}&cyclist=true`),
+    fetchCount(`${API_BASE}/api/stats?${baseParams}&drug=true`),
+    fetchJson(`${API_BASE}/api/stats?group_by=weather&${weatherParams}`),
+    fetchJson(`${API_BASE}/api/stats?group_by=lighting&${lightingParams}`),
+    fetchJson(`${API_BASE}/api/stats?group_by=collision_type&${collisionParams}`),
+    fetchCount(`${API_BASE}/api/stats?${driverAgeParams}&driver_age=16-21`),
+    fetchCount(`${API_BASE}/api/stats?${driverAgeParams}&driver_age=22-34`),
+    fetchCount(`${API_BASE}/api/stats?${driverAgeParams}&driver_age=35-49`),
+    fetchCount(`${API_BASE}/api/stats?${driverAgeParams}&driver_age=50-64`),
+    fetchCount(`${API_BASE}/api/stats?${driverAgeParams}&driver_age=65%2B`),
+    fetchCount(`${API_BASE}/api/stats?${roadTypeParams}&road_type=highway`),
+    fetchCount(`${API_BASE}/api/stats?${roadTypeParams}&road_type=local`),
+    fetchCount(`${API_BASE}/api/stats?${hitRunParams}&hit_run=true`),
   ]);
 
-  return counts;
+  const years: Record<number, number> = {};
+  for (const r of yearData) years[r.year] = r.crash_count;
+
+  const severities: Record<string, number> = {};
+  for (const r of sevData) severities[r.severity] = r.crash_count;
+
+  const causes: Record<string, number> = {};
+  for (const r of causeData) {
+    const slug = (r.canonical_cause ?? "").replace(/_/g, "-");
+    causes[slug] = r.crash_count;
+    causes[r.canonical_cause] = r.crash_count;
+  }
+
+  return {
+    years,
+    severities,
+    causes,
+    involvement: {
+      alcohol: alcCount,
+      distracted: distCount,
+      pedestrian: pedCount,
+      cyclist: cycCount,
+      drug: drugCount,
+    },
+    driverAge: {
+      "16-21": age1621,
+      "22-34": age2234,
+      "35-49": age3549,
+      "50-64": age5064,
+      "65+": age65p,
+    },
+    conditions: {
+      weather: Object.fromEntries(weatherData.filter((r: { value: string }) => r.value !== "unknown").map((r: { value: string; crash_count: number }) => [r.value, r.crash_count])),
+      lighting: Object.fromEntries(lightingData.filter((r: { value: string }) => r.value !== "unknown").map((r: { value: string; crash_count: number }) => [r.value, r.crash_count])),
+      collisionType: Object.fromEntries(collisionData.filter((r: { value: string }) => r.value !== "unknown").map((r: { value: string; crash_count: number }) => [r.value, r.crash_count])),
+      roadType: { highway: roadHighway, local: roadLocal },
+      hitRun: hitRunCount,
+    },
+  };
+}
+
+const EMPTY: FacetData = {
+  years: {},
+  severities: {},
+  causes: {},
+  involvement: {},
+  driverAge: {},
+  conditions: {},
+};
+
+export function useFacetCounts(staged: StagedFilters): FacetCounts {
+  const queryKey = ["facet-counts", ...serializeStaged(staged)];
+
+  const { data, isFetching, isSuccess } = useQuery({
+    queryKey,
+    queryFn: () => fetchAllFacets(staged),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    placeholderData: keepPreviousData,
+  });
+
+  return {
+    ...(data ?? EMPTY),
+    loading: isFetching,
+    loaded: isSuccess || !!data,
+  };
 }

--- a/frontend/src/hooks/useFilterParams.ts
+++ b/frontend/src/hooks/useFilterParams.ts
@@ -223,11 +223,17 @@ export function parseBoolFlag(param: string | null): boolean {
   return param === "true";
 }
 
+export function parseSetParam(param: string | null): Set<string> {
+  if (!param) return new Set<string>();
+  return new Set(param.split(",").map((s) => s.trim()).filter(Boolean));
+}
+
 // ── Shared utilities ──
 
 const FILTER_KEYS = [
   "start", "end", "year", "severity", "county", "cause",
   "alcohol", "distracted", "pedestrian", "cyclist", "drug", "driver_age",
+  "weather", "lighting", "collision_type", "road_type", "hit_run",
 ] as const;
 
 export function buildFilterQS(searchParams: URLSearchParams): string {
@@ -262,6 +268,11 @@ export function useFilterParams() {
   const cyclistParam = searchParams.get("cyclist");
   const drugParam = searchParams.get("drug");
   const driverAgeParam = searchParams.get("driver_age");
+  const weatherParam = searchParams.get("weather");
+  const lightingParam = searchParams.get("lighting");
+  const collisionTypeParam = searchParams.get("collision_type");
+  const roadTypeParam = searchParams.get("road_type");
+  const hitRunParam = searchParams.get("hit_run");
   const panel = searchParams.get("panel");
 
   const selectedDateRange = useMemo<DateRangeFilter | null>(() => {
@@ -285,6 +296,11 @@ export function useFilterParams() {
   const selectedCyclist = useMemo(() => parseBoolFlag(cyclistParam), [cyclistParam]);
   const selectedDrug = useMemo(() => parseBoolFlag(drugParam), [drugParam]);
   const selectedDriverAge = useMemo(() => driverAgeParam ?? null, [driverAgeParam]);
+  const selectedWeather = useMemo(() => parseSetParam(weatherParam), [weatherParam]);
+  const selectedLighting = useMemo(() => parseSetParam(lightingParam), [lightingParam]);
+  const selectedCollisionType = useMemo(() => parseSetParam(collisionTypeParam), [collisionTypeParam]);
+  const selectedRoadType = useMemo(() => roadTypeParam ?? null, [roadTypeParam]);
+  const selectedHitRun = useMemo(() => parseBoolFlag(hitRunParam), [hitRunParam]);
 
   // ── Action callbacks ──
 
@@ -454,6 +470,11 @@ export function useFilterParams() {
       params.delete("cyclist");
       params.delete("drug");
       params.delete("driver_age");
+      params.delete("weather");
+      params.delete("lighting");
+      params.delete("collision_type");
+      params.delete("road_type");
+      params.delete("hit_run");
       return params;
     }, { replace: true });
   }, [setSearchParams]);
@@ -469,6 +490,11 @@ export function useFilterParams() {
     cyclist?: boolean;
     drug?: boolean;
     driverAge?: string | null;
+    weather?: Set<string>;
+    lighting?: Set<string>;
+    collisionType?: Set<string>;
+    roadType?: string | null;
+    hitRun?: boolean;
   }) => {
     setSearchParams((prev) => {
       const params = buildNextParams(prev, {
@@ -480,6 +506,11 @@ export function useFilterParams() {
         cyclist: overrides.cyclist ?? false,
         drug: overrides.drug ?? false,
         driverAge: overrides.driverAge ?? null,
+        weather: overrides.weather ?? new Set(),
+        lighting: overrides.lighting ?? new Set(),
+        collisionType: overrides.collisionType ?? new Set(),
+        roadType: overrides.roadType ?? null,
+        hitRun: overrides.hitRun ?? false,
       });
       if (overrides.start) {
         params.set("start", formatYearMonth(overrides.start));
@@ -515,6 +546,11 @@ export function useFilterParams() {
     selectedCyclist,
     selectedDrug,
     selectedDriverAge,
+    selectedWeather,
+    selectedLighting,
+    selectedCollisionType,
+    selectedRoadType,
+    selectedHitRun,
     setDateRange,
     clearDateRange,
     toggleSeverity,
@@ -553,6 +589,11 @@ type ParamOverrides = {
   cyclist?: boolean;
   drug?: boolean;
   driverAge?: string | null;
+  weather?: Set<string>;
+  lighting?: Set<string>;
+  collisionType?: Set<string>;
+  roadType?: string | null;
+  hitRun?: boolean;
 };
 
 function buildNextParams(
@@ -605,6 +646,26 @@ function buildNextParams(
   if ("driverAge" in overrides) {
     if (overrides.driverAge) params.set("driver_age", overrides.driverAge);
     else params.delete("driver_age");
+  }
+  if ("weather" in overrides) {
+    if (overrides.weather && overrides.weather.size > 0) params.set("weather", [...overrides.weather].sort().join(","));
+    else params.delete("weather");
+  }
+  if ("lighting" in overrides) {
+    if (overrides.lighting && overrides.lighting.size > 0) params.set("lighting", [...overrides.lighting].sort().join(","));
+    else params.delete("lighting");
+  }
+  if ("collisionType" in overrides) {
+    if (overrides.collisionType && overrides.collisionType.size > 0) params.set("collision_type", [...overrides.collisionType].sort().join(","));
+    else params.delete("collision_type");
+  }
+  if ("roadType" in overrides) {
+    if (overrides.roadType) params.set("road_type", overrides.roadType);
+    else params.delete("road_type");
+  }
+  if ("hitRun" in overrides) {
+    if (overrides.hitRun) params.set("hit_run", "true");
+    else params.delete("hit_run");
   }
 
   return params;

--- a/frontend/src/hooks/useLiveCrashCount.ts
+++ b/frontend/src/hooks/useLiveCrashCount.ts
@@ -21,6 +21,11 @@ function buildCountUrl(staged: StagedFilters): string {
   if (staged.cyclist) p.set("cyclist", "true");
   if (staged.drug) p.set("drug", "true");
   if (staged.driverAge) p.set("driver_age", staged.driverAge);
+  if (staged.weather.size > 0) p.set("weather", [...staged.weather].join(","));
+  if (staged.lighting.size > 0) p.set("lighting", [...staged.lighting].join(","));
+  if (staged.collisionType.size > 0) p.set("collision_type", [...staged.collisionType].join(","));
+  if (staged.roadType) p.set("road_type", staged.roadType);
+  if (staged.hitRun) p.set("hit_run", "true");
   return `${API_BASE}/api/stats?${p}`;
 }
 
@@ -69,6 +74,14 @@ export function useLiveCrashCount(staged: StagedFilters) {
     staged.cyclist,
     staged.drug,
     staged.driverAge,
+    staged.weather.size,
+    [...staged.weather].join(","),
+    staged.lighting.size,
+    [...staged.lighting].join(","),
+    staged.collisionType.size,
+    [...staged.collisionType].join(","),
+    staged.roadType,
+    staged.hitRun,
     staged.dateRange?.start?.year,
     staged.dateRange?.start?.month,
     staged.dateRange?.end?.year,

--- a/frontend/src/hooks/useStagedFilters.ts
+++ b/frontend/src/hooks/useStagedFilters.ts
@@ -12,6 +12,11 @@ export interface StagedFilters {
   cyclist: boolean;
   drug: boolean;
   driverAge: string | null;
+  weather: Set<string>;
+  lighting: Set<string>;
+  collisionType: Set<string>;
+  roadType: string | null;
+  hitRun: boolean;
 }
 
 const EMPTY: StagedFilters = {
@@ -25,6 +30,11 @@ const EMPTY: StagedFilters = {
   cyclist: false,
   drug: false,
   driverAge: null,
+  weather: new Set(),
+  lighting: new Set(),
+  collisionType: new Set(),
+  roadType: null,
+  hitRun: false,
 };
 
 export function useStagedFilters(initial: StagedFilters) {
@@ -92,6 +102,53 @@ export function useStagedFilters(initial: StagedFilters) {
     setStaged((prev) => ({ ...prev, driverAge: bracket }));
   }, []);
 
+  const toggleWeather = useCallback((v: string) => {
+    setStaged((prev) => {
+      const next = new Set(prev.weather);
+      if (next.has(v)) next.delete(v);
+      else next.add(v);
+      return { ...prev, weather: next };
+    });
+  }, []);
+
+  const clearWeather = useCallback(() => {
+    setStaged((prev) => ({ ...prev, weather: new Set() }));
+  }, []);
+
+  const toggleLighting = useCallback((v: string) => {
+    setStaged((prev) => {
+      const next = new Set(prev.lighting);
+      if (next.has(v)) next.delete(v);
+      else next.add(v);
+      return { ...prev, lighting: next };
+    });
+  }, []);
+
+  const clearLighting = useCallback(() => {
+    setStaged((prev) => ({ ...prev, lighting: new Set() }));
+  }, []);
+
+  const toggleCollisionType = useCallback((v: string) => {
+    setStaged((prev) => {
+      const next = new Set(prev.collisionType);
+      if (next.has(v)) next.delete(v);
+      else next.add(v);
+      return { ...prev, collisionType: next };
+    });
+  }, []);
+
+  const clearCollisionType = useCallback(() => {
+    setStaged((prev) => ({ ...prev, collisionType: new Set() }));
+  }, []);
+
+  const setRoadType = useCallback((v: string | null) => {
+    setStaged((prev) => ({ ...prev, roadType: v }));
+  }, []);
+
+  const toggleHitRun = useCallback(() => {
+    setStaged((prev) => ({ ...prev, hitRun: !prev.hitRun }));
+  }, []);
+
   const clearAll = useCallback(() => {
     setStaged(EMPTY);
   }, []);
@@ -105,7 +162,10 @@ export function useStagedFilters(initial: StagedFilters) {
     || staged.severities.size > 0
     || staged.causes.size > 0
     || staged.alcohol || staged.distracted || staged.pedestrian
-    || staged.cyclist || staged.drug || staged.driverAge !== null;
+    || staged.cyclist || staged.drug || staged.driverAge !== null
+    || staged.weather.size > 0 || staged.lighting.size > 0
+    || staged.collisionType.size > 0 || staged.roadType !== null
+    || staged.hitRun;
 
   const has2016Plus = (() => {
     if (staged.dateRange) {
@@ -127,6 +187,14 @@ export function useStagedFilters(initial: StagedFilters) {
     toggleInvolvement,
     setDateRange,
     setDriverAge,
+    toggleWeather,
+    clearWeather,
+    toggleLighting,
+    clearLighting,
+    toggleCollisionType,
+    clearCollisionType,
+    setRoadType,
+    toggleHitRun,
     clearAll,
     reset,
     hasAnyFilter,

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -75,6 +75,11 @@ function MapPageInner() {
     selectedCyclist,
     selectedDrug,
     selectedDriverAge,
+    selectedWeather,
+    selectedLighting,
+    selectedCollisionType,
+    selectedRoadType,
+    selectedHitRun,
     toggleCounty,
     setCounty,
     clearCounties,
@@ -137,6 +142,11 @@ function MapPageInner() {
     cyclist: selectedCyclist || undefined,
     drug: selectedDrug || undefined,
     driverAge: selectedDriverAge ?? undefined,
+    weather: selectedWeather.size > 0 ? [...selectedWeather] : undefined,
+    lighting: selectedLighting.size > 0 ? [...selectedLighting] : undefined,
+    collisionType: selectedCollisionType.size > 0 ? [...selectedCollisionType] : undefined,
+    roadType: selectedRoadType ?? undefined,
+    hitRun: selectedHitRun || undefined,
   };
 
   const statewideHeatmap = useCrashHeatmap({
@@ -188,8 +198,13 @@ function MapPageInner() {
       cyclist: selectedCyclist || undefined,
       drug: selectedDrug || undefined,
       driverAge: selectedDriverAge ?? undefined,
+      weather: selectedWeather.size > 0 ? [...selectedWeather] : undefined,
+      lighting: selectedLighting.size > 0 ? [...selectedLighting] : undefined,
+      collisionType: selectedCollisionType.size > 0 ? [...selectedCollisionType] : undefined,
+      roadType: selectedRoadType ?? undefined,
+      hitRun: selectedHitRun || undefined,
     }),
-    [selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug, selectedDriverAge],
+    [selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug, selectedDriverAge, selectedWeather, selectedLighting, selectedCollisionType, selectedRoadType, selectedHitRun],
   );
   const choroplethData = useChoroplethData(measure, choroplethFilters);
 
@@ -325,7 +340,12 @@ function MapPageInner() {
     cyclist: selectedCyclist,
     drug: selectedDrug,
     driverAge: selectedDriverAge,
-  }), [selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug, selectedDriverAge, selectedYears]);
+    weather: new Set(selectedWeather),
+    lighting: new Set(selectedLighting),
+    collisionType: new Set(selectedCollisionType),
+    roadType: selectedRoadType,
+    hitRun: selectedHitRun,
+  }), [selectedDateRange, selectedSeverities, selectedCauses, selectedAlcohol, selectedDistracted, selectedPedestrian, selectedCyclist, selectedDrug, selectedDriverAge, selectedYears, selectedWeather, selectedLighting, selectedCollisionType, selectedRoadType, selectedHitRun]);
 
   const handleApplyFilters = useCallback((filters: StagedFilters) => {
     let start: { year: number; month: number } | null = null;
@@ -351,6 +371,11 @@ function MapPageInner() {
       cyclist: filters.cyclist,
       drug: filters.drug,
       driverAge: filters.driverAge,
+      weather: filters.weather,
+      lighting: filters.lighting,
+      collisionType: filters.collisionType,
+      roadType: filters.roadType,
+      hitRun: filters.hitRun,
     });
 
     setShowMobileFilters(false);
@@ -468,6 +493,11 @@ function MapPageInner() {
           cyclist={selectedCyclist}
           drug={selectedDrug}
           driverAge={selectedDriverAge}
+          weather={selectedWeather}
+          lighting={selectedLighting}
+          collisionType={selectedCollisionType}
+          roadType={selectedRoadType}
+          hitRun={selectedHitRun}
           totalCrashes={choroplethData.dataSummary.totalCrashes}
           isLoading={choroplethData.isLoading}
           onClear={handleClearAll}


### PR DESCRIPTION
## Summary
- Loading skeletons on step transitions — no more count pop-in
- Facet counts cached via React Query (instant on panel reopen)
- Dynamic crash counts on View step measures
- Hide pure demographics/context measures when crash filters active
- Hide unavailable measures entirely instead of graying out
- **Deploy pipeline: add `backfill_derived`** — at_fault_driver_age was empty on prod (0 rows vs 2M on dev)

## Test plan
- [ ] Open filter wizard, navigate between steps — skeleton shows until counts load, then all at once
- [ ] Close and reopen panel — counts appear instantly (cached)
- [ ] View step with crash filters: only crash-relevant measures shown
- [ ] View step with year < 2005: demographics measures hidden
- [ ] Deploy runs backfill_derived and populates at_fault_driver_age on prod

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)