### PR TITLE
feat(#202): landing page intro with data storytelling

### DIFF
--- a/frontend/src/components/map/IntroOverlay.tsx
+++ b/frontend/src/components/map/IntroOverlay.tsx
@@ -1,0 +1,151 @@
+import { useState, useEffect } from "react";
+import logo from "../../assets/logo.webp";
+
+const STORAGE_KEY = "calsight-intro-seen";
+
+interface IntroOverlayProps {
+  onStart: (mode: "simple" | "advanced") => void;
+}
+
+function useCountUp(target: number, duration = 1500, delay = 400): number {
+  const [value, setValue] = useState(0);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      const start = performance.now();
+      const step = (now: number) => {
+        const progress = Math.min((now - start) / duration, 1);
+        const eased = 1 - Math.pow(1 - progress, 3);
+        setValue(Math.round(eased * target));
+        if (progress < 1) requestAnimationFrame(step);
+      };
+      requestAnimationFrame(step);
+    }, delay);
+    return () => clearTimeout(timeout);
+  }, [target, duration, delay]);
+  return value;
+}
+
+const DATA_SOURCES = [
+  { name: "CCRS", detail: "CHP crash reports 2016–2026" },
+  { name: "SWITRS", detail: "Statewide records 2001–2020" },
+  { name: "Census ACS", detail: "Demographics & income" },
+  { name: "CalEnviroScreen", detail: "Environmental burden" },
+  { name: "Caltrans", detail: "Traffic volumes & roads" },
+  { name: "NOAA", detail: "Weather conditions" },
+];
+
+export default function IntroOverlay({ onStart }: IntroOverlayProps) {
+  const [visible, setVisible] = useState(false);
+  const [exiting, setExiting] = useState(false);
+  const [entered, setEntered] = useState(false);
+
+  const crashCount = useCountUp(11129647, 1400, 500);
+  const sourceCount = useCountUp(17, 800, 700);
+  const rowCount = useCountUp(253, 1000, 900);
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY)) return;
+    setVisible(true);
+    requestAnimationFrame(() => setTimeout(() => setEntered(true), 50));
+  }, []);
+
+  if (!visible) return null;
+
+  const handleStart = (mode: "simple" | "advanced") => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    localStorage.setItem("calsight-filter-mode", mode);
+    setExiting(true);
+    setTimeout(() => {
+      setVisible(false);
+      onStart(mode);
+    }, 500);
+  };
+
+  return (
+    <div className={`fixed inset-0 z-[300] overflow-y-auto transition-opacity duration-500 ${exiting ? "opacity-0" : "opacity-100"}`}>
+      <div className="fixed inset-0 bg-surface" />
+
+      <div className="relative z-10 min-h-full flex flex-col items-center justify-center py-12 px-4">
+        <div className="w-full max-w-xl">
+
+          {/* Header */}
+          <div className={`text-center mb-10 transform transition-all duration-700 delay-100 ${entered && !exiting ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"}`}>
+            <div className="flex items-center justify-center gap-3 mb-6">
+              <img src={logo} alt="" className="h-10 w-auto" />
+              <h1 className="font-headline text-4xl md:text-5xl font-bold text-on-surface tracking-tighter">
+                CalSight
+              </h1>
+            </div>
+            <p className="text-lg md:text-xl text-on-surface-variant leading-relaxed max-w-md mx-auto">
+              Translating California's crash data into actionable insights for safer communities.
+            </p>
+          </div>
+
+          {/* Stat cards */}
+          <div className={`grid grid-cols-3 gap-3 mb-8 transform transition-all duration-700 delay-300 ${entered && !exiting ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"}`}>
+            {[
+              { value: crashCount.toLocaleString(), label: "Crash records" },
+              { value: String(sourceCount), label: "Data sources" },
+              { value: `${rowCount / 10}M`, label: "Total rows" },
+            ].map(({ value, label }) => (
+              <div key={label} className="bg-surface-container-lowest rounded-xl ambient-shadow flex flex-col items-center justify-center text-center py-5 px-3">
+                <p className="font-headline text-xl md:text-2xl font-bold text-on-surface tracking-tight">
+                  {value}
+                </p>
+                <p className="text-[9px] md:text-[10px] text-on-surface-variant uppercase tracking-widest font-semibold mt-1">
+                  {label}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          {/* Data source pills */}
+          <div className={`mb-10 transform transition-all duration-700 delay-500 ${entered && !exiting ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"}`}>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-on-surface-variant text-center mb-3">
+              Powered by
+            </p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {DATA_SOURCES.map((src) => (
+                <span
+                  key={src.name}
+                  className="text-[11px] font-semibold bg-surface-container-lowest text-on-surface-variant px-3 py-1.5 rounded-full ambient-shadow"
+                  title={src.detail}
+                >
+                  {src.name}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Mode selection */}
+          <div className={`transform transition-all duration-700 delay-700 ${entered && !exiting ? "translate-y-0 opacity-100" : "translate-y-6 opacity-0"}`}>
+            <p className="text-xs uppercase tracking-[0.2em] text-on-surface-variant text-center mb-4">
+              Choose your experience
+            </p>
+
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                onClick={() => handleStart("simple")}
+                className="rounded-xl px-5 py-5 bg-surface-container-lowest ambient-shadow hover:bg-surface-container-low transition-all duration-200 hover:scale-[1.02] text-center"
+              >
+                <span className="material-symbols-outlined text-[28px] text-primary block mb-2">tune</span>
+                <p className="text-on-surface font-semibold text-base">Simple</p>
+                <p className="text-on-surface-variant text-xs mt-1">Quick presets & filters</p>
+              </button>
+
+              <button
+                onClick={() => handleStart("advanced")}
+                className="rounded-xl px-5 py-5 bg-primary-container ambient-shadow hover:bg-primary-container/80 transition-all duration-200 hover:scale-[1.02] text-center"
+              >
+                <span className="material-symbols-outlined text-[28px] text-on-primary-container block mb-2">settings</span>
+                <p className="text-on-primary-container font-semibold text-base">Advanced</p>
+                <p className="text-on-primary-container/70 text-xs mt-1">Step-by-step wizard</p>
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -96,6 +96,7 @@ function MapPageInner() {
   } = useFilterParams();
 
   const [activePanel, setActivePanel] = useState<string | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleIntroStart = useCallback((_mode: "simple" | "advanced") => {
     const isMobile = window.innerWidth < 768;
     if (isMobile) {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -32,6 +32,7 @@ import { useRandomInsight } from "../hooks/useRandomInsight";
 import ActiveFiltersBanner from "../components/map/ActiveFiltersBanner";
 import { usePrefetchFacets } from "../hooks/usePrefetchFacets";
 import FilteredUrlPrompt from "../components/map/FilteredUrlPrompt";
+import IntroOverlay from "../components/map/IntroOverlay";
 
 const PANEL_META: Record<string, { title: string; subtitle: string }> = {
   filters: { title: "Filters", subtitle: "Secondary Parameters" },
@@ -95,6 +96,14 @@ function MapPageInner() {
   } = useFilterParams();
 
   const [activePanel, setActivePanel] = useState<string | null>(null);
+  const handleIntroStart = useCallback((_mode: "simple" | "advanced") => {
+    const isMobile = window.innerWidth < 768;
+    if (isMobile) {
+      setShowMobileFilters(true);
+    } else {
+      setActivePanel("filters");
+    }
+  }, []);
   const [showInsight, setShowInsight] = useState(true);
   const [showMobileFilters, setShowMobileFilters] = useState(false);
   const [mobileSearchExpanded, setMobileSearchExpanded] = useState(false);
@@ -678,6 +687,8 @@ function MapPageInner() {
         isOpen={showHelp}
         onClose={() => setShowHelp(false)}
       />
+
+      <IntroOverlay onStart={handleIntroStart} />
 
       {showFilterPrompt && (
         <FilteredUrlPrompt


### PR DESCRIPTION
## Summary
- Full-screen intro overlay on first visit
- Animated count-up stats (11M crashes, 17 data sources, 25.3M rows)
- Data source pills (CCRS, SWITRS, Census ACS, CalEnviroScreen, Caltrans, NOAA)
- Simple vs Advanced mode selection
- Staggered fade-in animations
- Mobile-aware: opens bottom sheet on mobile, sidebar on desktop
- Persisted in localStorage — returning visitors skip it

## Test plan
- [ ] First visit shows intro overlay with animations
- [ ] Clicking Simple/Advanced opens filters and dismisses overlay
- [ ] Refreshing after dismissal skips the intro
- [ ] Works on mobile (bottom sheet) and desktop (sidebar)
- [ ] `localStorage.removeItem("calsight-intro-seen")` resets it

Closes #202