### PR TITLE
feat(#215): replace Recharts with lightweight SVG charts (-390KB)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,6 @@
         "react-leaflet-cluster": "^4.1.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.2",
-        "recharts": "^2.15.0",
         "tailwindcss": "^3.4.19",
         "topojson-client": "^3.1.0"
       },
@@ -1942,69 +1941,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3052,15 +2988,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3203,127 +3130,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -3360,12 +3166,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -3428,16 +3228,6 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/dompurify": {
       "version": "3.4.2",
@@ -3737,12 +3527,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3765,15 +3549,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-equals": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
-      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -4152,15 +3927,6 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/iobuffer": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
@@ -4308,6 +4074,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4527,12 +4294,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4548,18 +4309,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -5779,23 +5528,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -5868,12 +5600,6 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
     },
     "node_modules/react-leaflet": {
       "version": "5.0.0",
@@ -5981,37 +5707,6 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/react-smooth": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
-      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6043,38 +5738,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/recharts": {
-      "version": "2.15.4",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
-      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
-      "license": "MIT",
-      "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^18.3.1",
-        "react-smooth": "^4.0.4",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/recharts-scale": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
-      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
-      "license": "MIT",
-      "dependencies": {
-        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/redent": {
@@ -6554,7 +6217,6 @@
       "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -6605,12 +6267,6 @@
       "engines": {
         "node": ">=0.8"
       }
-    },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7023,28 +6679,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "36.9.2",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
-      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,7 +29,6 @@
     "react-leaflet-cluster": "^4.1.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.2",
-    "recharts": "^2.15.0",
     "tailwindcss": "^3.4.19",
     "topojson-client": "^3.1.0"
   },

--- a/frontend/src/components/ask/InlineChart.tsx
+++ b/frontend/src/components/ask/InlineChart.tsx
@@ -1,4 +1,6 @@
-import { BarChart, Bar, LineChart, Line, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+import SimpleBarChart from "../charts/SimpleBarChart";
+import SimpleLineChart from "../charts/SimpleLineChart";
+import SimpleDonutChart from "../charts/SimpleDonutChart";
 import type { ChartData } from "../../hooks/useAskAi";
 
 const COLORS = ["#6b8fa3", "#c25560", "#b0a050", "#7ba088", "#b89a6b", "#8e7cc3", "#5a9eaf", "#d4845a"];
@@ -7,19 +9,12 @@ interface Props {
   chart: ChartData;
 }
 
-function formatNumber(val: number): string {
-  if (val >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
-  if (val >= 1_000) return `${(val / 1_000).toFixed(1)}K`;
-  return val.toLocaleString();
-}
-
-function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: { value: number }[]; label?: string }) {
-  if (!active || !payload?.length) return null;
+function Tip({ label, value }: { label: string; value: number }) {
   return (
-    <div className="bg-surface-container-lowest ghost-border rounded-lg px-3 py-2 text-xs">
+    <>
       <p className="font-bold text-on-surface">{label}</p>
-      <p className="text-on-surface-variant">{payload[0].value.toLocaleString()} crashes</p>
-    </div>
+      <p className="text-on-surface-variant">{value.toLocaleString()} crashes</p>
+    </>
   );
 }
 
@@ -34,32 +29,30 @@ export default function InlineChart({ chart }: Props) {
         <p className="text-[10px] md:text-xs font-bold text-on-surface-variant uppercase tracking-widest mb-2">{title}</p>
       )}
       <div className="min-w-[300px]">
-      <ResponsiveContainer width="100%" height={180}>
         {type === "line" ? (
-          <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-            <XAxis dataKey="label" tick={{ fontSize: 10 }} stroke="var(--color-on-surface-variant, #666)" interval={data.length > 10 ? Math.floor(data.length / 6) : 0} angle={data.length > 8 ? -45 : 0} textAnchor={data.length > 8 ? "end" : "middle"} height={data.length > 8 ? 45 : 30} />
-            <YAxis tick={{ fontSize: 11 }} stroke="var(--color-on-surface-variant, #666)" width={55} tickFormatter={formatNumber} />
-            <Tooltip content={<CustomTooltip />} />
-            <Line type="monotone" dataKey="value" stroke="#6b8fa3" strokeWidth={2} dot={data.length <= 12 ? { r: 3 } : false} />
-          </LineChart>
+          <SimpleLineChart
+            data={data}
+            height={180}
+            showDots={data.length <= 12}
+            renderTooltip={(item) => <Tip label={item.label} value={item.value} />}
+          />
         ) : type === "pie" ? (
-          <PieChart>
-            <Pie data={data} dataKey="value" nameKey="label" cx="50%" cy="50%" outerRadius={80} label={({ label }) => label}>
-              {data.map((_, i) => (
-                <Cell key={i} fill={COLORS[i % COLORS.length]} />
-              ))}
-            </Pie>
-            <Tooltip content={<CustomTooltip />} />
-          </PieChart>
+          <SimpleDonutChart
+            data={data.map((d, i) => ({ label: d.label, value: d.value, color: COLORS[i % COLORS.length] }))}
+            height={180}
+            outerRadius={80}
+            innerRadius={0}
+            renderTooltip={(item) => <Tip label={item.label} value={item.value} />}
+          />
         ) : (
-          <BarChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
-            <XAxis dataKey="label" tick={{ fontSize: 10 }} stroke="var(--color-on-surface-variant, #666)" interval={0} angle={data.length > 5 ? -45 : 0} textAnchor={data.length > 5 ? "end" : "middle"} height={data.length > 5 ? 60 : 30} />
-            <YAxis tick={{ fontSize: 11 }} stroke="var(--color-on-surface-variant, #666)" width={55} tickFormatter={formatNumber} />
-            <Tooltip content={<CustomTooltip />} />
-            <Bar dataKey="value" fill="#6b8fa3" radius={[4, 4, 0, 0]} />
-          </BarChart>
+          <SimpleBarChart
+            data={data.map((d) => ({ label: d.label, value: d.value }))}
+            height={180}
+            defaultColor="#6b8fa3"
+            radius={4}
+            renderTooltip={(item) => <Tip label={item.label} value={item.value} />}
+          />
         )}
