### PR TITLE
fix: driver age 65+ filter mapping in stats router

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -160,7 +160,7 @@ mv_wide = Table(
 )
 
 _AGE_BRACKET_MAP = {
-    (16, 21): 1, (22, 34): 2, (35, 49): 3, (50, 64): 4,
+    (16, 21): 1, (22, 34): 2, (35, 49): 3, (50, 64): 4, (65, 200): 5,
 }
 
 
@@ -213,8 +213,6 @@ def _apply_wide_filters(stmt, years, county_codes, severities, causes,
         bracket = _AGE_BRACKET_MAP.get(driver_age_v)
         if bracket is not None:
             stmt = stmt.where(w.c.age_bracket == bracket)
-        elif driver_age_v[0] >= 65:
-            stmt = stmt.where(w.c.age_bracket == 5)
     return stmt
 
 


### PR DESCRIPTION
## Summary
The `_AGE_BRACKET_MAP` in stats.py was missing the `(65, 200): 5` entry for the 65+ age bracket. The filter worked by accident via an `elif` fallback, but any refactor would silently break it.

- Added the missing mapping entry
- Removed the redundant `elif` branch

## Context
The involvement filters (alcohol, distracted, pedestrian, cyclist, drug) were investigated and are working correctly. The driver age filter was the only actual bug — a fragile mapping, not a broken query.

## Test plan
- [ ] Select "65+" age bracket in filters → verify crash count changes
- [ ] Select other age brackets → verify they still work
- [ ] Backend unit tests pass (64/64)