### PR TITLE
fix(ci): add User-Agent header and ?wait=true to Discord webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
           run_id = os.environ.get("GH_RUN_ID", "")
           branch = os.environ.get("GH_BRANCH", "")
           actor = os.environ.get("GH_ACTOR", "")
-          webhook = os.environ.get("DISCORD_WEBHOOK_URL", "")
+          webhook = os.environ.get("DISCORD_WEBHOOK_URL", "") + "?wait=true"
           disk = os.environ.get("DISK", "unknown")
 
           short_sha = sha[:7] if sha else "unknown"
@@ -178,7 +178,7 @@ jobs:
           req = urllib.request.Request(
               webhook,
               data=data,
-              headers={"Content-Type": "application/json"}
+              headers={"Content-Type": "application/json", "User-Agent": "CalSightBot/1.0"}
           )
           try:
               with urllib.request.urlopen(req, timeout=10) as resp:


### PR DESCRIPTION
Append '?wait=true' to the Discord webhook URL and add a User-Agent header for the request.

## What does this PR do?


## Dependencies
<!-- If this PR requires another PR to merge first, list it here. The bot will block merge until it's done. -->
<!-- Example: Depends on #143 -->


## How to test
- [ ]

## Checklist
- [ ] Code builds without errors
- [ ] Tested locally
- [ ] No console errors/warnings
- [ ] No other PRs need to merge before this one (or listed above)
