### PR TITLE
feat(#250): Accessibility — MEGA 4

### DIFF
--- a/frontend/src/components/BottomTabBar.tsx
+++ b/frontend/src/components/BottomTabBar.tsx
@@ -14,7 +14,7 @@ export default function BottomTabBar() {
   const qs = buildFilterQS(searchParams);
 
   return (
-    <nav aria-label="Main navigation" className="fixed bottom-0 left-0 right-0 z-50 md:hidden bg-surface-container-lowest bottom-tab-shadow" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
+    <nav aria-label="Main navigation" className="fixed bottom-0 left-0 right-0 z-50 lg:hidden bg-surface-container-lowest bottom-tab-shadow" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}>
       <div className="flex items-center justify-around h-14">
         {tabs.map((tab) => (
           <NavLink

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import NavBar from "./NavBar";
 import Footer from "./Footer";
 import BottomTabBar from "./BottomTabBar";
 import { OfflineIndicator } from "./ui/OfflineIndicator";
+import { ErrorBoundary } from "./ui/ErrorBoundary";
 
 const PAGE_TITLES: Record<string, string> = {
   "/": "Map Explorer — CalSight",
@@ -45,6 +46,7 @@ export default function Layout() {
       </a>
       <NavBar />
       <OfflineIndicator />
+      <ErrorBoundary>
       {isMapPage ? (
         <main id="main-content" className="pt-12 pb-14 md:pt-16 md:pb-0 flex h-dvh overflow-hidden">
           <Outlet />
@@ -63,6 +65,7 @@ export default function Layout() {
           <Footer />
         </div>
       )}
+      </ErrorBoundary>
       <BottomTabBar />
     </>
   );

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -31,7 +31,7 @@ export default function NavBar() {
             Beta
           </span>
         </NavLink>
-        <nav aria-label="Main navigation" className="hidden md:flex gap-6 items-center">
+        <nav aria-label="Main navigation" className="hidden lg:flex gap-6 items-center">
           {navLinks.map((link) => (
             <NavLink
               key={link.to}

--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -50,9 +50,12 @@ export default function SettingsPopover({ onClose, containerRef }: SettingsPopov
 
     document.addEventListener("mousedown", handleClickOutside);
     document.addEventListener("keydown", handleEscape);
+    const isMobileSheet = window.innerWidth < 768;
+    if (isMobileSheet) document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEscape);
+      if (isMobileSheet) document.body.style.overflow = "";
     };
   }, [onClose]);
 

--- a/frontend/src/components/charts/ChartTooltip.tsx
+++ b/frontend/src/components/charts/ChartTooltip.tsx
@@ -29,6 +29,7 @@ export default function ChartTooltip({ x, y, visible, children, containerRef }: 
   return (
     <div
       ref={tipRef}
+      role="tooltip"
       className="fixed z-50 pointer-events-none bg-surface-container-lowest border border-outline-variant/15 rounded px-3 py-2 text-xs ambient-shadow"
       style={{ left: pos.left, top: pos.top }}
     >

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -187,7 +187,7 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
           </div>
           <div className="flex items-center gap-1.5">
             <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: "#6b7280" }} />
-            <span className="text-[10px] text-on-surface-variant font-semibold">PDO</span>
+            <span className="text-[10px] text-on-surface-variant font-semibold" title="Property Damage Only">PDO</span>
           </div>
           {mismatchCount != null && mismatchCount > 0 && (
             <div className="flex items-center gap-1.5">

--- a/frontend/src/components/map/MobileFilterSheet.tsx
+++ b/frontend/src/components/map/MobileFilterSheet.tsx
@@ -39,6 +39,14 @@ export default function MobileFilterSheet({
     if (isOpen) setActiveTab("filters");
   }, [isOpen]);
 
+  // Lock body scroll when sheet is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+      return () => { document.body.style.overflow = ""; };
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const currentTab = tabs.find((t) => t.key === activeTab) ?? tabs[0];

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div role="alert" className="flex flex-col items-center justify-center p-8 text-center min-h-[200px]">
+          <span className="material-symbols-outlined text-[32px] text-error mb-2" aria-hidden="true">error</span>
+          <p className="text-on-surface font-semibold">Something went wrong</p>
+          <button
+            type="button"
+            onClick={() => this.setState({ hasError: false })}
+            className="mt-3 px-4 py-2 bg-primary text-on-primary rounded-full text-sm font-semibold hover:opacity-90 transition-opacity"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/ui/SearchableMultiSelect.tsx
+++ b/frontend/src/components/ui/SearchableMultiSelect.tsx
@@ -89,7 +89,7 @@ export default function SearchableMultiSelect({
           onFocus={() => setIsOpen(true)}
           placeholder={placeholder}
           aria-label={placeholder}
-          className="w-full bg-surface-container-high border-none rounded-lg py-3 pl-10 pr-4 text-sm text-on-surface placeholder:text-outline focus:ring-2 focus:ring-primary/20"
+          className="w-full bg-surface-container-high border-none rounded-lg py-3 pl-10 pr-4 text-base md:text-sm text-on-surface placeholder:text-outline focus:ring-2 focus:ring-primary/20"
         />
       </div>
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -265,8 +265,7 @@
 .reduce-motion *,
 .reduce-motion *::before,
 .reduce-motion *::after {
-  animation-duration: 0.01ms !important;
-  animation-iteration-count: 1 !important;
+  animation: none !important;
   transition-duration: 0.01ms !important;
   scroll-behavior: auto !important;
 }

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -230,7 +230,7 @@ export default function AskAiPage() {
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); handleSend(); } }}
-            className="w-full bg-transparent border-none resize-none overflow-hidden px-2 md:px-3 py-2 md:py-2.5 text-on-surface placeholder:text-outline font-body text-sm"
+            className="w-full bg-transparent border-none resize-none overflow-hidden px-2 md:px-3 py-2 md:py-2.5 text-on-surface placeholder:text-outline font-body text-base md:text-sm"
             placeholder="Ask about crash data..."
             aria-label="Ask a question about California crash data"
             disabled={isLoading}


### PR DESCRIPTION
## Summary
Accessibility fixes from MEGA 4 (#250). 11 files, 7 fixes.

### Changes
- **Error boundary**: New ErrorBoundary component wrapping all page content — crashes show retry button instead of blank page
- **iOS auto-zoom**: AskAiPage textarea + SearchableMultiSelect input use text-base on mobile (16px prevents zoom)
- **Body scroll lock**: MobileFilterSheet and SettingsPopover set overflow:hidden when open
- **Reduce motion**: Changed from animation-duration hack to `animation: none !important` (actually stops Tailwind animations)
- **Landscape mode**: BottomTabBar/NavBar breakpoint changed md→lg (768→1024px) so tab bar stays on iPhone landscape (926px)
- **Chart tooltip**: Added role="tooltip" for screen readers
- **PDO label**: Added title="Property Damage Only" tooltip on hover

## Test plan
- [x] Frontend tests pass (172/172)
- [ ] iOS Safari: tap search/textarea inputs — no auto-zoom
- [ ] Landscape iPhone: bottom tab bar visible
- [ ] Open mobile filter sheet — page behind doesn't scroll