### PR TITLE
fix: migration chain conflict + favorite star toggle (#226)

### DIFF
--- a/backend/migrations/versions/l0m1n2o3p4q5_add_cities_table_and_crashes_city_id.py
+++ b/backend/migrations/versions/l0m1n2o3p4q5_add_cities_table_and_crashes_city_id.py
@@ -1,7 +1,7 @@
 """add cities table and crashes.city_id
 
-Revision ID: k9l0m1n2o3p4
-Revises: j8k9l0m1n2o3
+Revision ID: l0m1n2o3p4q5
+Revises: k9l0m1n2o3p4
 Create Date: 2026-05-13 00:00:00.000000
 """
 from typing import Sequence, Union
@@ -10,8 +10,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "k9l0m1n2o3p4"
-down_revision: Union[str, None] = "j8k9l0m1n2o3"
+revision: str = "l0m1n2o3p4q5"
+down_revision: Union[str, None] = "k9l0m1n2o3p4"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/frontend/src/components/map/UnifiedSearchBar.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.tsx
@@ -28,7 +28,7 @@ export default function UnifiedSearchBar({
   const containerRef = useRef<HTMLDivElement>(null);
   const mobileInputRef = useRef<HTMLInputElement>(null);
 
-  const { favorites, addFavorite, removeFavorite } = useFavoriteLocations();
+  const { favorites, addFavorite, removeFavorite, isFavorite } = useFavoriteLocations();
 
   const trimmed = query.trim().toLowerCase();
   const countyMatches = trimmed
@@ -183,16 +183,24 @@ export default function UnifiedSearchBar({
                   className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0 min-w-[24px] min-h-[24px] flex items-center justify-center"
                   aria-label={`Remove ${item.label} from favorites`}
                 >
-                  <span className="material-symbols-outlined text-[14px] text-on-surface-variant">close</span>
+                  <span className="material-symbols-outlined text-[14px] text-primary" style={{ fontVariationSettings: "'FILL' 1" }}>star</span>
                 </button>
               ) : item.type === "place" && item.lat != null ? (
-                <button
-                  onClick={(e) => handleSaveFavorite(item, e)}
-                  className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0 min-w-[24px] min-h-[24px] flex items-center justify-center"
-                  aria-label={`Save ${item.label} to favorites`}
-                >
-                  <span className="material-symbols-outlined text-[14px] text-on-surface-variant">star</span>
-                </button>
+                (() => {
+                  const saved = isFavorite(item.lat!, item.lng!);
+                  return (
+                    <button
+                      onClick={(e) => saved ? handleRemoveFavorite(item, e) : handleSaveFavorite(item, e)}
+                      className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0 min-w-[24px] min-h-[24px] flex items-center justify-center"
+                      aria-label={saved ? `Remove ${item.label} from favorites` : `Save ${item.label} to favorites`}
+                    >
+                      <span
+                        className={`material-symbols-outlined text-[14px] ${saved ? "text-primary" : "text-on-surface-variant"}`}
+                        style={saved ? { fontVariationSettings: "'FILL' 1" } : undefined}
+                      >star</span>
+                    </button>
+                  );
+                })()
               ) : null}
             </button>
           </div>


### PR DESCRIPTION
## Summary

- Fix Alembic duplicate revision ID (`k9l0m1n2o3p4`) that caused deploy failure — rename cities migration to `l0m1n2o3p4q5` chained after the ETL widen migration
- Wire up `isFavorite()` in UnifiedSearchBar so star icon toggles filled/outlined and clicking a saved star removes it

## Deploy note

This unblocks the failed deploy from PR #222. The cities migration will run on next deploy as `l0m1n2o3p4q5`.

Migration chain: `j8k9l0m1n2o3 → k9l0m1n2o3p4 (ETL widen, on prod) → l0m1n2o3p4q5 (cities, pending)`

## Closes

- Closes #226

## Test plan

- [ ] Deploy succeeds — `alembic upgrade head` runs without "multiple heads" error
- [ ] Cities table gets created in prod DB
- [ ] Search for a place, click star — icon fills and turns primary color
- [ ] Click filled star — removes favorite, icon goes back to outlined
- [ ] Open search bar with empty query — saved favorites appear at top
