### PR TITLE
fix(#251): Data Bugs — MEGA 5

### DIFF
--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -242,7 +242,10 @@ def parse_weather(raw: str | None) -> list[str] | None:
         return None
     valid = {"clear", "cloudy", "rain", "fog", "snow", "wind", "other"}
     values = [v.strip() for v in raw.split(",")]
-    return [v for v in values if v in valid] or None
+    bad = [v for v in values if v not in valid]
+    if bad:
+        raise FilterError("weather", f"Unknown weather '{bad[0]}'. Allowed: {', '.join(sorted(valid))}.")
+    return values or None
 
 
 def parse_lighting(raw: str | None) -> list[str] | None:
@@ -250,7 +253,10 @@ def parse_lighting(raw: str | None) -> list[str] | None:
         return None
     valid = {"daylight", "dark_lit", "dark_unlit", "dusk_dawn", "other"}
     values = [v.strip() for v in raw.split(",")]
-    return [v for v in values if v in valid] or None
+    bad = [v for v in values if v not in valid]
+    if bad:
+        raise FilterError("lighting", f"Unknown lighting '{bad[0]}'. Allowed: {', '.join(sorted(valid))}.")
+    return values or None
 
 
 def parse_collision_type(raw: str | None) -> list[str] | None:
@@ -258,7 +264,10 @@ def parse_collision_type(raw: str | None) -> list[str] | None:
         return None
     valid = {"rear_end", "broadside", "sideswipe", "hit_object", "head_on", "other"}
     values = [v.strip() for v in raw.split(",")]
-    return [v for v in values if v in valid] or None
+    bad = [v for v in values if v not in valid]
+    if bad:
+        raise FilterError("collision_type", f"Unknown collision_type '{bad[0]}'. Allowed: {', '.join(sorted(valid))}.")
+    return values or None
 
 
 def parse_road_type(raw: str | None) -> bool | None:
@@ -268,7 +277,7 @@ def parse_road_type(raw: str | None) -> bool | None:
         return True
     if raw == "local":
         return False
-    return None
+    raise FilterError("road_type", "road_type must be 'highway' or 'local'.")
 
 
 def parse_hit_run(raw: str | None) -> bool | None:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -173,9 +173,6 @@ class Crash(Base):
     crash_month = Column(SmallInteger)
     day_of_week_num = Column(SmallInteger)
 
-    crash_month = Column(SmallInteger)
-    day_of_week_num = Column(SmallInteger)
-
     created_at = Column(DateTime, server_default=func.now())
 
     __table_args__ = (

--- a/backend/app/routers/heatmap.py
+++ b/backend/app/routers/heatmap.py
@@ -91,7 +91,7 @@ def crash_heatmap(
     """Crash locations for heatmap rendering.
 
     Resolution controls output:
-      - raw — individual crash lat/lng (county required, limit 10K)
+      - raw — individual crash lat/lng (county required, limit 150K per batch)
       - low  (0.1 deg, ~7 mi)  — grid-aggregated
       - medium (0.01 deg, ~0.7 mi) — grid-aggregated
       - high (0.001 deg, ~350 ft) — grid-aggregated

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -888,7 +888,7 @@ def stats(
 ALLOWED_GROUPS = {
     "year", "hour", "cause", "severity", "month", "day_of_week",
     "gender", "age_bracket", "at_fault_gender", "at_fault_age_bracket",
-    "rate", "county",
+    "rate", "county", "weather", "lighting", "collision_type",
 }
 
 _limiter = Limiter(key_func=get_remote_address)

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -175,7 +175,7 @@ def build_default_registry() -> JobRegistry:
     registry.register(Job(
         name="matviews",
         module="etl.refresh_materialized_views",
-        depends_on=["backfill", "data_quality"],
+        depends_on=["backfill", "data_quality", "demographics", "licensed_drivers", "vehicles", "road_miles", "aadt"],
         schedule="daily",
     ))
     registry.register(Job(

--- a/frontend/src/context/LiteModeContext.tsx
+++ b/frontend/src/context/LiteModeContext.tsx
@@ -16,7 +16,7 @@ function detectSlowDevice(): boolean {
   if (typeof navigator === "undefined") return false;
   const conn = (navigator as unknown as { connection?: { effectiveType?: string; saveData?: boolean } }).connection;
   if (conn?.saveData) return true;
-  if (conn?.effectiveType === "2g" || conn?.effectiveType === "slow-2g") return true;
+  if (conn?.effectiveType === "2g" || conn?.effectiveType === "slow-2g" || conn?.effectiveType === "3g") return true;
   if (typeof navigator.hardwareConcurrency === "number" && navigator.hardwareConcurrency <= 2) return true;
   const mem = (navigator as unknown as { deviceMemory?: number }).deviceMemory;
   if (typeof mem === "number" && mem <= 2) return true;

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -116,7 +116,7 @@ export function useAskAi() {
         lastWas429 = false;
 
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 45_000);
+        const timeout = setTimeout(() => controller.abort(), 55_000);
         const resp = await fetch(API_URL, {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/frontend/src/hooks/useNominatim.ts
+++ b/frontend/src/hooks/useNominatim.ts
@@ -16,7 +16,7 @@ export interface NominatimResult {
 }
 
 const CA_VIEWBOX = "-124.5,42.0,-114.1,32.5";
-const DEBOUNCE_MS = 350;
+const DEBOUNCE_MS = 1000;
 
 export function useNominatim(query: string, enabled: boolean) {
   const [results, setResults] = useState<NominatimResult[]>([]);

--- a/frontend/src/lib/choropleth/measures.ts
+++ b/frontend/src/lib/choropleth/measures.ts
@@ -250,6 +250,7 @@ export function computeMeasureValue(
     if (vals.length === 0) return { value: null, hasEnoughData: false };
     const avgPoverty = vals.reduce((s, d) => s + d.poverty_rate!, 0) / vals.length;
     const avgPop = vals.reduce((s, d) => s + d.population!, 0) / vals.length;
+    if (avgPoverty <= 0 || avgPop <= 0) return { value: null, hasEnoughData: false };
     return { value: (stats.crash_count / avgPoverty / avgPop) * 100_000, hasEnoughData: true };
   }
 

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -90,8 +90,8 @@ export default function StatsPage() {
       };
 
   const severityColorMap: Record<string, string> = isDark
-    ? { "Fatal": "#d4606b", "Injury": "#b0a050", "Property Damage Only": "#6b8fa3" }
-    : { "Fatal": "#991b1b", "Injury": "#6d7e1e", "Property Damage Only": "#4a7a8c" };
+    ? { "Fatal": "#ef4444", "Injury": "#fbbf24", "Property Damage Only": "#9ca3af" }
+    : { "Fatal": "#dc2626", "Injury": "#f59e0b", "Property Damage Only": "#6b7280" };
 
   const causeColor = (label: string) => causeColorMap[label] ?? clrOnSurfaceVariant;
   const severityColor = (label: string) => severityColorMap[label] ?? clrOnSurfaceVariant;


### PR DESCRIPTION
## Summary
Data integrity and quality fixes from MEGA 5 (#251). 10 fixes across 10 files.

### Changes
- **Duplicate columns removed**: `crash_month` and `day_of_week_num` defined twice in Crash model
- **Batch endpoint expanded**: Added `weather`, `lighting`, `collision_type` to ALLOWED_GROUPS
- **Filter validation**: `parse_weather/lighting/collision_type/road_type` now raise FilterError on invalid values
- **Heatmap docstring**: Corrected limit from 10K to 150K per batch
- **Matviews dependencies**: Added demographics, licensed_drivers, vehicles, road_miles, aadt
- **Timeout alignment**: Frontend Ask AI timeout 45s → 55s (backend is 60s)
- **Severity colors**: Standardized StatsPage to match CrashDotLayer/ChoroplethLegend (#dc2626/#f59e0b/#6b7280)
- **Division guard**: crashes_per_poverty now guards avgPoverty/avgPop <= 0
- **Nominatim throttle**: Debounce 350ms → 1000ms (OSM 1req/s policy)
- **3G detection**: Lite mode now detects 3G connections (was only 2g/slow-2g)

## Test plan
- [x] Backend tests pass (364/364)
- [x] Frontend tests pass (172/172)