### PR TITLE
perf(#213): batch stats endpoint — 12 API requests to 2

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -28,6 +28,7 @@ from app.schemas.stats import (
     AgeBracketRow,
     AtFaultAgeBracketRow,
     AtFaultGenderRow,
+    BatchStatsRequest,
     CauseRow,
     CountyRow,
     DayOfWeekRow,
@@ -228,80 +229,35 @@ def _apply_filters(stmt, view, years, county_codes, severities, causes):
     return stmt
 
 
-@router.get("/stats")
-def stats(
-    response: Response,
-    year: str | None = Query(None),
-    start: str | None = Query(None),
-    end: str | None = Query(None),
-    county: str | None = Query(None),
-    severity: str | None = Query(None),
-    cause: str | None = Query(None),
-    alcohol: str | None = Query(None),
-    distracted: str | None = Query(None),
-    pedestrian: str | None = Query(None),
-    cyclist: str | None = Query(None),
-    drug: str | None = Query(None),
-    driver_age: str | None = Query(None),
-    weather: str | None = Query(None),
-    lighting: str | None = Query(None),
-    collision_type: str | None = Query(None),
-    road_type: str | None = Query(None),
-    hit_run: str | None = Query(None),
-    group_by: str | None = Query(
-        None,
-        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|at_fault_gender|at_fault_age_bracket|rate|weather|lighting|collision_type)$",
-    ),
-    db: Session = Depends(get_db),
-):
-    """Aggregated stats from materialized views.
+def _run_group_query(
+    group_by: str | None,
+    years: list[int] | None,
+    county_codes: list[int] | None,
+    severities: list[str] | None,
+    causes: list[str] | None,
+    db: Session,
+    *,
+    alcohol_v=None,
+    distracted_v=None,
+    pedestrian_v=None,
+    cyclist_v=None,
+    drug_v=None,
+    driver_age_v=None,
+    weather_v=None,
+    lighting_v=None,
+    collision_type_v=None,
+    road_type_v=None,
+    hit_run_v=None,
+) -> list[dict] | dict:
+    """Execute the appropriate query for the given group_by value and filters.
 
-    `group_by` dispatches to one of four views (see `docs/db-schema.md`):
-      - `hour` -> mv_crashes_by_hour (counts only, no killed/injured)
-      - `cause` OR any cause filter -> mv_crashes_by_cause
-      - `gender` / `age_bracket` -> mv_crash_victims_by_demographics
-        (counts VICTIMS, not crashes — see GenderRow docstring)
-      - `at_fault_gender` / `at_fault_age_bracket` ->
-        mv_at_fault_parties_by_demographics (counts AT-FAULT PARTIES —
-        typically drivers — not victims and not crashes)
-      - everything else -> mv_crashes_by_year
-
-    `alcohol` / `distracted` are not supported here (crash views don't carry
-    those columns). Use `/api/crashes` with those filters for drill-down.
-    `cause` filter is incompatible with `group_by=gender|age_bracket|
-    at_fault_gender|at_fault_age_bracket` because the demographic views
-    don't carry canonical_cause.
-
-    `start`/`end` (YYYY-MM) are accepted but rounded outward to year
-    boundaries here, since the underlying materialized views aggregate by
-    year. For month-precise filtering, use `/api/crashes` or
-    `/api/crashes/heatmap`.
+    This contains all query dispatch logic extracted from the stats() endpoint.
     """
-    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
-
-    alcohol_v = parse_bool_flag(alcohol, "alcohol")
-    distracted_v = parse_bool_flag(distracted, "distracted")
-    pedestrian_v = parse_bool_flag(pedestrian, "pedestrian")
-    cyclist_v = parse_bool_flag(cyclist, "cyclist")
-    drug_v = parse_bool_flag(drug, "drug")
-    driver_age_v = parse_driver_age(driver_age)
-    weather_v = parse_weather(weather)
-    lighting_v = parse_lighting(lighting)
-    collision_type_v = parse_collision_type(collision_type)
-    road_type_v = parse_road_type(road_type)
-    hit_run_v = parse_hit_run(hit_run)
-
     has_involvement = any(v is not None for v in [
         alcohol_v, distracted_v, pedestrian_v, cyclist_v, drug_v, driver_age_v,
         weather_v, lighting_v, collision_type_v, road_type_v, hit_run_v,
     ])
     has_condition_group = group_by in ("weather", "lighting", "collision_type")
-
-    date_range = parse_date_range(start, end)
-    years = years_from_date_range(date_range) if date_range is not None else parse_year(year)
-    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
-    severities = parse_severity(severity)
-    causes = parse_cause(cause)
 
     def _raw_preds():
         return build_crash_predicates(
@@ -840,3 +796,136 @@ def stats(
 
     # Unreachable — pattern validator catches bad values.
     raise HTTPException(status_code=500, detail="Unreachable group_by branch")
+
+
+@router.get("/stats")
+def stats(
+    response: Response,
+    year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    pedestrian: str | None = Query(None),
+    cyclist: str | None = Query(None),
+    drug: str | None = Query(None),
+    driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
+    group_by: str | None = Query(
+        None,
+        pattern="^(county|year|cause|hour|month|day_of_week|severity|gender|age_bracket|at_fault_gender|at_fault_age_bracket|rate|weather|lighting|collision_type)$",
+    ),
+    db: Session = Depends(get_db),
+):
+    """Aggregated stats from materialized views.
+
+    `group_by` dispatches to one of four views (see `docs/db-schema.md`):
+      - `hour` -> mv_crashes_by_hour (counts only, no killed/injured)
+      - `cause` OR any cause filter -> mv_crashes_by_cause
+      - `gender` / `age_bracket` -> mv_crash_victims_by_demographics
+        (counts VICTIMS, not crashes — see GenderRow docstring)
+      - `at_fault_gender` / `at_fault_age_bracket` ->
+        mv_at_fault_parties_by_demographics (counts AT-FAULT PARTIES —
+        typically drivers — not victims and not crashes)
+      - everything else -> mv_crashes_by_year
+
+    `alcohol` / `distracted` are not supported here (crash views don't carry
+    those columns). Use `/api/crashes` with those filters for drill-down.
+    `cause` filter is incompatible with `group_by=gender|age_bracket|
+    at_fault_gender|at_fault_age_bracket` because the demographic views
+    don't carry canonical_cause.
+
+    `start`/`end` (YYYY-MM) are accepted but rounded outward to year
+    boundaries here, since the underlying materialized views aggregate by
+    year. For month-precise filtering, use `/api/crashes` or
+    `/api/crashes/heatmap`.
+    """
+    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+
+    alcohol_v = parse_bool_flag(alcohol, "alcohol")
+    distracted_v = parse_bool_flag(distracted, "distracted")
+    pedestrian_v = parse_bool_flag(pedestrian, "pedestrian")
+    cyclist_v = parse_bool_flag(cyclist, "cyclist")
+    drug_v = parse_bool_flag(drug, "drug")
+    driver_age_v = parse_driver_age(driver_age)
+    weather_v = parse_weather(weather)
+    lighting_v = parse_lighting(lighting)
+    collision_type_v = parse_collision_type(collision_type)
+    road_type_v = parse_road_type(road_type)
+    hit_run_v = parse_hit_run(hit_run)
+
+    date_range = parse_date_range(start, end)
+    years = years_from_date_range(date_range) if date_range is not None else parse_year(year)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+
+    return _run_group_query(
+        group_by, years, county_codes, severities, causes, db,
+        alcohol_v=alcohol_v,
+        distracted_v=distracted_v,
+        pedestrian_v=pedestrian_v,
+        cyclist_v=cyclist_v,
+        drug_v=drug_v,
+        driver_age_v=driver_age_v,
+        weather_v=weather_v,
+        lighting_v=lighting_v,
+        collision_type_v=collision_type_v,
+        road_type_v=road_type_v,
+        hit_run_v=hit_run_v,
+    )
+
+
+ALLOWED_GROUPS = {
+    "year", "hour", "cause", "severity", "month", "day_of_week",
+    "gender", "age_bracket", "at_fault_gender", "at_fault_age_bracket",
+    "rate", "county",
+}
+
+@router.post("/stats/batch")
+def stats_batch(
+    body: BatchStatsRequest,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    """Run multiple group_by queries in one request."""
+    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+
+    invalid = set(body.groups) - ALLOWED_GROUPS
+    if invalid:
+        raise FilterError("groups", f"Invalid group_by values: {', '.join(sorted(invalid))}")
+
+    date_range = parse_date_range(body.start, body.end)
+    years = years_from_date_range(date_range) if date_range else parse_year(body.year)
+    county_codes = parse_county_codes(body.county, get_slug_map(db)) if body.county else None
+    severities = parse_severity(body.severity)
+    causes = parse_cause(body.cause)
+
+    kwargs = dict(
+        alcohol_v=parse_bool_flag(body.alcohol, "alcohol"),
+        distracted_v=parse_bool_flag(body.distracted, "distracted"),
+        pedestrian_v=parse_bool_flag(body.pedestrian, "pedestrian"),
+        cyclist_v=parse_bool_flag(body.cyclist, "cyclist"),
+        drug_v=parse_bool_flag(body.drug, "drug"),
+        driver_age_v=parse_driver_age(body.driver_age),
+        weather_v=parse_weather(body.weather),
+        lighting_v=parse_lighting(body.lighting),
+        collision_type_v=parse_collision_type(body.collision_type),
+        road_type_v=parse_road_type(body.road_type),
+        hit_run_v=parse_hit_run(body.hit_run),
+    )
+
+    results = {}
+    for group in body.groups:
+        results[group] = _run_group_query(
+            group, years, county_codes, severities, causes, db, **kwargs,
+        )
+
+    return results

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -107,3 +107,24 @@ class RateRow(BaseModel):
     per_100_road_miles: float | None = None
     per_100k_aadt: float | None = None
     per_10k_vehicles: float | None = None
+
+
+class BatchStatsRequest(BaseModel):
+    groups: list[str]
+    year: str | None = None
+    start: str | None = None
+    end: str | None = None
+    county: str | None = None
+    severity: str | None = None
+    cause: str | None = None
+    alcohol: str | None = None
+    distracted: str | None = None
+    pedestrian: str | None = None
+    cyclist: str | None = None
+    drug: str | None = None
+    driver_age: str | None = None
+    weather: str | None = None
+    lighting: str | None = None
+    collision_type: str | None = None
+    road_type: str | None = None
+    hit_run: str | None = None

--- a/backend/tests/api/test_stats_batch.py
+++ b/backend/tests/api/test_stats_batch.py
@@ -1,0 +1,25 @@
+"""Tests for POST /api/stats/batch."""
+
+
+def test_batch_returns_requested_groups(client):
+    response = client.post("/api/stats/batch", json={
+        "groups": ["year", "hour"],
+    })
+    assert response.status_code == 200
+    data = response.json()
+    assert "year" in data
+    assert "hour" in data
+    assert isinstance(data["year"], list)
+    assert isinstance(data["hour"], list)
+
+
+def test_batch_rejects_invalid_group(client):
+    response = client.post("/api/stats/batch", json={
+        "groups": ["year", "bogus"],
+    })
+    assert response.status_code in (400, 422)
+
+
+def test_batch_cache_header(client):
+    response = client.post("/api/stats/batch", json={"groups": ["year"]})
+    assert "max-age=3600" in response.headers.get("cache-control", "")

--- a/frontend/src/hooks/useStats.test.tsx
+++ b/frontend/src/hooks/useStats.test.tsx
@@ -43,7 +43,7 @@ const DEMO_ROWS = [
 ];
 
 function mockFetch() {
-  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input);
     if (url.includes("/api/stats/batch")) {
       return new Response(JSON.stringify({

--- a/frontend/src/hooks/useStats.test.tsx
+++ b/frontend/src/hooks/useStats.test.tsx
@@ -43,16 +43,22 @@ const DEMO_ROWS = [
 ];
 
 function mockFetch() {
-  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = String(input);
-    if (url.includes("group_by=year")) {
-      return new Response(JSON.stringify(YEAR_ROWS));
-    }
-    if (url.includes("group_by=hour")) {
-      return new Response(JSON.stringify(HOUR_ROWS));
-    }
-    if (url.includes("group_by=cause")) {
-      return new Response(JSON.stringify(CAUSE_ROWS));
+    if (url.includes("/api/stats/batch")) {
+      return new Response(JSON.stringify({
+        year: YEAR_ROWS,
+        hour: HOUR_ROWS,
+        cause: CAUSE_ROWS,
+        severity: [],
+        gender: [],
+        age_bracket: [],
+        at_fault_gender: [],
+        at_fault_age_bracket: [],
+        month: [],
+        day_of_week: [],
+        rate: [],
+      }));
     }
     if (url.includes("/api/demographics")) {
       return new Response(JSON.stringify(DEMO_ROWS));
@@ -66,52 +72,52 @@ describe("useStats", () => {
     vi.restoreAllMocks();
   });
 
-  it("fires 3 parallel fetches with correct group_by and filter params", async () => {
+  it("fires batch POST + demographics GET", async () => {
     const spy = mockFetch();
-    const { result } = renderHook(() => useStats(FILTERS), {
-      wrapper: makeWrapper(),
-    });
+    const { result } = renderHook(() => useStats(FILTERS), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(spy).toHaveBeenCalledTimes(12);
-    const urls = spy.mock.calls.map((c) => String(c[0]));
-    expect(urls.some((u) => u.includes("group_by=year") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=hour") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=cause") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
-    expect(urls.some((u) => u.includes("/api/demographics") && u.includes("start=2022-01") && u.includes("end=2023-12"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=severity"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=gender"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=age_bracket"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=at_fault_gender"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=at_fault_age_bracket"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=month"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=day_of_week"))).toBe(true);
-    expect(urls.some((u) => u.includes("group_by=rate"))).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+    const batchCall = spy.mock.calls.find(c => String(c[0]).includes("/api/stats/batch"));
+    expect(batchCall).toBeDefined();
+    const body = JSON.parse((batchCall![1] as RequestInit).body as string);
+    expect(body.groups).toContain("year");
+    expect(body.groups).toContain("hour");
+    expect(body.groups).toContain("cause");
+    expect(body.start).toBe("2022-01");
+    expect(body.end).toBe("2023-12");
   });
 
   it("maps at-fault demographic responses to chart data points", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
-      if (url.includes("group_by=at_fault_gender")) {
-        return new Response(JSON.stringify([
-          { gender: "M", party_count: 7000, fatal_party_count: 200 },
-          { gender: "F", party_count: 3000, fatal_party_count: 80 },
-          { gender: "U", party_count: 100, fatal_party_count: 1 },
-        ]));
+      if (url.includes("/api/stats/batch")) {
+        return new Response(JSON.stringify({
+          year: YEAR_ROWS,
+          hour: HOUR_ROWS,
+          cause: CAUSE_ROWS,
+          severity: [],
+          gender: [],
+          age_bracket: [],
+          at_fault_gender: [
+            { gender: "M", party_count: 7000, fatal_party_count: 200 },
+            { gender: "F", party_count: 3000, fatal_party_count: 80 },
+            { gender: "U", party_count: 100, fatal_party_count: 1 },
+          ],
+          at_fault_age_bracket: [
+            { age_bracket: "25_44", party_count: 5000, fatal_party_count: 100 },
+            { age_bracket: "18_24", party_count: 2500, fatal_party_count: 60 },
+            { age_bracket: "45_64", party_count: 2000, fatal_party_count: 40 },
+            { age_bracket: "over_65", party_count: 800, fatal_party_count: 30 },
+            { age_bracket: "under_18", party_count: 200, fatal_party_count: 5 },
+            { age_bracket: "unknown", party_count: 50, fatal_party_count: 0 },
+          ],
+          month: [],
+          day_of_week: [],
+          rate: [],
+        }));
       }
-      if (url.includes("group_by=at_fault_age_bracket")) {
-        return new Response(JSON.stringify([
-          { age_bracket: "25_44", party_count: 5000, fatal_party_count: 100 },
-          { age_bracket: "18_24", party_count: 2500, fatal_party_count: 60 },
-          { age_bracket: "45_64", party_count: 2000, fatal_party_count: 40 },
-          { age_bracket: "over_65", party_count: 800, fatal_party_count: 30 },
-          { age_bracket: "under_18", party_count: 200, fatal_party_count: 5 },
-          { age_bracket: "unknown", party_count: 50, fatal_party_count: 0 },
-        ]));
-      }
-      if (url.includes("group_by=year")) return new Response(JSON.stringify(YEAR_ROWS));
-      if (url.includes("group_by=hour")) return new Response(JSON.stringify(HOUR_ROWS));
-      if (url.includes("group_by=cause")) return new Response(JSON.stringify(CAUSE_ROWS));
+      if (url.includes("/api/demographics")) return new Response(JSON.stringify(DEMO_ROWS));
       return new Response(JSON.stringify([]));
     });
 
@@ -174,15 +180,26 @@ describe("useStats", () => {
     const currentYear = new Date().getFullYear();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
-      if (url.includes("group_by=year")) {
-        return new Response(JSON.stringify([
-          { year: currentYear - 2, crash_count: 400_000, total_killed: 3800, total_injured: 120_000 },
-          { year: currentYear - 1, crash_count: 420_000, total_killed: 3600, total_injured: 125_000 },
-          { year: currentYear, crash_count: 5_000, total_killed: 50, total_injured: 2_000 },
-        ]));
+      if (url.includes("/api/stats/batch")) {
+        return new Response(JSON.stringify({
+          year: [
+            { year: currentYear - 2, crash_count: 400_000, total_killed: 3800, total_injured: 120_000 },
+            { year: currentYear - 1, crash_count: 420_000, total_killed: 3600, total_injured: 125_000 },
+            { year: currentYear, crash_count: 5_000, total_killed: 50, total_injured: 2_000 },
+          ],
+          hour: HOUR_ROWS,
+          cause: CAUSE_ROWS,
+          severity: [],
+          gender: [],
+          age_bracket: [],
+          at_fault_gender: [],
+          at_fault_age_bracket: [],
+          month: [],
+          day_of_week: [],
+          rate: [],
+        }));
       }
-      if (url.includes("group_by=hour")) return new Response(JSON.stringify(HOUR_ROWS));
-      if (url.includes("group_by=cause")) return new Response(JSON.stringify(CAUSE_ROWS));
+      if (url.includes("/api/demographics")) return new Response(JSON.stringify(DEMO_ROWS));
       return new Response(JSON.stringify([]));
     });
     const { result } = renderHook(() => useStats(FILTERS), { wrapper: makeWrapper() });

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { useQueries } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { SEVERITIES, CAUSES, formatYearMonth, type DateRangeFilter } from "./useFilterParams";
 import { API_BASE } from "../config";
 
@@ -115,34 +115,12 @@ function normalizeFilters(f: StatsFilters): StatsFilters {
   };
 }
 
-function appendDateRange(p: URLSearchParams, dr: DateRangeFilter | null) {
-  if (!dr) return;
-  if (dr.start) p.set("start", formatYearMonth(dr.start));
-  if (dr.end) p.set("end", formatYearMonth(dr.end));
-}
-
-function buildUrl(groupBy: string, filters: StatsFilters): string {
-  const p = new URLSearchParams();
-  p.set("group_by", groupBy);
-  appendDateRange(p, filters.dateRange);
-  if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
-  if (filters.causes.length) p.set("cause", filters.causes.join(","));
-  if (filters.counties.length) p.set("county", filters.counties.join(","));
-  return `${API_BASE}/api/stats?${p}`;
-}
-
-function buildVictimUrl(groupBy: string, filters: StatsFilters): string {
-  const p = new URLSearchParams();
-  p.set("group_by", groupBy);
-  appendDateRange(p, filters.dateRange);
-  if (filters.severities.length) p.set("severity", filters.severities.map(severityToSlug).join(","));
-  if (filters.counties.length) p.set("county", filters.counties.join(","));
-  return `${API_BASE}/api/stats?${p}`;
-}
-
 function buildDemoUrl(filters: StatsFilters): string {
   const p = new URLSearchParams();
-  appendDateRange(p, filters.dateRange);
+  if (filters.dateRange) {
+    if (filters.dateRange.start) p.set("start", formatYearMonth(filters.dateRange.start));
+    if (filters.dateRange.end) p.set("end", formatYearMonth(filters.dateRange.end));
+  }
   if (filters.counties.length) p.set("county", filters.counties.join(","));
   const qs = p.toString();
   return `${API_BASE}/api/demographics${qs ? `?${qs}` : ""}`;
@@ -191,159 +169,104 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
     : "";
   const cacheKey = { d: dateKey, s: filters.severities, c: filters.causes, co: filters.counties };
 
-  const queries = useQueries({
-    queries: [
-      {
-        queryKey: ["stats", "year", cacheKey],
-        queryFn: () => fetchJson<YearRow[]>(buildUrl("year", filters)),
-      },
-      {
-        queryKey: ["stats", "hour", cacheKey],
-        queryFn: () => fetchJson<HourRow[]>(buildUrl("hour", filters)),
-      },
-      {
-        queryKey: ["stats", "cause", cacheKey],
-        queryFn: () => fetchJson<CauseRow[]>(buildUrl("cause", filters)),
-      },
-      {
-        queryKey: ["stats", "demographics", { d: dateKey, co: filters.counties }],
-        queryFn: () => fetchJson<DemoRow[]>(buildDemoUrl(filters)),
-      },
-      {
-        queryKey: ["stats", "severity", cacheKey],
-        queryFn: () => fetchJson<SeverityRow[]>(buildUrl("severity", filters)),
-      },
-      {
-        queryKey: ["stats", "gender", { d: dateKey, s: filters.severities, co: filters.counties }],
-        queryFn: () => fetchJson<GenderRow[]>(buildVictimUrl("gender", filters)),
-      },
-      {
-        queryKey: ["stats", "age_bracket", { d: dateKey, s: filters.severities, co: filters.counties }],
-        queryFn: () => fetchJson<AgeBracketRow[]>(buildVictimUrl("age_bracket", filters)),
-      },
-      {
-        queryKey: ["stats", "at_fault_gender", { d: dateKey, s: filters.severities, co: filters.counties }],
-        queryFn: () => fetchJson<AtFaultGenderRow[]>(buildVictimUrl("at_fault_gender", filters)),
-      },
-      {
-        queryKey: ["stats", "at_fault_age_bracket", { d: dateKey, s: filters.severities, co: filters.counties }],
-        queryFn: () => fetchJson<AtFaultAgeBracketRow[]>(buildVictimUrl("at_fault_age_bracket", filters)),
-      },
-      {
-        queryKey: ["stats", "month", cacheKey],
-        queryFn: () => fetchJson<MonthRow[]>(buildUrl("month", filters)),
-      },
-      {
-        queryKey: ["stats", "day_of_week", cacheKey],
-        queryFn: () => fetchJson<DayOfWeekRow[]>(buildUrl("day_of_week", filters)),
-      },
-      {
-        queryKey: ["stats", "rate", { d: dateKey, co: filters.counties, s: filters.severities }],
-        queryFn: () => fetchJson<RateRow[]>(buildUrl("rate", filters)),
-      },
-    ],
+  const batchUrl = `${API_BASE}/api/stats/batch`;
+
+  const batchBody = useMemo(() => {
+    const b: Record<string, string> = {};
+    if (filters.dateRange?.start) b.start = formatYearMonth(filters.dateRange.start);
+    if (filters.dateRange?.end) b.end = formatYearMonth(filters.dateRange.end);
+    if (filters.severities.length) b.severity = filters.severities.map(severityToSlug).join(",");
+    if (filters.causes.length) b.cause = filters.causes.join(",");
+    if (filters.counties.length) b.county = filters.counties.join(",");
+    return b;
+  }, [filters]);
+
+  const BATCH_GROUPS = [
+    "year", "hour", "cause", "severity",
+    "gender", "age_bracket", "at_fault_gender", "at_fault_age_bracket",
+    "month", "day_of_week", "rate",
+  ];
+
+  type BatchResponse = Record<string, unknown[]>;
+
+  const batchQuery = useQuery({
+    queryKey: ["stats", "batch", cacheKey],
+    queryFn: async (): Promise<BatchResponse> => {
+      const res = await fetch(batchUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ groups: BATCH_GROUPS, ...batchBody }),
+      });
+      if (!res.ok) throw new Error(`stats batch ${res.status}`);
+      return res.json();
+    },
   });
 
-  const [yearQ, hourQ, causeQ, demoQ, severityQ, genderQ, ageQ, atFaultGenderQ, atFaultAgeQ, monthQ, dowQ, rateQ] = queries;
-  const loading = yearQ.isLoading || hourQ.isLoading || causeQ.isLoading;
-  const rawError = yearQ.error ?? hourQ.error ?? causeQ.error;
+  const demoQuery = useQuery({
+    queryKey: ["stats", "demographics", { d: dateKey, co: filters.counties }],
+    queryFn: () => fetchJson<DemoRow[]>(buildDemoUrl(filters)),
+  });
+
+  const loading = batchQuery.isLoading;
+  const rawError = batchQuery.error;
 
   const data = useMemo<StatsData | null>(() => {
-    if (!yearQ.data || !hourQ.data || !causeQ.data) return null;
+    if (!batchQuery.data) return null;
+    const b = batchQuery.data;
 
-    const yearlyData: YearlyDataPoint[] = yearQ.data.map((r) => ({
-      year: r.year,
-      count: r.crash_count,
-      killed: r.total_killed,
-      injured: r.total_injured,
+    const yearlyData: YearlyDataPoint[] = ((b.year ?? []) as YearRow[]).map((r) => ({
+      year: r.year, count: r.crash_count, killed: r.total_killed, injured: r.total_injured,
     }));
-
-    const hourlyData: HourlyDataPoint[] = hourQ.data.map((r) => ({
-      hour: r.hour,
-      count: r.crash_count,
+    const hourlyData: HourlyDataPoint[] = ((b.hour ?? []) as HourRow[]).map((r) => ({
+      hour: r.hour, count: r.crash_count,
     }));
-
-    const causesData: CauseDataPoint[] = causeQ.data.map((r) => ({
-      label: CAUSE_LABEL[r.canonical_cause] ?? r.canonical_cause,
-      count: r.crash_count,
+    const causesData: CauseDataPoint[] = ((b.cause ?? []) as CauseRow[]).map((r) => ({
+      label: CAUSE_LABEL[r.canonical_cause] ?? r.canonical_cause, count: r.crash_count,
     }));
-
-    const severityData: SeverityDataPoint[] = (severityQ.data ?? []).map((r) => ({
-      label: r.severity,
-      count: r.crash_count,
+    const severityData: SeverityDataPoint[] = ((b.severity ?? []) as SeverityRow[]).map((r) => ({
+      label: r.severity, count: r.crash_count,
     }));
-
-    const genderData: GenderDataPoint[] = (genderQ.data ?? [])
+    const genderData: GenderDataPoint[] = ((b.gender ?? []) as GenderRow[])
       .filter((r) => r.gender && r.gender !== "unknown")
-      .map((r) => ({
-        label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1),
-        count: r.victim_count,
-      }));
-
-    const ageBracketData: AgeBracketDataPoint[] = (ageQ.data ?? [])
-      .sort((a, b) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b.age_bracket))
+      .map((r) => ({ label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1), count: r.victim_count }));
+    const ageBracketData: AgeBracketDataPoint[] = ((b.age_bracket ?? []) as AgeBracketRow[])
+      .sort((a, b2) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b2.age_bracket))
       .filter((r) => r.age_bracket !== "unknown")
-      .map((r) => ({
-        label: AGE_LABEL[r.age_bracket] ?? r.age_bracket,
-        count: r.victim_count,
-      }));
-
-    const atFaultGenderData: AtFaultGenderDataPoint[] = (atFaultGenderQ.data ?? [])
+      .map((r) => ({ label: AGE_LABEL[r.age_bracket] ?? r.age_bracket, count: r.victim_count }));
+    const atFaultGenderData: AtFaultGenderDataPoint[] = ((b.at_fault_gender ?? []) as AtFaultGenderRow[])
       .filter((r) => r.gender && r.gender !== "unknown")
-      .map((r) => ({
-        label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1),
-        count: r.party_count,
-      }));
-
-    const atFaultAgeBracketData: AtFaultAgeBracketDataPoint[] = (atFaultAgeQ.data ?? [])
-      .sort((a, b) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b.age_bracket))
+      .map((r) => ({ label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1), count: r.party_count }));
+    const atFaultAgeBracketData: AtFaultAgeBracketDataPoint[] = ((b.at_fault_age_bracket ?? []) as AtFaultAgeBracketRow[])
+      .sort((a, b2) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b2.age_bracket))
       .filter((r) => r.age_bracket !== "unknown")
-      .map((r) => ({
-        label: AGE_LABEL[r.age_bracket] ?? r.age_bracket,
-        count: r.party_count,
-      }));
-
-    const monthlyData: MonthlyDataPoint[] = (monthQ.data ?? []).map((r) => ({
-      month: r.month,
-      label: MONTH_LABEL[r.month - 1] ?? String(r.month),
-      count: r.crash_count,
-      killed: r.total_killed,
-      injured: r.total_injured,
+      .map((r) => ({ label: AGE_LABEL[r.age_bracket] ?? r.age_bracket, count: r.party_count }));
+    const monthlyData: MonthlyDataPoint[] = ((b.month ?? []) as MonthRow[]).map((r) => ({
+      month: r.month, label: MONTH_LABEL[r.month - 1] ?? String(r.month),
+      count: r.crash_count, killed: r.total_killed, injured: r.total_injured,
+    }));
+    const dayOfWeekData: DayOfWeekDataPoint[] = ((b.day_of_week ?? []) as DayOfWeekRow[]).map((r) => ({
+      day: r.day_of_week, label: DOW_LABEL[r.day_of_week] ?? String(r.day_of_week), count: r.crash_count,
+    }));
+    const rateData: RateDataPoint[] = ((b.rate ?? []) as RateRow[]).map((r) => ({
+      county_code: r.county_code, county_name: r.county_name ?? "Unknown", year: r.year,
+      severity: r.severity, total_crashes: r.total_crashes, total_killed: r.total_killed,
+      total_injured: r.total_injured, per_100k_population: r.per_100k_population,
+      per_10k_licensed_drivers: r.per_10k_licensed_drivers, per_100_road_miles: r.per_100_road_miles,
+      per_100k_aadt: r.per_100k_aadt, per_10k_vehicles: r.per_10k_vehicles,
     }));
 
-    const dayOfWeekData: DayOfWeekDataPoint[] = (dowQ.data ?? []).map((r) => ({
-      day: r.day_of_week,
-      label: DOW_LABEL[r.day_of_week] ?? String(r.day_of_week),
-      count: r.crash_count,
-    }));
-
-    const rateData: RateDataPoint[] = (rateQ.data ?? []).map((r) => ({
-      county_code: r.county_code,
-      county_name: r.county_name ?? "Unknown",
-      year: r.year,
-      severity: r.severity,
-      total_crashes: r.total_crashes,
-      total_killed: r.total_killed,
-      total_injured: r.total_injured,
-      per_100k_population: r.per_100k_population,
-      per_10k_licensed_drivers: r.per_10k_licensed_drivers,
-      per_100_road_miles: r.per_100_road_miles,
-      per_100k_aadt: r.per_100k_aadt,
-      per_10k_vehicles: r.per_10k_vehicles,
-    }));
-
-    const population = demoQ.data
-      ? demoQ.data.reduce((s, r) => s + (r.population ?? 0), 0)
+    const population = demoQuery.data
+      ? demoQuery.data.reduce((s, r) => s + (r.population ?? 0), 0)
       : null;
-    const heroMetrics = computeHeroMetrics(yearQ.data, population);
+    const heroMetrics = computeHeroMetrics((b.year ?? []) as YearRow[], population);
 
     return { hourlyData, yearlyData, causesData, severityData, genderData, ageBracketData, atFaultGenderData, atFaultAgeBracketData, monthlyData, dayOfWeekData, rateData, heroMetrics };
-  }, [yearQ.data, hourQ.data, causeQ.data, demoQ.data, severityQ.data, genderQ.data, ageQ.data, atFaultGenderQ.data, atFaultAgeQ.data, monthQ.data, dowQ.data, rateQ.data]);
+  }, [batchQuery.data, demoQuery.data]);
 
   return {
     data,
     loading,
     error: rawError ? String(rawError) : null,
-    refetch: () => queries.forEach((q) => q.refetch()),
+    refetch: () => { batchQuery.refetch(); demoQuery.refetch(); },
   };
 }


### PR DESCRIPTION
## Summary

Replace 12 parallel API calls on the Stats page with a single `POST /api/stats/batch` request + 1 demographics GET.

- Extract `_run_group_query()` helper from 600-line `stats()` function
- Add `POST /api/stats/batch` endpoint with `BatchStatsRequest` schema
- Update frontend `useStats` hook from 12 `useQueries` to single `useQuery` POST
- Demographics stays as separate GET (different table)

## Expected impact

- Stats page: 12 HTTP requests → 2 (1 batch + 1 demographics)
- Faster page load on high-latency connections (1 round trip vs 12)

## Closes

- Partially closes #213

## Test plan

- [ ] Stats page loads all charts with data
- [ ] Filter changes trigger single batch POST
- [ ] Backend and frontend tests pass
- [ ] Verified in Playwright