### PR TITLE
feat(#44): unified search with geolocation, address lookup, favorites

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect } from "react";
-import { MapContainer, TileLayer, useMap } from "react-leaflet";
+import { MapContainer, TileLayer, Marker, useMap } from "react-leaflet";
 import type { LatLngBoundsExpression, Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
 import CountyBoundaries from "./CountyBoundaries";
@@ -35,6 +35,7 @@ interface MapCanvasProps {
   heatmapPalette: PaletteKey;
   countyDrilldown?: boolean;
   mismatchPoints?: HeatmapPoint[];
+  tempMarker?: [number, number] | null;
 }
 
 const HEATMAP_MAX_ZOOM: Record<string, number> = {
@@ -56,6 +57,7 @@ function MapInternals({
   heatmapPalette,
   countyDrilldown,
   mismatchPoints = [],
+  tempMarker,
 }: MapCanvasProps) {
   const map = useMap();
   const { otherLayers } = useLayersState();
@@ -119,6 +121,7 @@ function MapInternals({
         showHospitals={otherLayers.hospitals}
         showSchools={otherLayers.schools}
       />
+      {tempMarker && <Marker position={tempMarker} />}
     </>
   );
 }
@@ -135,6 +138,7 @@ export default function MapCanvas({
   heatmapPalette,
   countyDrilldown,
   mismatchPoints = [],
+  tempMarker,
 }: MapCanvasProps) {
   const isDark = useIsDark();
   // CartoDB tile variants — swap between light_* and dark_* so counties
@@ -185,6 +189,7 @@ export default function MapCanvas({
         heatmapPalette={heatmapPalette}
         countyDrilldown={countyDrilldown}
         mismatchPoints={mismatchPoints}
+        tempMarker={tempMarker}
       />
 
       <TileLayer

--- a/frontend/src/components/map/UnifiedSearchBar.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.tsx
@@ -7,7 +7,7 @@ import { useFavoriteLocations } from "../../hooks/useFavoriteLocations";
 interface UnifiedSearchBarProps {
   map: LeafletMap | null;
   onSelectCounty: (name: string) => void;
-  onSelectPlace: (lat: number, lng: number, name: string) => void;
+  onSelectPlace: (lat: number, lng: number) => void;
   onGeolocate: () => void;
   locating?: boolean;
 }
@@ -92,7 +92,7 @@ export default function UnifiedSearchBar({
     if (item.type === "county") {
       onSelectCounty(item.label);
     } else if ((item.type === "place" || item.type === "favorite") && item.lat != null && item.lng != null) {
-      onSelectPlace(item.lat, item.lng, item.label);
+      onSelectPlace(item.lat, item.lng);
     }
     setExpanded(false);
     setQuery("");

--- a/frontend/src/components/map/UnifiedSearchBar.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.tsx
@@ -1,0 +1,343 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { Map as LeafletMap } from "leaflet";
+import { CA_COUNTIES } from "../../hooks/useFilterParams";
+import { useNominatim } from "../../hooks/useNominatim";
+import { useFavoriteLocations } from "../../hooks/useFavoriteLocations";
+
+interface UnifiedSearchBarProps {
+  map: LeafletMap | null;
+  onSelectCounty: (name: string) => void;
+  onSelectPlace: (lat: number, lng: number, name: string) => void;
+  onGeolocate: () => void;
+  locating?: boolean;
+}
+
+const COUNTY_NAMES = (CA_COUNTIES as unknown as string[]).sort();
+
+export default function UnifiedSearchBar({
+  map,
+  onSelectCounty,
+  onSelectPlace,
+  onGeolocate,
+  locating = false,
+}: UnifiedSearchBarProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlightIdx, setHighlightIdx] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mobileInputRef = useRef<HTMLInputElement>(null);
+
+  const { favorites, addFavorite, removeFavorite } = useFavoriteLocations();
+
+  const trimmed = query.trim().toLowerCase();
+  const countyMatches = trimmed
+    ? COUNTY_NAMES.filter((n) => n.toLowerCase().includes(trimmed)).slice(0, 4)
+    : [];
+
+  const hasCountyMatch = countyMatches.some((c) => c.toLowerCase() === trimmed);
+  const { results: nominatimResults, loading: nominatimLoading } = useNominatim(
+    query,
+    expanded && trimmed.length >= 3 && !hasCountyMatch,
+  );
+
+  const showFavorites = expanded && !trimmed && favorites.length > 0;
+
+  const allResults: { type: "county" | "place" | "favorite"; label: string; sub?: string; lat?: number; lng?: number; county?: string | null }[] = [];
+
+  if (showFavorites) {
+    for (const f of favorites) {
+      allResults.push({ type: "favorite", label: f.name, sub: f.county ?? undefined, lat: f.lat, lng: f.lng, county: f.county });
+    }
+  }
+  for (const c of countyMatches) {
+    allResults.push({ type: "county", label: c, sub: "County" });
+  }
+  for (const r of nominatimResults) {
+    const parts = r.display_name.split(", ");
+    const label = parts[0];
+    const sub = parts.slice(1, 3).join(", ");
+    allResults.push({ type: "place", label, sub, lat: parseFloat(r.lat), lng: parseFloat(r.lon) });
+  }
+
+  useEffect(() => {
+    if (!map) return;
+    const collapse = () => { setExpanded(false); setQuery(""); setHighlightIdx(-1); };
+    map.on("movestart", collapse);
+    return () => { map.off("movestart", collapse); };
+  }, [map]);
+
+  useEffect(() => {
+    if (expanded && inputRef.current) inputRef.current.focus();
+  }, [expanded]);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setExpanded(false);
+        setQuery("");
+        setHighlightIdx(-1);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [expanded]);
+
+  useEffect(() => {
+    setHighlightIdx(-1);
+  }, [query]);
+
+  const handleSelect = useCallback((item: typeof allResults[0]) => {
+    if (item.type === "county") {
+      onSelectCounty(item.label);
+    } else if ((item.type === "place" || item.type === "favorite") && item.lat != null && item.lng != null) {
+      onSelectPlace(item.lat, item.lng, item.label);
+    }
+    setExpanded(false);
+    setQuery("");
+    setHighlightIdx(-1);
+  }, [onSelectCounty, onSelectPlace]);
+
+  const handleSaveFavorite = useCallback((item: typeof allResults[0], e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (item.lat != null && item.lng != null) {
+      addFavorite({ name: item.label, lat: item.lat, lng: item.lng, county: item.county ?? null });
+    }
+  }, [addFavorite]);
+
+  const handleRemoveFavorite = useCallback((item: typeof allResults[0], e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (item.lat != null && item.lng != null) {
+      removeFavorite(item.lat, item.lng);
+    }
+  }, [removeFavorite]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      setExpanded(false);
+      setQuery("");
+      setHighlightIdx(-1);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlightIdx((i) => Math.min(i + 1, allResults.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlightIdx((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      if (highlightIdx >= 0 && highlightIdx < allResults.length) {
+        handleSelect(allResults[highlightIdx]);
+      } else if (allResults.length > 0) {
+        handleSelect(allResults[0]);
+      }
+    }
+  };
+
+  const close = () => { setExpanded(false); setQuery(""); setHighlightIdx(-1); };
+
+  const iconForType = (type: string) => {
+    if (type === "county") return "map";
+    if (type === "favorite") return "star";
+    return "location_on";
+  };
+
+  const renderResults = (isMobile: boolean) => {
+    if (!expanded || allResults.length === 0) return null;
+    return (
+      <div className={`${isMobile ? "mt-1" : "mt-1.5"} bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg overflow-hidden max-h-72 overflow-y-auto`}>
+        {showFavorites && (
+          <div className="px-4 pt-3 pb-1">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">Favorites</span>
+          </div>
+        )}
+        {countyMatches.length > 0 && trimmed && (
+          <div className="px-4 pt-3 pb-1">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">Counties</span>
+          </div>
+        )}
+        {allResults.map((item, idx) => (
+          <div key={`${item.type}-${item.label}-${idx}`}>
+            {item.type === "place" && idx === countyMatches.length + (showFavorites ? favorites.length : 0) && (
+              <div className="px-4 pt-3 pb-1">
+                <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
+                  Places {nominatimLoading && <span className="inline-block w-2 h-2 bg-primary rounded-full animate-pulse ml-1" />}
+                </span>
+              </div>
+            )}
+            <button
+              onClick={() => handleSelect(item)}
+              className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors ${
+                idx === highlightIdx ? "bg-primary-container text-on-primary-container" : "text-on-surface hover:bg-surface-container"
+              }`}
+            >
+              <span className="material-symbols-outlined text-[16px] text-on-surface-variant shrink-0">
+                {iconForType(item.type)}
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="truncate font-medium">{item.label}{item.type === "county" ? " County" : ""}</div>
+                {item.sub && <div className="text-[11px] text-on-surface-variant truncate">{item.sub}</div>}
+              </div>
+              {item.type === "favorite" ? (
+                <button
+                  onClick={(e) => handleRemoveFavorite(item, e)}
+                  className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0"
+                >
+                  <span className="material-symbols-outlined text-[14px] text-on-surface-variant">close</span>
+                </button>
+              ) : item.type === "place" && item.lat != null ? (
+                <button
+                  onClick={(e) => handleSaveFavorite(item, e)}
+                  className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0"
+                >
+                  <span className="material-symbols-outlined text-[14px] text-on-surface-variant">star</span>
+                </button>
+              ) : null}
+            </button>
+          </div>
+        ))}
+        {trimmed && countyMatches.length === 0 && nominatimResults.length === 0 && !nominatimLoading && trimmed.length >= 3 && (
+          <div className="px-4 py-3 text-sm text-on-surface-variant">
+            No results for "{query}"
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  // --- Mobile expanded search ---
+  const [mobileExpanded, setMobileExpanded] = useState(false);
+  const [mobileQuery, setMobileQuery] = useState("");
+
+  useEffect(() => {
+    if (!map) return;
+    const collapse = () => { setMobileExpanded(false); setMobileQuery(""); };
+    map.on("movestart", collapse);
+    return () => { map.off("movestart", collapse); };
+  }, [map]);
+
+  useEffect(() => {
+    if (mobileExpanded && mobileInputRef.current) mobileInputRef.current.focus();
+  }, [mobileExpanded]);
+
+  // Sync mobile query into the main query so hooks work
+  useEffect(() => {
+    if (mobileExpanded) {
+      setExpanded(true);
+      setQuery(mobileQuery);
+    }
+  }, [mobileQuery, mobileExpanded]);
+
+  return (
+    <>
+      {/* ── Mobile: bottom pill ── */}
+      <div className={`absolute z-10 md:hidden ${mobileExpanded ? "bottom-4 left-4 right-4" : "bottom-4 left-4"}`}>
+        {mobileExpanded ? (
+          <div ref={containerRef}>
+            <div className="flex items-center gap-2 px-4 py-2 bg-surface-container-lowest rounded-full shadow-lg ghost-border">
+              <span className="material-symbols-outlined text-lg text-on-surface-variant">search</span>
+              <input
+                ref={mobileInputRef}
+                type="text"
+                value={mobileQuery}
+                onChange={(e) => setMobileQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Search counties, places..."
+                className="flex-1 bg-transparent text-sm text-on-surface placeholder:text-on-surface-variant/60 outline-none ring-0 focus:outline-none focus:ring-0 border-none"
+              />
+              <button
+                onClick={() => { setMobileExpanded(false); setMobileQuery(""); close(); }}
+                className="p-1 hover:bg-surface-container rounded-full transition-colors"
+              >
+                <span className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
+              </button>
+            </div>
+            {renderResults(true)}
+          </div>
+        ) : (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setMobileExpanded(true)}
+              className="flex items-center gap-2 px-4 py-3 bg-primary text-on-primary rounded-full shadow-lg transition-colors hover:opacity-90"
+            >
+              <span className="material-symbols-outlined text-lg">search</span>
+              <span className="text-sm font-semibold tracking-tight">Search</span>
+            </button>
+            <button
+              onClick={onGeolocate}
+              disabled={locating}
+              className={`p-3 bg-surface-container-lowest text-on-surface-variant rounded-full shadow-lg transition-colors hover:text-on-surface ${locating ? "animate-pulse" : ""}`}
+            >
+              <span className="material-symbols-outlined text-lg">my_location</span>
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ── Desktop: top center search bar + bottom controls ── */}
+      <div
+        ref={!mobileExpanded ? containerRef : undefined}
+        className={`hidden md:block absolute top-3 z-20 transition-[width] duration-300 left-1/2 -translate-x-1/2 ${expanded ? "w-96" : "w-auto"}`}
+      >
+        <div
+          className={`flex items-center gap-2 bg-surface-container-lowest/95 backdrop-blur-md ghost-border shadow-lg transition-colors duration-300 ${
+            expanded ? "rounded-2xl px-4 py-2.5" : "rounded-full px-4 py-2.5 cursor-pointer"
+          }`}
+          onClick={() => !expanded && setExpanded(true)}
+        >
+          <span className="material-symbols-outlined text-[20px] text-on-surface-variant shrink-0">search</span>
+          {expanded ? (
+            <>
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Search counties, places, addresses..."
+                className="flex-1 bg-transparent text-sm text-on-surface placeholder:text-on-surface-variant/60 outline-none border-none focus:outline-none focus:ring-0"
+              />
+              {nominatimLoading && (
+                <span className="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin shrink-0" />
+              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); close(); }}
+                className="p-0.5 rounded-full hover:bg-surface-container transition-colors"
+              >
+                <span className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
+              </button>
+            </>
+          ) : (
+            <span className="text-sm text-on-surface-variant font-medium whitespace-nowrap pr-1">
+              Search California
+            </span>
+          )}
+        </div>
+        {renderResults(false)}
+      </div>
+
+      {/* ── Desktop: bottom controls (location + zoom) ── */}
+      <div className="hidden md:flex absolute bottom-8 left-1/2 -translate-x-1/2 z-10 items-center gap-1 p-1 bg-white dark:bg-neutral-800 rounded-full shadow-lg">
+        <button
+          onClick={onGeolocate}
+          disabled={locating}
+          className={`p-3 text-on-surface-variant hover:text-on-surface transition-colors ${locating ? "animate-pulse" : ""}`}
+        >
+          <span className="material-symbols-outlined">my_location</span>
+        </button>
+        <div className="w-[1px] h-6 bg-outline-variant/30" />
+        <button
+          onClick={() => map?.zoomIn(1, { animate: true })}
+          className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          <span className="material-symbols-outlined">zoom_in</span>
+        </button>
+        <button
+          onClick={() => map?.zoomOut(1, { animate: true })}
+          className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
+        >
+          <span className="material-symbols-outlined">zoom_out</span>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/hooks/useFavoriteLocations.ts
+++ b/frontend/src/hooks/useFavoriteLocations.ts
@@ -1,0 +1,68 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export interface FavoriteLocation {
+  name: string;
+  lat: number;
+  lng: number;
+  county: string | null;
+}
+
+const STORAGE_KEY = "calsight-favorites";
+const MAX_FAVORITES = 10;
+
+let listeners: (() => void)[] = [];
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+function readFavorites(): FavoriteLocation[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeFavorites(favs: FavoriteLocation[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(favs.slice(0, MAX_FAVORITES)));
+  emit();
+}
+
+let snapshot = readFavorites();
+function getSnapshot() {
+  const next = readFavorites();
+  if (JSON.stringify(next) !== JSON.stringify(snapshot)) {
+    snapshot = next;
+  }
+  return snapshot;
+}
+
+function subscribe(listener: () => void) {
+  listeners.push(listener);
+  return () => {
+    listeners = listeners.filter((l) => l !== listener);
+  };
+}
+
+export function useFavoriteLocations() {
+  const favorites = useSyncExternalStore(subscribe, getSnapshot);
+
+  const addFavorite = useCallback((fav: FavoriteLocation) => {
+    const current = readFavorites();
+    if (current.some((f) => f.lat === fav.lat && f.lng === fav.lng)) return;
+    writeFavorites([fav, ...current]);
+  }, []);
+
+  const removeFavorite = useCallback((lat: number, lng: number) => {
+    const current = readFavorites();
+    writeFavorites(current.filter((f) => f.lat !== lat || f.lng !== lng));
+  }, []);
+
+  const isFavorite = useCallback(
+    (lat: number, lng: number) => favorites.some((f) => f.lat === lat && f.lng === lng),
+    [favorites],
+  );
+
+  return { favorites, addFavorite, removeFavorite, isFavorite };
+}

--- a/frontend/src/hooks/useNominatim.ts
+++ b/frontend/src/hooks/useNominatim.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface NominatimResult {
+  place_id: number;
+  display_name: string;
+  lat: string;
+  lon: string;
+  type: string;
+  address?: {
+    county?: string;
+    city?: string;
+    town?: string;
+    village?: string;
+    state?: string;
+  };
+}
+
+const CA_VIEWBOX = "-124.5,42.0,-114.1,32.5";
+const DEBOUNCE_MS = 350;
+
+export function useNominatim(query: string, enabled: boolean) {
+  const [results, setResults] = useState<NominatimResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!enabled || trimmed.length < 3) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const timer = setTimeout(async () => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const params = new URLSearchParams({
+          q: trimmed,
+          format: "json",
+          bounded: "1",
+          viewbox: CA_VIEWBOX,
+          limit: "4",
+          addressdetails: "1",
+        });
+        const res = await fetch(
+          `https://nominatim.openstreetmap.org/search?${params}`,
+          {
+            signal: controller.signal,
+            headers: { "User-Agent": "CalSight/1.0 (https://calsight.app)" },
+          },
+        );
+        if (!res.ok) throw new Error(`Nominatim ${res.status}`);
+        const data: NominatimResult[] = await res.json();
+        setResults(data);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      abortRef.current?.abort();
+    };
+  }, [query, enabled]);
+
+  return { results, loading };
+}

--- a/frontend/src/lib/geo/pointInCounty.ts
+++ b/frontend/src/lib/geo/pointInCounty.ts
@@ -1,0 +1,45 @@
+type Position = [number, number];
+type Ring = Position[];
+
+function pointInRing(lng: number, lat: number, ring: Ring): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i];
+    const [xj, yj] = ring[j];
+    if ((yi > lat) !== (yj > lat) && lng < ((xj - xi) * (lat - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function pointInPolygon(lng: number, lat: number, coords: Position[][]): boolean {
+  if (!pointInRing(lng, lat, coords[0])) return false;
+  for (let i = 1; i < coords.length; i++) {
+    if (pointInRing(lng, lat, coords[i])) return false;
+  }
+  return true;
+}
+
+function pointInMultiPolygon(lng: number, lat: number, coords: Position[][][]): boolean {
+  return coords.some((poly) => pointInPolygon(lng, lat, poly));
+}
+
+export function findCountyAtPoint(
+  lat: number,
+  lng: number,
+  geojson: GeoJSON.FeatureCollection,
+): string | null {
+  for (const feature of geojson.features) {
+    const geom = feature.geometry;
+    const coords = (geom as GeoJSON.Polygon | GeoJSON.MultiPolygon).coordinates;
+    const hit =
+      geom.type === "Polygon"
+        ? pointInPolygon(lng, lat, coords as Position[][])
+        : geom.type === "MultiPolygon"
+          ? pointInMultiPolygon(lng, lat, coords as Position[][][])
+          : false;
+    if (hit) return (feature.properties?.name ?? null) as string | null;
+  }
+  return null;
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -255,7 +255,7 @@ function MapPageInner() {
     }
   }, [compareMode, focusedCounty, setCounty, toggleCounty]);
 
-  const handleSelectPlace = useCallback((lat: number, lng: number, _name: string) => {
+  const handleSelectPlace = useCallback((lat: number, lng: number) => {
     setTempMarker([lat, lng]);
     mapRef.current?.setView([lat, lng], 14, { animate: true, duration: 0.5 });
     if (countyGeoJson) {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -32,6 +32,8 @@ import { useRandomInsight } from "../hooks/useRandomInsight";
 import ActiveFiltersBanner from "../components/map/ActiveFiltersBanner";
 import { usePrefetchFacets } from "../hooks/usePrefetchFacets";
 import { useCountyGeoJson } from "../hooks/useCountyGeoJson";
+import { findCountyAtPoint } from "../lib/geo/pointInCounty";
+import UnifiedSearchBar from "../components/map/UnifiedSearchBar";
 import FilteredUrlPrompt from "../components/map/FilteredUrlPrompt";
 import IntroOverlay from "../components/map/IntroOverlay";
 
@@ -88,8 +90,9 @@ function MapPageInner() {
   }, []);
   const [showInsight, setShowInsight] = useState(true);
   const [showMobileFilters, setShowMobileFilters] = useState(false);
-  const [mobileSearchExpanded, setMobileSearchExpanded] = useState(false);
   const [focusedCounty, setFocusedCounty] = useState<string | null>(null);
+  const [tempMarker, setTempMarker] = useState<[number, number] | null>(null);
+  const [locating, setLocating] = useState(false);
   const [compareCounty, setCompareCounty] = useState<string | null>(null);
   const [compareMode, setCompareMode] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -108,7 +111,7 @@ function MapPageInner() {
 
   const countyNames = CA_COUNTIES.map((c) => String(c)).sort();
   usePrefetchFacets();
-  useCountyGeoJson();
+  const { data: countyGeoJson } = useCountyGeoJson();
 
   const { measure, otherLayers, heatmapResolution, palette, choroplethOn } = useLayersState();
 
@@ -251,6 +254,37 @@ function MapPageInner() {
       setTimeout(() => { selectingRef.current = false; }, 300);
     }
   }, [compareMode, focusedCounty, setCounty, toggleCounty]);
+
+  const handleSelectPlace = useCallback((lat: number, lng: number, _name: string) => {
+    setTempMarker([lat, lng]);
+    mapRef.current?.setView([lat, lng], 14, { animate: true, duration: 0.5 });
+    if (countyGeoJson) {
+      const county = findCountyAtPoint(lat, lng, countyGeoJson);
+      if (county) handleSelectCounty(county);
+    }
+  }, [countyGeoJson, handleSelectCounty]);
+
+  const handleGeolocate = useCallback(() => {
+    if (!navigator.geolocation) return;
+    setLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude, longitude } = pos.coords;
+        setTempMarker([latitude, longitude]);
+        mapRef.current?.setView([latitude, longitude], 12, { animate: true, duration: 0.5 });
+        if (countyGeoJson) {
+          const county = findCountyAtPoint(latitude, longitude, countyGeoJson);
+          if (county) handleSelectCounty(county);
+        }
+        setLocating(false);
+      },
+      () => {
+        mapRef.current?.setView([37.2, -119.5], 6, { animate: true, duration: 0.5 });
+        setLocating(false);
+      },
+      { enableHighAccuracy: false, timeout: 8000 },
+    );
+  }, [countyGeoJson, handleSelectCounty]);
 
   const handleDeselect = useCallback(() => {
     setFocusedCounty(null);
@@ -444,36 +478,27 @@ function MapPageInner() {
           heatmapPalette={palette}
           countyDrilldown={useCountyDetail}
           mismatchPoints={otherLayers.coordMismatches ? mismatchHeatmap.points : []}
+          tempMarker={tempMarker}
         />
 
-        {/* Mobile: search + filter icon buttons (right), hide when search expanded */}
-        {!mobileSearchExpanded && (
-          <div className="absolute top-3 right-3 z-20 md:hidden flex items-center gap-2">
-            <button
-              onClick={() => setMobileSearchExpanded(true)}
-              className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
-              aria-label="Search"
-            >
-              <span className="material-symbols-outlined text-[20px]">search</span>
-            </button>
-            <button
-              onClick={() => setShowMobileFilters(true)}
-              className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
-              aria-label="Open filters"
-            >
-              <span className="material-symbols-outlined text-[20px]">tune</span>
-            </button>
-          </div>
-        )}
-        {mobileSearchExpanded && (
-          <MobileSearchPill
-            expanded={true}
-            onExpand={() => setMobileSearchExpanded(true)}
-            onCollapse={() => setMobileSearchExpanded(false)}
-            onSelect={(name) => { handleSelectCounty(name); setMobileSearchExpanded(false); }}
-            map={mapRef.current}
-          />
-        )}
+        {/* Mobile: filter button (right) */}
+        <div className="absolute top-3 right-3 z-20 md:hidden">
+          <button
+            onClick={() => setShowMobileFilters(true)}
+            className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
+            aria-label="Open filters"
+          >
+            <span className="material-symbols-outlined text-[20px]">tune</span>
+          </button>
+        </div>
+
+        <UnifiedSearchBar
+          map={mapRef.current}
+          onSelectCounty={handleSelectCounty}
+          onSelectPlace={handleSelectPlace}
+          onGeolocate={handleGeolocate}
+          locating={locating}
+        />
 
         <ActiveFiltersBanner
           dateRange={selectedDateRange}
@@ -493,7 +518,7 @@ function MapPageInner() {
           totalCrashes={choroplethData.dataSummary.totalCrashes}
           isLoading={choroplethData.isLoading}
           onClear={handleClearAll}
-          searchOpen={mobileSearchExpanded}
+          searchOpen={false}
         />
 
         {!choroplethData.isLoading
@@ -570,7 +595,7 @@ function MapPageInner() {
           heatmapLoading={heatmapEnabled && heatmap.isLoading}
           countyActive={!!focusedCounty}
           countyTotalCrashes={inspectedData?.rawCount ?? null}
-          searchOpen={mobileSearchExpanded}
+          searchOpen={false}
           mismatchCount={otherLayers.coordMismatches ? mismatchHeatmap.totalCrashes : null}
         />
         {otherLayers.heatmapStatewide && !focusedCounty && !choroplethOn && (
@@ -578,7 +603,7 @@ function MapPageInner() {
             totalCrashes={statewideHeatmap.totalCrashes}
             displayed={statewideHeatmap.points.length}
             isLoading={statewideHeatmap.isLoading}
-            searchOpen={mobileSearchExpanded}
+            searchOpen={false}
           />
         )}
         {!focusedCounty && showStatewide && randomCard && (
@@ -759,127 +784,3 @@ function ChoroplethLegendContainer({
 // Mobile search pill — inline at top center, expands to show results below
 // ---------------------------------------------------------------------------
 
-const MOBILE_COUNTY_NAMES = (CA_COUNTIES as unknown as string[]).slice().sort();
-
-function MobileSearchPill({
-  expanded,
-  onExpand,
-  onCollapse,
-  onSelect,
-  map,
-}: {
-  expanded: boolean;
-  onExpand: () => void;
-  onCollapse: () => void;
-  onSelect: (name: string) => void;
-  map: LeafletMap | null;
-}) {
-  const [query, setQuery] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  const results = query.trim()
-    ? MOBILE_COUNTY_NAMES.filter((n) =>
-        n.toLowerCase().includes(query.toLowerCase())
-      ).slice(0, 4)
-    : [];
-
-  useEffect(() => {
-    if (expanded && inputRef.current) inputRef.current.focus();
-  }, [expanded]);
-
-  // Collapse when map moves
-  useEffect(() => {
-    if (!map) return;
-    const collapse = () => { onCollapse(); setQuery(""); };
-    map.on("movestart", collapse);
-    return () => { map.off("movestart", collapse); };
-  }, [map, onCollapse]);
-
-  // Close on outside tap
-  useEffect(() => {
-    if (!expanded) return;
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        onCollapse();
-        setQuery("");
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [expanded, onCollapse]);
-
-  const handleSelect = (name: string) => {
-    onSelect(name);
-    setQuery("");
-  };
-
-  return (
-    <div
-      ref={containerRef}
-      className={expanded
-        ? "absolute top-3 left-3 right-3 z-20 md:hidden"
-        : "md:hidden"
-      }
-    >
-      <div
-        className={`
-          flex items-center gap-2
-          bg-surface-container-lowest/90 backdrop-blur-md
-          ghost-border shadow-lg
-          ${expanded ? "h-10 rounded-2xl px-3" : "h-10 rounded-full px-3 cursor-pointer"}
-        `}
-        onClick={() => !expanded && onExpand()}
-      >
-        <span className="material-symbols-outlined text-[18px] text-on-surface-variant shrink-0">
-          search
-        </span>
-        {expanded ? (
-          <>
-            <input
-              ref={inputRef}
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Escape") { onCollapse(); setQuery(""); }
-                if (e.key === "Enter" && results.length > 0) handleSelect(results[0]);
-              }}
-              placeholder="Search counties…"
-              className="flex-1 bg-transparent text-sm text-on-surface placeholder:text-on-surface-variant/60 outline-none border-none min-w-0"
-            />
-            <button
-              onClick={(e) => { e.stopPropagation(); onCollapse(); setQuery(""); }}
-              className="p-0.5 rounded-full"
-            >
-              <span className="material-symbols-outlined text-[16px] text-on-surface-variant">close</span>
-            </button>
-          </>
-        ) : (
-          <span className="text-[11px] text-on-surface-variant font-medium">Counties</span>
-        )}
-      </div>
-
-      {expanded && results.length > 0 && (
-        <div className="mt-1.5 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg overflow-hidden">
-          {results.map((name) => (
-            <button
-              key={name}
-              onClick={() => handleSelect(name)}
-              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-on-surface text-left hover:bg-surface-container transition-colors"
-            >
-              <span className="material-symbols-outlined text-[14px] text-on-surface-variant">location_on</span>
-              <span>{name} County</span>
-            </button>
-          ))}
-        </div>
-      )}
-
-      {expanded && query.trim() && results.length === 0 && (
-        <div className="mt-1.5 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg px-3 py-2.5">
-          <p className="text-xs text-on-surface-variant">No match for "{query}"</p>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -68,6 +68,27 @@ export default function PrivacyPage() {
         </section>
 
         <section>
+          <h2 className="font-headline text-lg font-bold text-on-surface mb-2">Location Features</h2>
+          <p>
+            The &ldquo;My Location&rdquo; button uses your browser&apos;s geolocation API to center the map
+            on your position. Your coordinates are processed entirely in your browser to identify the
+            nearest county &mdash; they are never sent to our servers.
+          </p>
+          <p className="mt-2">
+            Address and place searches are sent to OpenStreetMap&apos;s Nominatim geocoding service.
+            Only your search text is transmitted, not your GPS coordinates or any personal information.
+            See the{" "}
+            <a href="https://osmfoundation.org/wiki/Privacy_Policy" className="text-primary underline" target="_blank" rel="noopener noreferrer">
+              OpenStreetMap privacy policy
+            </a>{" "}
+            for details.
+          </p>
+          <p className="mt-2">
+            Saved favorite locations are stored in your browser&apos;s local storage and are never transmitted.
+          </p>
+        </section>
+
+        <section>
           <h2 className="font-headline text-lg font-bold text-on-surface mb-2">Data Sources</h2>
           <p>
             All crash data displayed on CalSight is sourced from publicly available California state datasets


### PR DESCRIPTION
## Summary
- **Unified search bar** replaces 3 separate search components (SearchPill, MapSearchBar, inline MobileSearchPill) with one component on both mobile and desktop
- **County search** — instant local filtering as you type
- **Place/address search** — live Nominatim geocoding (type "Golden Gate Bridge" or "123 Main St, Fresno")
- **Browser geolocation** — My Location button on mobile + desktop, auto-detects your county
- **Auto-county detection** — client-side point-in-polygon finds which county any lat/lng falls in
- **Favorite locations** — star to save, stored in localStorage, shown at top of search dropdown
- **Temporary marker pin** — dropped at searched/geolocated position
- **Privacy policy** — new Location section covering GPS, Nominatim, and favorites

## Test plan
- [ ] Desktop: click "Search California" → type "Fresno" → county result appears → select → map pans + insight card
- [ ] Desktop: type "Golden Gate Bridge" → place result appears → select → pin + zoom + SF County auto-selected
- [ ] Desktop: click My Location → browser permission prompt → zooms to you → county detected
- [ ] Mobile: tap Search pill → same search behavior as desktop
- [ ] Mobile: tap location button → same geolocation behavior
- [ ] Star a place result → close search → reopen → favorite appears at top
- [ ] Remove favorite via X button
- [ ] Deny geolocation → falls back to CA center
- [ ] Visit /privacy → Location section visible with Nominatim and GPS disclosures
- [ ] Keyboard: arrow keys navigate results, Enter selects, Escape closes

Closes #44