### PR TITLE
fix: add Icon.Default to leaflet test mock

### DIFF
--- a/frontend/src/__mocks__/leaflet.ts
+++ b/frontend/src/__mocks__/leaflet.ts
@@ -93,6 +93,7 @@ const L = {
   geoJSON: vi.fn(() => geoJSONLayerMock),
   tooltip: vi.fn(() => tooltipMock),
   latLngBounds: vi.fn(() => createBoundsMock()),
+  Icon: { Default: { mergeOptions: vi.fn() } },
   DomUtil: { create: vi.fn(), remove: vi.fn() },
   DomEvent: { disableClickPropagation: vi.fn(), disableScrollPropagation: vi.fn() },
 };


### PR DESCRIPTION
 ## What
  Restores a green test suite on main. PR #244 added a top-level
  L.Icon.Default.mergeOptions() call to MapCanvas.tsx but didn't add
  Icon to the leaflet test mock, so MapCanvas.test.tsx fails to load.

  ## Dependencies
  None. Follow-up to #244.

  ## How to test
  - npm test  (was: 1 file failed / 169 passed; now: 20 passed / 172 passed)

  ## Checklist
  - [x] npm test passes (172/172)
  - [x] tsc + lint clean
