### PR TITLE
fix: resolve broken Leaflet marker icon on prod

### DIFF
--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1,7 +1,17 @@
 import { useEffect, useLayoutEffect } from "react";
 import { MapContainer, TileLayer, Marker, useMap } from "react-leaflet";
+import L from "leaflet";
 import type { LatLngBoundsExpression, Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
+import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+
+L.Icon.Default.mergeOptions({
+  iconUrl: markerIcon,
+  iconRetinaUrl: markerIcon2x,
+  shadowUrl: markerShadow,
+});
 import CountyBoundaries from "./CountyBoundaries";
 import CrashHeatmap from "./CrashHeatmap";
 import CoordMismatchLayer from "./CoordMismatchLayer";


### PR DESCRIPTION
## Summary
- Fixes the blank/broken location pin when using the geolocation button on prod
- Leaflet's default marker icon PNGs aren't bundled by Vite — explicitly imports them and configures `L.Icon.Default`

## Test plan
- [ ] Click geolocation button on mobile/desktop — pin should render as blue Leaflet marker