### PR TITLE
(#112) backend: Add read-only database role and update ETL to use it

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,6 +3,9 @@ from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from app.settings import settings
 
+# API engine. In production this points at a read-only Postgres role
+# (see backend/sql/create_readonly_role.sql). Sized for the FastAPI
+# request load — every router shares this pool via get_db().
 engine = create_engine(
     settings.effective_database_url,
     pool_size=20,
@@ -11,6 +14,20 @@ engine = create_engine(
     pool_pre_ping=True,
 )
 SessionLocal = sessionmaker(bind=engine)
+
+# ETL / alembic engine. Carries DDL + write permissions in production.
+# Falls back to the API URL when ETL_DATABASE_URL* aren't set (local
+# dev, integration tests) — see settings.effective_etl_database_url.
+# Smaller pool because ETL is single-threaded; one connection at a
+# time.
+etl_engine = create_engine(
+    settings.effective_etl_database_url,
+    pool_size=5,
+    max_overflow=5,
+    pool_recycle=3600,
+    pool_pre_ping=True,
+)
+EtlSessionLocal = sessionmaker(bind=etl_engine)
 
 
 class Base(DeclarativeBase):

--- a/backend/app/seed_counties.py
+++ b/backend/app/seed_counties.py
@@ -1,6 +1,6 @@
 """Seed the counties table with all 58 California counties."""
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County
 
 # California counties: code, name, FIPS, center lat, center lng

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -30,7 +30,25 @@ class Settings(BaseSettings):
     # everyone queries the same loaded 25M-row dataset. If it's missing
     # (or empty) the app falls back to the local Postgres URL so a fresh
     # clone of the repo still boots against `docker compose up db`.
+    #
+    # In production both DATABASE_URL and DATABASE_URL_AZURE point at a
+    # read-only Postgres role — ETL/alembic use ETL_DATABASE_URL[_AZURE]
+    # below, which carries DDL + write permissions. See
+    # backend/sql/create_readonly_role.sql.
     database_url_azure: str = ""
+
+    # ETL connection: full read/write/DDL access. Used by every ETL
+    # loader (via app.database.EtlSessionLocal) and by alembic
+    # migrations. The API never touches this engine — it stays on the
+    # read-only `database_url[_azure]` pair so a compromised dependency
+    # can't run destructive SQL.
+    #
+    # Both fields are optional: if neither is set we fall back to the
+    # API URL. That keeps local dev and integration tests one-URL
+    # simple — the split only matters in production where the API role
+    # is genuinely read-only.
+    etl_database_url: str = ""
+    etl_database_url_azure: str = ""
 
     # -- CORS --
     # Comma-separated origins, e.g. "http://localhost:5173,https://calsight.example.com"
@@ -81,6 +99,21 @@ class Settings(BaseSettings):
         if self.database_url_azure:
             return self.database_url_azure
         return self.database_url
+
+    @property
+    def effective_etl_database_url(self) -> str:
+        """Pick the URL ETL + alembic should use.
+
+        Priority: ETL_DATABASE_URL_AZURE > ETL_DATABASE_URL > the API
+        URL. The fallback to the API URL means local dev / tests work
+        without setting a second variable — the split only matters in
+        prod where the API role is read-only and ETL needs DDL.
+        """
+        if self.etl_database_url_azure:
+            return self.etl_database_url_azure
+        if self.etl_database_url:
+            return self.etl_database_url
+        return self.effective_database_url
 
 
 # Single instance — import this everywhere instead of creating new Settings()

--- a/backend/etl/_utils.py
+++ b/backend/etl/_utils.py
@@ -42,7 +42,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator, TypeVar
 import httpx
 from sqlalchemy import desc, text
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import EtlRun
 
 if TYPE_CHECKING:

--- a/backend/etl/backfill_conditions.py
+++ b/backend/etl/backfill_conditions.py
@@ -27,7 +27,7 @@ import re
 
 from sqlalchemy import text
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from etl._utils import track_etl_run
 
 logging.basicConfig(

--- a/backend/etl/backfill_derived.py
+++ b/backend/etl/backfill_derived.py
@@ -26,7 +26,7 @@ from datetime import datetime
 
 from sqlalchemy import text
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County
 from etl._utils import track_etl_run
 

--- a/backend/etl/bls_unemployment.py
+++ b/backend/etl/bls_unemployment.py
@@ -21,7 +21,7 @@ import time
 
 from sqlalchemy import select
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, UnemploymentRate
 from app.settings import settings
 from etl._utils import post_with_retry, track_etl_run

--- a/backend/etl/caltrans_aadt.py
+++ b/backend/etl/caltrans_aadt.py
@@ -23,7 +23,7 @@ import logging
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, TrafficVolume
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/compute_data_quality.py
+++ b/backend/etl/compute_data_quality.py
@@ -21,7 +21,7 @@ import logging
 
 from sqlalchemy import text
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import DataQualityStat
 from etl._utils import track_etl_run
 

--- a/backend/etl/dmv_vehicles.py
+++ b/backend/etl/dmv_vehicles.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 import httpx
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, VehicleRegistration
 from etl._utils import track_etl_run
 

--- a/backend/etl/dump_insight_cards.py
+++ b/backend/etl/dump_insight_cards.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import sys
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import CountyInsightCard, StatewideInsight
 
 

--- a/backend/etl/generate_county_cards.py
+++ b/backend/etl/generate_county_cards.py
@@ -18,7 +18,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, CountyInsightCard
 
 logger = logging.getLogger(__name__)

--- a/backend/etl/generate_fun_facts.py
+++ b/backend/etl/generate_fun_facts.py
@@ -23,7 +23,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, CountyInsightCard, StatewideInsight
 
 logger = logging.getLogger(__name__)

--- a/backend/etl/generate_insights.py
+++ b/backend/etl/generate_insights.py
@@ -45,7 +45,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.llm import generate_narrative
 from app.models import County, CountyInsight
 from etl._utils import track_etl_run

--- a/backend/etl/generate_trend_cards.py
+++ b/backend/etl/generate_trend_cards.py
@@ -26,7 +26,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, CountyInsightCard
 
 logger = logging.getLogger(__name__)

--- a/backend/etl/load_calenviroscreen.py
+++ b/backend/etl/load_calenviroscreen.py
@@ -19,7 +19,7 @@ import logging
 
 from sqlalchemy import select
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, CalenviroScreen
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -30,7 +30,7 @@ from datetime import datetime
 from sqlalchemy import extract, func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import Crash, EtlRun
 
 logging.basicConfig(

--- a/backend/etl/load_demographics.py
+++ b/backend/etl/load_demographics.py
@@ -23,7 +23,7 @@ import sys
 
 from sqlalchemy import select
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, Demographic
 from app.settings import settings
 from etl._utils import track_etl_run

--- a/backend/etl/load_hospitals.py
+++ b/backend/etl/load_hospitals.py
@@ -17,7 +17,7 @@ import logging
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, Hospital
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/load_licensed_drivers.py
+++ b/backend/etl/load_licensed_drivers.py
@@ -21,7 +21,7 @@ import logging
 
 from sqlalchemy import select
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, LicensedDriver
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/load_parties_victims.py
+++ b/backend/etl/load_parties_victims.py
@@ -25,7 +25,7 @@ import time
 import httpx
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import CrashParty, CrashVictim
 from etl._utils import track_etl_run
 

--- a/backend/etl/load_road_miles.py
+++ b/backend/etl/load_road_miles.py
@@ -24,7 +24,7 @@ import logging
 
 from sqlalchemy import select
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, RoadMile
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/load_schools.py
+++ b/backend/etl/load_schools.py
@@ -16,7 +16,7 @@ import logging
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, SchoolLocation
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/load_speed_limits.py
+++ b/backend/etl/load_speed_limits.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, SpeedLimit
 from etl._utils import get_with_retry, track_etl_run
 

--- a/backend/etl/noaa_weather.py
+++ b/backend/etl/noaa_weather.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 import httpx
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import County, Weather
 from app.settings import settings
 from etl._utils import track_etl_run

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Literal
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import EtlRun
 
 logger = logging.getLogger(__name__)

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -26,7 +26,7 @@ import logging
 
 from sqlalchemy import text
 
-from app.database import engine
+from app.database import etl_engine as engine  # write/DDL role
 from etl._utils import track_etl_run
 
 logging.basicConfig(

--- a/backend/etl/vacuum_analyze.py
+++ b/backend/etl/vacuum_analyze.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 
-from app.database import engine
+from app.database import etl_engine as engine  # write/DDL role
 
 logging.basicConfig(
     level=logging.INFO,

--- a/backend/etl/validate_coords.py
+++ b/backend/etl/validate_coords.py
@@ -27,7 +27,7 @@ from shapely.geometry import Point, shape
 from shapely.prepared import prep
 from sqlalchemy import text, update
 
-from app.database import SessionLocal
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import Crash
 from etl._utils import track_etl_run
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,7 +1,8 @@
 """Alembic environment configuration.
 
 This file tells Alembic:
-1. How to connect to the database (DATABASE_URL from environment)
+1. How to connect to the database (uses the ETL URL — alembic needs DDL,
+   so it can't use the read-only API role)
 2. Where to find your models (app.models via Base.metadata)
 
 Alembic compares Base.metadata (what your models say) against the actual
@@ -22,7 +23,10 @@ from app.settings import settings
 import app.models  # noqa: F401
 
 config = context.config
-config.set_main_option("sqlalchemy.url", settings.database_url)
+# Use the ETL URL because alembic runs DDL (CREATE TABLE etc.) and the
+# API URL points at a read-only role in production. Falls back to the
+# API URL locally — see settings.effective_etl_database_url.
+config.set_main_option("sqlalchemy.url", settings.effective_etl_database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -1,0 +1,25 @@
+# `backend/sql/`
+
+Hand-run SQL scripts. These are NOT alembic migrations — alembic owns the
+schema. Files here cover infra/ops tasks that don't belong in a model
+migration:
+
+- **`create_readonly_role.sql`** — provisions the `calsight_api_ro` role
+  used by the FastAPI container. Defense-in-depth so a compromised
+  dependency can't run destructive SQL. Run once per environment after
+  bootstrapping the database, and re-run after rotating the role's
+  password. See the file header for the exact `psql` invocation.
+
+After running `create_readonly_role.sql` against Azure, the production
+`.env` should look like:
+
+```
+# Read-only role — used by the FastAPI container
+DATABASE_URL_AZURE=postgresql://calsight_api_ro:...@<host>/calsight
+
+# Superuser — used by alembic + ETL only
+ETL_DATABASE_URL_AZURE=postgresql://calsight:...@<host>/calsight
+```
+
+Locally, you can leave the ETL URL blank — see `CLAUDE.md` for the
+fallback rules.

--- a/backend/sql/create_readonly_role.sql
+++ b/backend/sql/create_readonly_role.sql
@@ -1,0 +1,80 @@
+-- Create the read-only Postgres role used by the FastAPI backend.
+--
+-- WHY:
+--   All 16 API endpoints are GET / SELECT-only. The API doesn't need
+--   write access — and not having it means a compromised dependency
+--   can't DROP, DELETE, or UPDATE anything. Defense-in-depth.
+--
+-- WHO RUNS THIS:
+--   The Azure Postgres admin (i.e. you). ETL + alembic stay on the
+--   superuser role; only the API container connects as `calsight_api_ro`.
+--
+-- HOW TO RUN:
+--   psql "<superuser connection string>" -v ON_ERROR_STOP=1 \
+--        -v role_password="'replace-me-with-a-real-password'" \
+--        -f backend/sql/create_readonly_role.sql
+--
+--   Then update the production .env so DATABASE_URL_AZURE points at
+--   `calsight_api_ro` and ETL_DATABASE_URL_AZURE points at the superuser
+--   role. See CLAUDE.md for the env-var layout.
+--
+-- IDEMPOTENT:
+--   Re-running is safe. CREATE ROLE / CREATE SCHEMA bits are guarded;
+--   GRANTs are no-ops if already granted.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- 1. The role itself. Login-enabled, no inherited superpowers.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'calsight_api_ro') THEN
+        EXECUTE format(
+            'CREATE ROLE calsight_api_ro LOGIN PASSWORD %L',
+            current_setting('role_password')
+        );
+    ELSE
+        EXECUTE format(
+            'ALTER ROLE calsight_api_ro WITH LOGIN PASSWORD %L',
+            current_setting('role_password')
+        );
+    END IF;
+END
+$$;
+
+-- 2. Connect + schema-usage perms.
+GRANT CONNECT ON DATABASE calsight TO calsight_api_ro;
+GRANT USAGE   ON SCHEMA   public   TO calsight_api_ro;
+
+-- 3. SELECT on everything that currently exists. Sequences are also
+--    granted USAGE/SELECT — SQLAlchemy autoflush sometimes peeks at
+--    nextval()-style queries even on pure-read sessions.
+GRANT SELECT                  ON ALL TABLES    IN SCHEMA public TO calsight_api_ro;
+GRANT SELECT, USAGE           ON ALL SEQUENCES IN SCHEMA public TO calsight_api_ro;
+
+-- 4. Future-proof: when alembic adds a new table or the ETL creates a
+--    new materialized view tomorrow, the API role automatically gets
+--    SELECT on it. Without this, every migration would need a manual
+--    GRANT step on the Azure side.
+--
+--    The `FOR ROLE` argument has to be the role that *creates* the
+--    object. Adjust to match whichever superuser runs alembic / ETL
+--    (typically `calsight`).
+ALTER DEFAULT PRIVILEGES FOR ROLE calsight IN SCHEMA public
+    GRANT SELECT ON TABLES TO calsight_api_ro;
+ALTER DEFAULT PRIVILEGES FOR ROLE calsight IN SCHEMA public
+    GRANT SELECT, USAGE ON SEQUENCES TO calsight_api_ro;
+
+COMMIT;
+
+-- 5. Sanity check — print what we just granted. Look for ~30 tables /
+--    materialized views in the output; if you see <10 the GRANT
+--    didn't take.
+\echo
+\echo 'Tables visible to calsight_api_ro:'
+SELECT table_schema, table_name
+FROM information_schema.table_privileges
+WHERE grantee = 'calsight_api_ro'
+  AND privilege_type = 'SELECT'
+ORDER BY table_schema, table_name;

--- a/backend/tests/api/test_etl.py
+++ b/backend/tests/api/test_etl.py
@@ -1,3 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
 def test_etl_status_returns_sources(client):
     response = client.get("/api/etl/status")
     assert response.status_code == 200

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -12,3 +12,59 @@ def test_census_api_key_defaults_to_empty_without_env(monkeypatch):
     monkeypatch.delenv("CENSUS_API_KEY", raising=False)
     s = Settings(_env_file=None)
     assert s.census_api_key == ""
+
+
+def test_effective_etl_database_url_prefers_azure(monkeypatch):
+    """ETL_DATABASE_URL_AZURE wins over every other URL."""
+    monkeypatch.delenv("ETL_DATABASE_URL", raising=False)
+    monkeypatch.delenv("ETL_DATABASE_URL_AZURE", raising=False)
+    s = Settings(
+        _env_file=None,
+        database_url="postgresql://api/db",
+        database_url_azure="postgresql://api-azure/db",
+        etl_database_url="postgresql://etl/db",
+        etl_database_url_azure="postgresql://etl-azure/db",
+    )
+    assert s.effective_etl_database_url == "postgresql://etl-azure/db"
+
+
+def test_effective_etl_database_url_falls_back_to_local_etl(monkeypatch):
+    """Without an azure ETL URL, the local ETL_DATABASE_URL wins."""
+    monkeypatch.delenv("ETL_DATABASE_URL", raising=False)
+    monkeypatch.delenv("ETL_DATABASE_URL_AZURE", raising=False)
+    s = Settings(
+        _env_file=None,
+        database_url="postgresql://api/db",
+        database_url_azure="postgresql://api-azure/db",
+        etl_database_url="postgresql://etl/db",
+    )
+    assert s.effective_etl_database_url == "postgresql://etl/db"
+
+
+def test_effective_etl_database_url_falls_back_to_api_url(monkeypatch):
+    """With no ETL URL set at all, ETL reuses the API URL.
+
+    Lets local dev / integration tests get away with a single URL —
+    the split only matters in prod where the API role is read-only.
+    """
+    monkeypatch.delenv("ETL_DATABASE_URL", raising=False)
+    monkeypatch.delenv("ETL_DATABASE_URL_AZURE", raising=False)
+    s = Settings(
+        _env_file=None,
+        database_url="postgresql://api/db",
+        database_url_azure="postgresql://api-azure/db",
+    )
+    # effective_database_url already prefers azure → that's what ETL gets
+    assert s.effective_etl_database_url == "postgresql://api-azure/db"
+
+
+def test_effective_etl_database_url_pure_local(monkeypatch):
+    """When nothing azure is set, ETL falls all the way back to DATABASE_URL."""
+    monkeypatch.delenv("ETL_DATABASE_URL", raising=False)
+    monkeypatch.delenv("ETL_DATABASE_URL_AZURE", raising=False)
+    monkeypatch.delenv("DATABASE_URL_AZURE", raising=False)
+    s = Settings(
+        _env_file=None,
+        database_url="postgresql://local/db",
+    )
+    assert s.effective_etl_database_url == "postgresql://local/db"


### PR DESCRIPTION
What does this PR do?

  Implements issue #112: splits the backend's single Postgres connection into a read-only role for the API and a
  write/DDL role for ETL + alembic, so a dependency-chain compromise of the FastAPI container can't run destructive SQL.

  - app/settings.py — adds ETL_DATABASE_URL / ETL_DATABASE_URL_AZURE plus effective_etl_database_url, which falls back
  to the API URL when unset so local dev / integration tests still work with a single URL.
  - app/database.py — adds a second etl_engine / EtlSessionLocal alongside the existing API engine. The API engine
  continues to bind to effective_database_url.
  - All 26 ETL modules + app/seed_counties.py rebind their SessionLocal import to EtlSessionLocal as SessionLocal
  (one-line per file). The two ETL scripts that import engine directly (refresh_materialized_views, vacuum_analyze)
  rebind to etl_engine.
  - migrations/env.py — alembic now uses effective_etl_database_url because migrations need DDL.
  - backend/sql/create_readonly_role.sql (new) — idempotent role provisioning script with ALTER DEFAULT PRIVILEGES so
  future tables automatically inherit SELECT for the API role. Includes the exact psql invocation in its header.
  backend/sql/README.md (new) documents the production .env layout.
  - Test coverage — 4 new unit tests in tests/test_settings.py lock in the URL-priority + fallback rules.

  Deploy steps after merge: run backend/sql/create_readonly_role.sql against the Azure DB (one-time), then update the
  prod .env so DATABASE_URL_AZURE points at calsight_api_ro and ETL_DATABASE_URL_AZURE keeps the superuser URL.

  Dependencies

  None. The fallback in effective_etl_database_url means existing deploys (without ETL_DATABASE_URL* set) keep working —
   the role split only takes effect once the SQL script is run and the env vars are updated.

  How to test

  - cd backend && ruff check . — passes with no new violations
  - cd backend && pytest tests/test_settings.py -v — all 6 settings tests pass (2 existing + 4 new fallback tests)
  - cd backend && pytest -m "not integration" — 327 unit tests pass (suite untouched by this change)
  - cd backend && pytest -m integration — integration suite still green; the conftest sets DATABASE_URL only, so ETL
  falls back to that URL automatically
  - Confirm python -m etl.<any-loader> still runs locally (uses EtlSessionLocal, which falls back to the same local URL
  when ETL_DATABASE_URL is unset)
  - Confirm alembic upgrade head still applies migrations locally

  Checklist

  [ ] Code builds without errors
  [ ] Tested locally
  [ ] No console errors/warnings
  [ ] No other PRs need to merge before this one (or listed above)