-      </ResponsiveContainer>
       </div>
     </div>
   );

--- a/frontend/src/components/charts/ChartTooltip.tsx
+++ b/frontend/src/components/charts/ChartTooltip.tsx
@@ -1,0 +1,38 @@
+import { useState, useRef, useEffect } from "react";
+
+interface TooltipProps {
+  x: number;
+  y: number;
+  visible: boolean;
+  children: React.ReactNode;
+  containerRef: React.RefObject<SVGSVGElement | null>;
+}
+
+export default function ChartTooltip({ x, y, visible, children, containerRef }: TooltipProps) {
+  const tipRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ left: 0, top: 0 });
+
+  useEffect(() => {
+    if (!visible || !containerRef.current || !tipRef.current) return;
+    const svgRect = containerRef.current.getBoundingClientRect();
+    const tipRect = tipRef.current.getBoundingClientRect();
+    let left = svgRect.left + x - tipRect.width / 2;
+    let top = svgRect.top + y - tipRect.height - 8;
+    if (left < 4) left = 4;
+    if (left + tipRect.width > window.innerWidth - 4) left = window.innerWidth - tipRect.width - 4;
+    if (top < 4) top = svgRect.top + y + 12;
+    setPos({ left, top });
+  }, [x, y, visible, containerRef]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      ref={tipRef}
+      className="fixed z-50 pointer-events-none bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow"
+      style={{ left: pos.left, top: pos.top }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/charts/SimpleBarChart.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.tsx
@@ -1,0 +1,153 @@
+import { useState, useRef, useCallback } from "react";
+import ChartTooltip from "./ChartTooltip";
+
+interface BarItem {
+  label: string;
+  value: number;
+  color?: string;
+  peakLabel?: string;
+}
+
+interface SimpleBarChartProps {
+  data: BarItem[];
+  height?: number;
+  defaultColor?: string;
+  gap?: number;
+  radius?: number;
+  renderTooltip?: (item: BarItem, idx: number) => React.ReactNode;
+  layout?: "vertical" | "horizontal";
+  labelFormatter?: (label: string, idx: number, isPeak: boolean) => React.ReactNode;
+  showXAxis?: boolean;
+}
+
+export default function SimpleBarChart({
+  data,
+  height = 192,
+  defaultColor = "rgb(var(--primary-container))",
+  gap = 0.15,
+  radius = 2,
+  renderTooltip,
+  layout = "vertical",
+  labelFormatter,
+  showXAxis = true,
+}: SimpleBarChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<SVGRectElement>, idx: number) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    setHover({ idx, x: e.clientX - rect.left, y: e.clientY - rect.top });
+  }, []);
+
+  if (!data.length) return null;
+  const maxVal = Math.max(...data.map((d) => d.value), 1);
+
+  if (layout === "horizontal") {
+    const barH = 18;
+    const labelW = 100;
+    const rowH = barH + 10;
+    const svgH = Math.max(height, data.length * rowH);
+    return (
+      <div className="w-full overflow-hidden" style={{ height: svgH }}>
+        <svg ref={svgRef} width="100%" height={svgH} className="block">
+          {data.map((d, i) => {
+            const y = i * rowH + 4;
+            const barW = maxVal > 0 ? ((svgRef.current?.clientWidth ?? 300) - labelW - 16) * (d.value / maxVal) : 0;
+            return (
+              <g key={d.label}>
+                <text x={0} y={y + barH / 2 + 4} fontSize={10} fontWeight={600} fill="rgb(var(--on-surface-variant))" fontFamily="'Inter Variable', Inter, sans-serif">
+                  {d.label}
+                </text>
+                <rect
+                  x={labelW}
+                  y={y}
+                  width={Math.max(barW, 2)}
+                  height={barH}
+                  rx={radius}
+                  fill={d.color ?? defaultColor}
+                  onMouseMove={(e) => handleMouseMove(e, i)}
+                  onMouseLeave={() => setHover(null)}
+                  className="cursor-pointer"
+                />
+              </g>
+            );
+          })}
+          <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
+            {hover !== null && renderTooltip?.(data[hover.idx], hover.idx)}
+          </ChartTooltip>
+        </svg>
+      </div>
+    );
+  }
+
+  const padding = { top: 24, right: 8, bottom: showXAxis ? 28 : 4, left: 8 };
+  const chartH = height - padding.top - padding.bottom;
+
+  return (
+    <div className="w-full overflow-hidden" style={{ height }}>
+      <svg ref={svgRef} width="100%" height={height} className="block">
+        {data.map((d, i) => {
+          const n = data.length;
+          const totalW = (svgRef.current?.clientWidth ?? 300) - padding.left - padding.right;
+          const slotW = totalW / n;
+          const barW = slotW * (1 - gap);
+          const barX = padding.left + i * slotW + (slotW - barW) / 2;
+          const barH = maxVal > 0 ? (d.value / maxVal) * chartH : 0;
+          const barY = padding.top + chartH - barH;
+
+          return (
+            <g key={`${d.label}-${i}`}>
+              {d.peakLabel && (
+                <text
+                  x={barX + barW / 2}
+                  y={barY - 4}
+                  textAnchor="middle"
+                  fill={d.color ?? defaultColor}
+                  fontSize={8}
+                  fontWeight={700}
+                  fontFamily="'Inter Variable', Inter, sans-serif"
+                  letterSpacing={1}
+                >
+                  {d.peakLabel}
+                </text>
+              )}
+              <rect
+                x={barX}
+                y={barY}
+                width={Math.max(barW, 1)}
+                height={Math.max(barH, 0)}
+                rx={radius}
+                fill={d.color ?? defaultColor}
+                onMouseMove={(e) => handleMouseMove(e, i)}
+                onMouseLeave={() => setHover(null)}
+                className="cursor-pointer"
+              />
+              {showXAxis && (
+                <g transform={`translate(${barX + barW / 2}, ${height - padding.bottom + 14})`}>
+                  {labelFormatter ? (
+                    labelFormatter(d.label, i, !!d.peakLabel)
+                  ) : (
+                    <text
+                      textAnchor="middle"
+                      fontSize={10}
+                      fontWeight={600}
+                      fill="rgb(var(--on-surface-variant))"
+                      fontFamily="'Inter Variable', Inter, sans-serif"
+                    >
+                      {d.label}
+                    </text>
+                  )}
+                </g>
+              )}
+            </g>
+          );
+        })}
+        <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
+          {hover !== null && renderTooltip?.(data[hover.idx], hover.idx)}
+        </ChartTooltip>
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/SimpleDonutChart.tsx
+++ b/frontend/src/components/charts/SimpleDonutChart.tsx
@@ -1,0 +1,115 @@
+import { useState, useRef, useCallback } from "react";
+import ChartTooltip from "./ChartTooltip";
+
+interface Segment {
+  label: string;
+  value: number;
+  color: string;
+}
+
+interface SimpleDonutChartProps {
+  data: Segment[];
+  height?: number;
+  innerRadius?: number;
+  outerRadius?: number;
+  renderTooltip?: (item: Segment & { pct: number }, idx: number) => React.ReactNode;
+}
+
+function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+function arcPath(cx: number, cy: number, r: number, startAngle: number, endAngle: number): string {
+  const start = polarToCartesian(cx, cy, r, endAngle);
+  const end = polarToCartesian(cx, cy, r, startAngle);
+  const large = endAngle - startAngle > 180 ? 1 : 0;
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${large} 0 ${end.x} ${end.y}`;
+}
+
+export default function SimpleDonutChart({
+  data,
+  height = 160,
+  innerRadius = 48,
+  outerRadius = 72,
+  renderTooltip,
+}: SimpleDonutChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<SVGPathElement>, idx: number) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    setHover({ idx, x: e.clientX - rect.left, y: e.clientY - rect.top });
+  }, []);
+
+  if (!data.length) return null;
+
+  const total = data.reduce((s, d) => s + d.value, 0);
+  if (total === 0) return null;
+
+  const cx = height / 2 + 20;
+  const cy = height / 2;
+  const padAngle = 2;
+
+  const segments: { path: string; outerPath: string; color: string; pct: number; item: Segment; midAngle: number }[] = [];
+  let cumAngle = 0;
+
+  for (const d of data) {
+    const sweep = (d.value / total) * (360 - padAngle * data.length);
+    const start = cumAngle;
+    const end = cumAngle + sweep;
+    const mid = (start + end) / 2;
+
+    const innerStart = polarToCartesian(cx, cy, innerRadius, end);
+    const innerEnd = polarToCartesian(cx, cy, innerRadius, start);
+    const outerStart = polarToCartesian(cx, cy, outerRadius, end);
+    const outerEnd = polarToCartesian(cx, cy, outerRadius, start);
+    const large = sweep > 180 ? 1 : 0;
+
+    const path = [
+      `M ${outerStart.x} ${outerStart.y}`,
+      `A ${outerRadius} ${outerRadius} 0 ${large} 0 ${outerEnd.x} ${outerEnd.y}`,
+      `L ${innerEnd.x} ${innerEnd.y}`,
+      `A ${innerRadius} ${innerRadius} 0 ${large} 1 ${innerStart.x} ${innerStart.y}`,
+      "Z",
+    ].join(" ");
+
+    const outerPath = arcPath(cx, cy, outerRadius, start, end);
+
+    segments.push({
+      path,
+      outerPath,
+      color: d.color,
+      pct: Math.round((d.value / total) * 100),
+      item: d,
+      midAngle: mid,
+    });
+
+    cumAngle = end + padAngle;
+  }
+
+  const withPct = data.map((d) => ({ ...d, pct: Math.round((d.value / total) * 100) }));
+
+  return (
+    <div className="w-full overflow-hidden" style={{ height }}>
+      <svg ref={svgRef} width="100%" height={height} className="block">
+        {segments.map((seg, i) => (
+          <path
+            key={seg.item.label}
+            d={seg.path}
+            fill={seg.color}
+            onMouseMove={(e) => handleMouseMove(e, i)}
+            onMouseLeave={() => setHover(null)}
+            className="cursor-pointer transition-opacity"
+            opacity={hover !== null && hover.idx !== i ? 0.5 : 1}
+          />
+        ))}
+        <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
+          {hover !== null && renderTooltip?.(withPct[hover.idx], hover.idx)}
+        </ChartTooltip>
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/SimpleLineChart.tsx
+++ b/frontend/src/components/charts/SimpleLineChart.tsx
@@ -1,0 +1,135 @@
+import { useState, useRef, useCallback } from "react";
+import ChartTooltip from "./ChartTooltip";
+
+interface LinePoint {
+  label: string;
+  value: number;
+}
+
+interface SimpleLineChartProps {
+  data: LinePoint[];
+  height?: number;
+  color?: string;
+  showDots?: boolean;
+  showYAxis?: boolean;
+  renderTooltip?: (item: LinePoint, idx: number) => React.ReactNode;
+}
+
+function formatNumber(val: number): string {
+  if (val >= 1_000_000) return `${(val / 1_000_000).toFixed(1)}M`;
+  if (val >= 1_000) return `${(val / 1_000).toFixed(1)}K`;
+  return val.toLocaleString();
+}
+
+export default function SimpleLineChart({
+  data,
+  height = 180,
+  color = "#6b8fa3",
+  showDots = true,
+  showYAxis = true,
+  renderTooltip,
+}: SimpleLineChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<SVGCircleElement | SVGRectElement>, idx: number) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    setHover({ idx, x: e.clientX - rect.left, y: e.clientY - rect.top });
+  }, []);
+
+  if (!data.length) return null;
+
+  const maxVal = Math.max(...data.map((d) => d.value), 1);
+  const yAxisW = showYAxis ? 50 : 0;
+  const padding = { top: 12, right: 12, bottom: 32, left: yAxisW + 8 };
+  const chartH = height - padding.top - padding.bottom;
+
+  const yTicks = 4;
+  const yTickVals = Array.from({ length: yTicks + 1 }, (_, i) => Math.round((maxVal / yTicks) * i));
+
+  return (
+    <div className="w-full overflow-hidden" style={{ height }}>
+      <svg ref={svgRef} width="100%" height={height} className="block">
+        {showYAxis && yTickVals.map((v) => {
+          const y = padding.top + chartH - (v / maxVal) * chartH;
+          return (
+            <g key={v}>
+              <line x1={padding.left} x2="100%" y1={y} y2={y} stroke="rgb(var(--outline-variant))" strokeOpacity={0.2} />
+              <text x={padding.left - 6} y={y + 3} textAnchor="end" fontSize={10} fill="rgb(var(--on-surface-variant))" fontFamily="'Inter Variable', Inter, sans-serif">
+                {formatNumber(v)}
+              </text>
+            </g>
+          );
+        })}
+
+        {(() => {
+          const svgW = svgRef.current?.clientWidth ?? 400;
+          const chartW = svgW - padding.left - padding.right;
+          const n = data.length;
+          if (n < 2) return null;
+
+          const points = data.map((d, i) => ({
+            x: padding.left + (i / (n - 1)) * chartW,
+            y: padding.top + chartH - (d.value / maxVal) * chartH,
+          }));
+
+          const pathD = points.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ");
+
+          const interval = n > 12 ? Math.ceil(n / 6) : 1;
+
+          return (
+            <>
+              <path d={pathD} fill="none" stroke={color} strokeWidth={2} />
+              {points.map((p, i) => (
+                <g key={i}>
+                  {showDots && (
+                    <circle cx={p.x} cy={p.y} r={3} fill={color} stroke="white" strokeWidth={1.5} />
+                  )}
+                  <rect
+                    x={p.x - chartW / n / 2}
+                    y={padding.top}
+                    width={chartW / n}
+                    height={chartH}
+                    fill="transparent"
+                    onMouseMove={(e) => handleMouseMove(e, i)}
+                    onMouseLeave={() => setHover(null)}
+                    className="cursor-pointer"
+                  />
+                  {i % interval === 0 && (
+                    <text
+                      x={p.x}
+                      y={height - padding.bottom + 16}
+                      textAnchor="middle"
+                      fontSize={10}
+                      fill="rgb(var(--on-surface-variant))"
+                      fontFamily="'Inter Variable', Inter, sans-serif"
+                    >
+                      {data[i].label}
+                    </text>
+                  )}
+                </g>
+              ))}
+              {hover !== null && points[hover.idx] && (
+                <line
+                  x1={points[hover.idx].x}
+                  x2={points[hover.idx].x}
+                  y1={padding.top}
+                  y2={padding.top + chartH}
+                  stroke={color}
+                  strokeOpacity={0.3}
+                  strokeDasharray="4 2"
+                />
+              )}
+            </>
+          );
+        })()}
+
+        <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
+          {hover !== null && renderTooltip?.(data[hover.idx], hover.idx)}
+        </ChartTooltip>
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -2,19 +2,9 @@ import { useState, useEffect, useMemo } from "react";
 import { useFilterParams, formatYearMonth, CAUSES as CAUSE_OPTIONS, SEVERITIES } from "../hooks/useFilterParams";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import FiltersPanel from "../components/map/FiltersPanel";
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-  PieChart,
-  Pie,
-  LabelList,
-} from "recharts";
-import { useStats, type HourlyDataPoint, type YearlyDataPoint, type CauseDataPoint, type MonthlyDataPoint, type DayOfWeekDataPoint } from "../hooks/useStats";
+import SimpleBarChart from "../components/charts/SimpleBarChart";
+import SimpleDonutChart from "../components/charts/SimpleDonutChart";
+import { useStats } from "../hooks/useStats";
 import { useDataQualityDisclaimer } from "../hooks/useDataQualityDisclaimer";
 import { Skeleton } from "../components/ui/Skeleton";
 import { EmptyState } from "../components/ui/EmptyState";
@@ -33,65 +23,12 @@ function token(name: string) {
   return `rgb(${getComputedStyle(document.documentElement).getPropertyValue(name).trim()})`;
 }
 
-function HourTooltip({ active, payload }: { active?: boolean; payload?: { payload: HourlyDataPoint }[] }) {
-  if (!active || !payload?.length) return null;
-  const { hour, count } = payload[0].payload;
-  const label = `${String(hour).padStart(2, "0")}:00`;
+function ChartTip({ title, lines }: { title: string; lines: string[] }) {
   return (
-    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-      <p className="font-headline font-bold text-on-surface">{label}</p>
-      <p className="text-on-surface-variant mt-0.5">{count.toLocaleString()} incidents</p>
-    </div>
-  );
-}
-
-function YearTooltip({ active, payload }: { active?: boolean; payload?: { payload: YearlyDataPoint }[] }) {
-  if (!active || !payload?.length) return null;
-  const { year, count } = payload[0].payload;
-  return (
-    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-      <p className="font-headline font-bold text-on-surface">{year}</p>
-      <p className="text-on-surface-variant mt-0.5">{count.toLocaleString()} incidents</p>
-    </div>
-  );
-}
-
-function YearCursor({ x, y, width, height }: { x?: number; y?: number; width?: number; height?: number }) {
-  if (x == null || y == null || width == null || height == null) return null;
-  return <rect x={x} y={y - 16} width={width} height={height + 16} fill="rgba(87,95,107,0.06)" rx={2} />;
-}
-
-function CauseTooltip({ active, payload }: { active?: boolean; payload?: { payload: CauseDataPoint & { pct: number } }[] }) {
-  if (!active || !payload?.length) return null;
-  const { label, count, pct } = payload[0].payload;
-  return (
-    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-      <p className="font-headline font-bold text-on-surface">{label}</p>
-      <p className="text-on-surface-variant mt-0.5">{pct}% · {count.toLocaleString()} incidents</p>
-    </div>
-  );
-}
-
-function MonthTooltip({ active, payload }: { active?: boolean; payload?: { payload: MonthlyDataPoint }[] }) {
-  if (!active || !payload?.length) return null;
-  const { label, count, killed, injured } = payload[0].payload;
-  return (
-    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-      <p className="font-headline font-bold text-on-surface">{label}</p>
-      <p className="text-on-surface-variant mt-0.5">{count.toLocaleString()} incidents</p>
-      <p className="text-on-surface-variant">{killed.toLocaleString()} killed · {injured.toLocaleString()} injured</p>
-    </div>
-  );
-}
-
-function DowTooltip({ active, payload }: { active?: boolean; payload?: { payload: DayOfWeekDataPoint }[] }) {
-  if (!active || !payload?.length) return null;
-  const { label, count } = payload[0].payload;
-  return (
-    <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-      <p className="font-headline font-bold text-on-surface">{label}</p>
-      <p className="text-on-surface-variant mt-0.5">{count.toLocaleString()} incidents</p>
-    </div>
+    <>
+      <p className="font-headline font-bold text-on-surface">{title}</p>
+      {lines.map((l, i) => <p key={i} className="text-on-surface-variant mt-0.5">{l}</p>)}
+    </>
   );
 }
 
@@ -415,47 +352,19 @@ export default function StatsPage() {
           ) : !hourlyData.length ? (
             <EmptyState icon="search_off" description="No data for the selected filters." className="h-48" />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={hourlyData} barCategoryGap="10%" margin={{ top: 8, right: 20, left: 10, bottom: 0 }}>
-                <XAxis
-                  dataKey="hour"
-                  ticks={[0, 6, 12, 18, 23]}
-                  minTickGap={0}
-                  tickFormatter={(h) => h === 23 ? "23:59" : `${String(h).padStart(2, "0")}:00`}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <Tooltip content={<HourTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
-                  {hourlyData.map((_, i) => (
-                    <Cell key={i} fill={i === peakHourIndex ? clrPrimary : clrPrimaryContainer} />
-                  ))}
-                  <LabelList
-                    dataKey="count"
-                    position="top"
-                    content={(props) => {
-                      const { x, y, width, index } = props as { x: number; y: number; width: number; index: number };
-                      if (index !== peakHourIndex) return null;
-                      return (
-                        <text
-                          x={Number(x) + Number(width) / 2}
-                          y={Number(y) - 4}
-                          textAnchor="middle"
-                          fill={clrPrimary}
-                          fontSize={8}
-                          fontWeight={700}
-                          fontFamily="Inter, sans-serif"
-                          letterSpacing={1}
-                        >
-                          PEAK
-                        </text>
-                      );
-                    }}
-                  />
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={hourlyData.map((d, i) => ({
+                label: [0, 6, 12, 18, 23].includes(d.hour) ? (d.hour === 23 ? "23:59" : `${String(d.hour).padStart(2, "0")}:00`) : "",
+                value: d.count,
+                color: i === peakHourIndex ? clrPrimary : clrPrimaryContainer,
+                peakLabel: i === peakHourIndex ? "PEAK" : undefined,
+              }))}
+              height={isMobile ? 240 : 192}
+              renderTooltip={(_, idx) => {
+                const d = hourlyData[idx];
+                return <ChartTip title={`${String(d.hour).padStart(2, "0")}:00`} lines={[`${d.count.toLocaleString()} incidents`]} />;
+              }}
+            />
           )}
         </div>
 
@@ -472,26 +381,11 @@ export default function StatsPage() {
             <EmptyState icon="search_off" description="No data for the selected filters." className="h-40" />
           ) : causesWithPct.length <= 5 ? (
             <>
-              <ResponsiveContainer width="100%" height={isMobile ? 200 : 160}>
-                <PieChart>
-                  <Pie
-                    data={causesWithPct}
-                    dataKey="pct"
-                    nameKey="label"
-                    innerRadius={48}
-                    outerRadius={72}
-                    paddingAngle={2}
-                    startAngle={90}
-                    endAngle={-270}
-                    strokeWidth={0}
-                  >
-                    {causesWithPct.map((c) => (
-                      <Cell key={c.label} fill={causeColor(c.label)} />
-                    ))}
-                  </Pie>
-                  <Tooltip content={<CauseTooltip />} />
-                </PieChart>
-              </ResponsiveContainer>
+              <SimpleDonutChart
+                data={causesWithPct.map((c) => ({ label: c.label, value: c.pct, color: causeColor(c.label) }))}
+                height={isMobile ? 200 : 160}
+                renderTooltip={(item) => <ChartTip title={item.label} lines={[`${item.pct}% · ${causesWithPct.find((c) => c.label === item.label)?.count.toLocaleString() ?? 0} incidents`]} />}
+              />
               <div className="space-y-4 mt-2">
                 {causesWithPct.map((cause) => (
                   <div key={cause.label} className="flex items-center gap-3">
@@ -507,25 +401,19 @@ export default function StatsPage() {
               </div>
             </>
           ) : (
-            <ResponsiveContainer width="100%" height={Math.max(200, causesWithPct.length * 32)}>
-              <BarChart data={[...causesWithPct].sort((a, b) => b.count - a.count)} layout="vertical" margin={{ top: 0, right: 20, left: 0, bottom: 0 }}>
-                <XAxis type="number" hide />
-                <YAxis
-                  type="category"
-                  dataKey="label"
-                  width={100}
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip content={<CauseTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
-                <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={18}>
-                  {[...causesWithPct].sort((a, b) => b.count - a.count).map((c) => (
-                    <Cell key={c.label} fill={causeColor(c.label)} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={[...causesWithPct].sort((a, b) => b.count - a.count).map((c) => ({
+                label: c.label,
+                value: c.count,
+                color: causeColor(c.label),
+              }))}
+              height={Math.max(200, causesWithPct.length * 32)}
+              layout="horizontal"
+              renderTooltip={(item) => {
+                const c = causesWithPct.find((x) => x.label === item.label);
+                return <ChartTip title={item.label} lines={[`${c?.pct ?? 0}% · ${item.value.toLocaleString()} incidents`]} />;
+              }}
+            />
           )}
         </div>
 
@@ -560,47 +448,39 @@ export default function StatsPage() {
               ))}
             </div>
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 200 : 256}>
-              <BarChart data={yearlyData} barCategoryGap="15%" margin={{ top: 24, right: 0, left: 0, bottom: 0 }}>
-                <XAxis
-                  dataKey="year"
-                  tickLine={false}
-                  axisLine={false}
-                  interval={0}
-                  tick={(props) => {
-                    const { x, y, payload } = props;
-                    const yr = payload.value as number;
-                    const isPeak = yr === peakYear;
-                    const nearPeak = Math.abs(yr - peakYear) <= 2 && !isPeak;
-                    const isEndpoint = yr === yearlyData[0]?.year || yr === yearlyData[yearlyData.length - 1]?.year;
-                    const showLabel = isPeak || (!nearPeak && (yr % 5 === 0 || isEndpoint));
-                    if (!showLabel) return <text />;
-                    return (
-                      <text
-                        x={x} y={y + 10}
-                        textAnchor="middle"
-                        fill={isPeak ? clrOnSurface : clrOnSurfaceVariant}
-                        fontSize={10}
-                        fontWeight={700}
-                        fontStyle={isPeak ? "italic" : "normal"}
-                        fontFamily="Inter, sans-serif"
-                      >
-                        {isPeak ? `${yr}*` : yr}
-                      </text>
-                    );
-                  }}
-                />
-                <Tooltip
-                  content={<YearTooltip />}
-                  cursor={<YearCursor />}
-                />
-                <Bar dataKey="count" radius={[4, 4, 0, 0]}>
-                  {yearlyData.map((entry, i) => (
-                    <Cell key={i} fill={entry.year === peakYear ? clrError : clrPrimaryContainer} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={yearlyData.map((d) => ({
+                label: String(d.year),
+                value: d.count,
+                color: d.year === peakYear ? clrError : clrPrimaryContainer,
+              }))}
+              height={isMobile ? 200 : 256}
+              radius={4}
+              renderTooltip={(_, idx) => {
+                const d = yearlyData[idx];
+                return <ChartTip title={String(d.year)} lines={[`${d.count.toLocaleString()} incidents`]} />;
+              }}
+              labelFormatter={(label, _idx, _isPeak) => {
+                const yr = parseInt(label);
+                const isPeak = yr === peakYear;
+                const nearPeak = Math.abs(yr - peakYear) <= 2 && !isPeak;
+                const isEndpoint = yr === yearlyData[0]?.year || yr === yearlyData[yearlyData.length - 1]?.year;
+                const show = isPeak || (!nearPeak && (yr % 5 === 0 || isEndpoint));
+                if (!show) return null;
+                return (
+                  <text
+                    textAnchor="middle"
+                    fill={isPeak ? clrOnSurface : clrOnSurfaceVariant}
+                    fontSize={10}
+                    fontWeight={700}
+                    fontStyle={isPeak ? "italic" : "normal"}
+                    fontFamily="'Inter Variable', Inter, sans-serif"
+                  >
+                    {isPeak ? `${yr}*` : yr}
+                  </text>
+                );
+              }}
+            />
           )}
           {yearlyData.length >= 3 && (
             <p className="mt-6 text-[10px] text-on-surface-variant italic leading-relaxed">
@@ -633,44 +513,19 @@ export default function StatsPage() {
           ) : !monthlyData.length ? (
             <EmptyState icon="search_off" description="No data for the selected filters." className="h-48" />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={monthlyData} barCategoryGap="10%" margin={{ top: 8, right: 20, left: 10, bottom: 0 }}>
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip content={<MonthTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
-                  {monthlyData.map((_, i) => (
-                    <Cell key={i} fill={i === peakMonthIndex ? clrPrimary : clrPrimaryContainer} />
-                  ))}
-                  <LabelList
-                    dataKey="count"
-                    position="top"
-                    content={(props) => {
-                      const { x, y, width, index } = props as { x: number; y: number; width: number; index: number };
-                      if (index !== peakMonthIndex) return null;
-                      return (
-                        <text
-                          x={Number(x) + Number(width) / 2}
-                          y={Number(y) - 4}
-                          textAnchor="middle"
-                          fill={clrPrimary}
-                          fontSize={8}
-                          fontWeight={700}
-                          fontFamily="Inter, sans-serif"
-                          letterSpacing={1}
-                        >
-                          PEAK
-                        </text>
-                      );
-                    }}
-                  />
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={monthlyData.map((d, i) => ({
+                label: d.label,
+                value: d.count,
+                color: i === peakMonthIndex ? clrPrimary : clrPrimaryContainer,
+                peakLabel: i === peakMonthIndex ? "PEAK" : undefined,
+              }))}
+              height={isMobile ? 240 : 192}
+              renderTooltip={(_, idx) => {
+                const d = monthlyData[idx];
+                return <ChartTip title={d.label} lines={[`${d.count.toLocaleString()} incidents`, `${d.killed.toLocaleString()} killed · ${d.injured.toLocaleString()} injured`]} />;
+              }}
+            />
           )}
         </div>
 
@@ -686,22 +541,15 @@ export default function StatsPage() {
           ) : !dayOfWeekData.length ? (
             <EmptyState icon="search_off" description="No data for the selected filters." className="h-48" />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={dayOfWeekData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip content={<DowTooltip />} cursor={{ fill: "rgba(87,95,107,0.06)" }} />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
-                  {dayOfWeekData.map((_, i) => (
-                    <Cell key={i} fill={i === peakDowIndex ? clrPrimary : clrPrimaryContainer} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={dayOfWeekData.map((d, i) => ({
+                label: d.label,
+                value: d.count,
+                color: i === peakDowIndex ? clrPrimary : clrPrimaryContainer,
+              }))}
+              height={isMobile ? 240 : 192}
+              renderTooltip={(item) => <ChartTip title={item.label} lines={[`${item.value.toLocaleString()} incidents`]} />}
+            />
           )}
         </div>
       </section>
@@ -721,26 +569,11 @@ export default function StatsPage() {
             <EmptyState icon="search_off" description="No data for the selected filters." className="h-40" />
           ) : (
             <>
-              <ResponsiveContainer width="100%" height={isMobile ? 200 : 160}>
-                <PieChart>
-                  <Pie
-                    data={sevWithPct}
-                    dataKey="pct"
-                    nameKey="label"
-                    innerRadius={48}
-                    outerRadius={72}
-                    paddingAngle={2}
-                    startAngle={90}
-                    endAngle={-270}
-                    strokeWidth={0}
-                  >
-                    {sevWithPct.map((s) => (
-                      <Cell key={s.label} fill={severityColor(s.label)} />
-                    ))}
-                  </Pie>
-                  <Tooltip content={<CauseTooltip />} />
-                </PieChart>
-              </ResponsiveContainer>
+              <SimpleDonutChart
+                data={sevWithPct.map((s) => ({ label: s.label, value: s.pct, color: severityColor(s.label) }))}
+                height={isMobile ? 200 : 160}
+                renderTooltip={(item) => <ChartTip title={item.label} lines={[`${item.pct}% · ${sevWithPct.find((s) => s.label === item.label)?.count.toLocaleString() ?? 0} incidents`]} />}
+              />
               <div className="space-y-4 mt-2">
                 {sevWithPct.map((sev) => (
                   <div key={sev.label} className="flex items-center gap-3">
@@ -781,36 +614,20 @@ export default function StatsPage() {
               className="h-48"
             />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={genderData} barCategoryGap="25%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip
-                  content={({ active, payload }) => {
-                    if (!active || !payload?.length) return null;
-                    const d = payload[0].payload as { label: string; count: number };
-                    const total = genderData.reduce((s, g) => s + g.count, 0);
-                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
-                    return (
-                      <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-                        <p className="font-headline font-bold text-on-surface">{d.label}</p>
-                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} victims</p>
-                      </div>
-                    );
-                  }}
-                  cursor={{ fill: "rgba(87,95,107,0.06)" }}
-                />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
-                  {genderData.map((_, i) => (
-                    <Cell key={i} fill={[clrPrimary, clrTertiary, clrPrimaryContainer][i] ?? clrPrimaryContainer} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={genderData.map((d, i) => ({
+                label: d.label,
+                value: d.count,
+                color: [clrPrimary, clrTertiary, clrPrimaryContainer][i] ?? clrPrimaryContainer,
+              }))}
+              height={isMobile ? 240 : 192}
+              gap={0.3}
+              renderTooltip={(item) => {
+                const total = genderData.reduce((s, g) => s + g.count, 0);
+                const pct = total > 0 ? Math.round((item.value / total) * 100) : 0;
+                return <ChartTip title={item.label} lines={[`${pct}% · ${item.value.toLocaleString()} victims`]} />;
+              }}
+            />
           )}
         </div>
 
@@ -837,32 +654,16 @@ export default function StatsPage() {
               className="h-48"
             />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={ageBracketData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip
-                  content={({ active, payload }) => {
-                    if (!active || !payload?.length) return null;
-                    const d = payload[0].payload as { label: string; count: number };
-                    const total = ageBracketData.reduce((s, a) => s + a.count, 0);
-                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
-                    return (
-                      <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-                        <p className="font-headline font-bold text-on-surface">{d.label}</p>
-                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} victims</p>
-                      </div>
-                    );
-                  }}
-                  cursor={{ fill: "rgba(87,95,107,0.06)" }}
-                />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]} fill={clrPrimaryContainer} />
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={ageBracketData.map((d) => ({ label: d.label, value: d.count }))}
+              height={isMobile ? 240 : 192}
+              defaultColor={clrPrimaryContainer}
+              renderTooltip={(item) => {
+                const total = ageBracketData.reduce((s, a) => s + a.count, 0);
+                const pct = total > 0 ? Math.round((item.value / total) * 100) : 0;
+                return <ChartTip title={item.label} lines={[`${pct}% · ${item.value.toLocaleString()} victims`]} />;
+              }}
+            />
           )}
         </div>
 
@@ -886,36 +687,20 @@ export default function StatsPage() {
               className="h-48"
             />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={atFaultGenderData} barCategoryGap="25%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip
-                  content={({ active, payload }) => {
-                    if (!active || !payload?.length) return null;
-                    const d = payload[0].payload as { label: string; count: number };
-                    const total = atFaultGenderData.reduce((s, g) => s + g.count, 0);
-                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
-                    return (
-                      <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-                        <p className="font-headline font-bold text-on-surface">{d.label}</p>
-                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} drivers</p>
-                      </div>
-                    );
-                  }}
-                  cursor={{ fill: "rgba(87,95,107,0.06)" }}
-                />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]}>
-                  {atFaultGenderData.map((_, i) => (
-                    <Cell key={i} fill={[clrPrimary, clrTertiary, clrPrimaryContainer][i] ?? clrPrimaryContainer} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={atFaultGenderData.map((d, i) => ({
+                label: d.label,
+                value: d.count,
+                color: [clrPrimary, clrTertiary, clrPrimaryContainer][i] ?? clrPrimaryContainer,
+              }))}
+              height={isMobile ? 240 : 192}
+              gap={0.3}
+              renderTooltip={(item) => {
+                const total = atFaultGenderData.reduce((s, g) => s + g.count, 0);
+                const pct = total > 0 ? Math.round((item.value / total) * 100) : 0;
+                return <ChartTip title={item.label} lines={[`${pct}% · ${item.value.toLocaleString()} drivers`]} />;
+              }}
+            />
           )}
         </div>
 
@@ -939,32 +724,16 @@ export default function StatsPage() {
               className="h-48"
             />
           ) : (
-            <ResponsiveContainer width="100%" height={isMobile ? 240 : 192}>
-              <BarChart data={atFaultAgeBracketData} barCategoryGap="15%" margin={{ top: 8, right: 0, left: 0, bottom: 0 }}>
-                <XAxis
-                  dataKey="label"
-                  tickLine={false}
-                  axisLine={false}
-                  tick={{ fontSize: 10, fill: clrOnSurfaceVariant, fontWeight: 600, fontFamily: "Inter, sans-serif" }}
-                />
-                <Tooltip
-                  content={({ active, payload }) => {
-                    if (!active || !payload?.length) return null;
-                    const d = payload[0].payload as { label: string; count: number };
-                    const total = atFaultAgeBracketData.reduce((s, a) => s + a.count, 0);
-                    const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
-                    return (
-                      <div className="bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow">
-                        <p className="font-headline font-bold text-on-surface">{d.label}</p>
-                        <p className="text-on-surface-variant mt-0.5">{pct}% · {d.count.toLocaleString()} drivers</p>
-                      </div>
-                    );
-                  }}
-                  cursor={{ fill: "rgba(87,95,107,0.06)" }}
-                />
-                <Bar dataKey="count" radius={[2, 2, 0, 0]} fill={clrPrimaryContainer} />
-              </BarChart>
-            </ResponsiveContainer>
+            <SimpleBarChart
+              data={atFaultAgeBracketData.map((d) => ({ label: d.label, value: d.count }))}
+              height={isMobile ? 240 : 192}
+              defaultColor={clrPrimaryContainer}
+              renderTooltip={(item) => {
+                const total = atFaultAgeBracketData.reduce((s, a) => s + a.count, 0);
+                const pct = total > 0 ? Math.round((item.value / total) * 100) : 0;
+                return <ChartTip title={item.label} lines={[`${pct}% · ${item.value.toLocaleString()} drivers`]} />;
+              }}
+            />
           )}
         </div>
       </section>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -460,7 +460,7 @@ export default function StatsPage() {
                 const d = yearlyData[idx];
                 return <ChartTip title={String(d.year)} lines={[`${d.count.toLocaleString()} incidents`]} />;
               }}
-              labelFormatter={(label, _idx, _isPeak) => {
+              labelFormatter={(label) => {
                 const yr = parseInt(label);
                 const isPeak = yr === peakYear;
                 const nearPeak = Math.abs(yr - peakYear) <= 2 && !isPeak;


### PR DESCRIPTION
## Summary
Removes the entire `recharts` dependency (390KB + 37 sub-packages) and replaces it with 3 custom SVG chart components totaling ~8KB:

- **SimpleBarChart** — vertical + horizontal layouts, hover tooltips, peak highlighting, custom axis labels
- **SimpleDonutChart** — donut/pie with colored segments, hover opacity, tooltips
- **SimpleLineChart** — line path with dots, y-axis, hover crosshair, responsive labels

All 10 chart instances in StatsPage and all 3 in InlineChart (Ask AI) have been replaced.

## Impact
- Stats page JS: **439KB → 42KB** (-90%)
- 37 npm packages removed
- No new dependencies added

## Test plan
- [ ] Stats page: verify all charts render (hourly, yearly, monthly, day of week, cause, severity, demographics)
- [ ] Stats page: hover over bars → tooltip appears with correct data
- [ ] Stats page: peak bars highlighted in accent color with "PEAK" label
- [ ] Stats page: cause donut shows ≤5 causes as pie, >5 as horizontal bars
- [ ] Ask AI: send a question that returns a chart → verify bar/line/pie render
- [ ] Dark mode: verify chart colors update with theme
- [ ] Mobile: verify charts resize correctly

Closes #215