### PR TITLE
fix(#252): Dark Mode — MEGA 6

### DIFF
--- a/frontend/src/components/ask/InlineChart.tsx
+++ b/frontend/src/components/ask/InlineChart.tsx
@@ -3,7 +3,13 @@ import SimpleLineChart from "../charts/SimpleLineChart";
 import SimpleDonutChart from "../charts/SimpleDonutChart";
 import type { ChartData } from "../../hooks/useAskAi";
 
-const COLORS = ["#6b8fa3", "#c25560", "#b0a050", "#7ba088", "#b89a6b", "#8e7cc3", "#5a9eaf", "#d4845a"];
+const COLORS_LIGHT = ["#4a7a8c", "#994444", "#6b6b2e", "#3d7a5c", "#8a6d3b", "#5b4fa0", "#2d7d8a", "#b45309"];
+const COLORS_DARK = ["#6b8fa3", "#c28a8a", "#b0a050", "#7ba088", "#b89a6b", "#8e7cc3", "#6baab5", "#c27862"];
+
+function useColors() {
+  const isDark = document.documentElement.classList.contains("dark");
+  return isDark ? COLORS_DARK : COLORS_LIGHT;
+}
 
 interface Props {
   chart: ChartData;
@@ -20,6 +26,7 @@ function Tip({ label, value }: { label: string; value: number }) {
 
 export default function InlineChart({ chart }: Props) {
   const { type, title, data } = chart;
+  const colors = useColors();
 
   if (!data || data.length === 0) return null;
 
@@ -38,7 +45,7 @@ export default function InlineChart({ chart }: Props) {
           />
         ) : type === "pie" ? (
           <SimpleDonutChart
-            data={data.map((d, i) => ({ label: d.label, value: d.value, color: COLORS[i % COLORS.length] }))}
+            data={data.map((d, i) => ({ label: d.label, value: d.value, color: colors[i % colors.length] }))}
             height={180}
             outerRadius={80}
             innerRadius={0}
@@ -48,7 +55,7 @@ export default function InlineChart({ chart }: Props) {
           <SimpleBarChart
             data={data.map((d) => ({ label: d.label, value: d.value }))}
             height={180}
-            defaultColor="#6b8fa3"
+            defaultColor={colors[0]}
             radius={4}
             renderTooltip={(item) => <Tip label={item.label} value={item.value} />}
           />

--- a/frontend/src/components/charts/SimpleLineChart.tsx
+++ b/frontend/src/components/charts/SimpleLineChart.tsx
@@ -85,7 +85,7 @@ export default function SimpleLineChart({
               {points.map((p, i) => (
                 <g key={i}>
                   {showDots && (
-                    <circle cx={p.x} cy={p.y} r={3} fill={color} stroke="white" strokeWidth={1.5} />
+                    <circle cx={p.x} cy={p.y} r={3} fill={color} stroke="rgb(var(--surface))" strokeWidth={1.5} />
                   )}
                   <rect
                     x={p.x - chartW / n / 2}

--- a/frontend/src/components/map/CrashDotLayer.tsx
+++ b/frontend/src/components/map/CrashDotLayer.tsx
@@ -106,35 +106,35 @@ export default memo(function CrashDotLayer({ points, enabled }: CrashDotLayerPro
                   <span style={{ width: 10, height: 10, borderRadius: "50%", backgroundColor: getColor(p.severity), display: "inline-block", border: `2px solid ${borderColor}`, flexShrink: 0 }} />
                   <strong style={{ fontSize: 14 }}>{p.severity ?? "Unknown"}</strong>
                   {p.hit_run && (
-                    <span style={{ fontSize: 10, fontWeight: 700, background: "#fde8e8", color: "#b91c1c", padding: "2px 8px", borderRadius: 10 }}>
+                    <span style={{ fontSize: 10, fontWeight: 700, background: "rgb(var(--error-container))", color: "rgb(var(--on-error-container))", padding: "2px 8px", borderRadius: 10 }}>
                       HIT & RUN
                     </span>
                   )}
                 </div>
 
-                <div style={{ color: "#6b7280", marginBottom: 8, fontSize: 12 }}>{formatDate(p.crash_datetime)}</div>
+                <div style={{ color: "rgb(var(--on-surface-variant))", marginBottom: 8, fontSize: 12 }}>{formatDate(p.crash_datetime)}</div>
 
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
                   <tbody>
                     {p.primary_road && (
                       <tr>
-                        <td style={{ color: "#6b7280", paddingRight: 12, paddingBottom: 4, whiteSpace: "nowrap", verticalAlign: "top" }}>Road</td>
+                        <td style={{ color: "rgb(var(--on-surface-variant))", paddingRight: 12, paddingBottom: 4, whiteSpace: "nowrap", verticalAlign: "top" }}>Road</td>
                         <td style={{ paddingBottom: 4 }}>{p.primary_road}</td>
                       </tr>
                     )}
                     <tr>
-                      <td style={{ color: "#6b7280", paddingRight: 12, paddingBottom: 4, whiteSpace: "nowrap" }}>Cause</td>
+                      <td style={{ color: "rgb(var(--on-surface-variant))", paddingRight: 12, paddingBottom: 4, whiteSpace: "nowrap" }}>Cause</td>
                       <td style={{ paddingBottom: 4 }}>{formatCause(p.canonical_cause)}</td>
                     </tr>
                     {p.weather && (
                       <tr>
-                        <td style={{ color: "#6b7280", paddingRight: 12, paddingBottom: 4 }}>Weather</td>
+                        <td style={{ color: "rgb(var(--on-surface-variant))", paddingRight: 12, paddingBottom: 4 }}>Weather</td>
                         <td style={{ paddingBottom: 4 }}>{p.weather}</td>
                       </tr>
                     )}
                     {p.lighting && (
                       <tr>
-                        <td style={{ color: "#6b7280", paddingRight: 12, paddingBottom: 4 }}>Lighting</td>
+                        <td style={{ color: "rgb(var(--on-surface-variant))", paddingRight: 12, paddingBottom: 4 }}>Lighting</td>
                         <td style={{ paddingBottom: 4 }}>{p.lighting}</td>
                       </tr>
                     )}
@@ -142,14 +142,14 @@ export default memo(function CrashDotLayer({ points, enabled }: CrashDotLayerPro
                 </table>
 
                 {(p.number_killed || p.number_injured) ? (
-                  <div style={{ display: "flex", gap: 16, marginTop: 8, paddingTop: 8, borderTop: "1px solid #e5e7eb" }}>
+                  <div style={{ display: "flex", gap: 16, marginTop: 8, paddingTop: 8, borderTop: "1px solid rgb(var(--outline-variant))" }}>
                     {p.number_killed ? <span style={{ color: DOT_COLORS.fatal, fontWeight: 700, fontSize: 12 }}>{p.number_killed} killed</span> : null}
-                    {p.number_injured ? <span style={{ color: "#92600a", fontWeight: 700, fontSize: 12 }}>{p.number_injured} injured</span> : null}
+                    {p.number_injured ? <span style={{ color: "rgb(var(--tertiary))", fontWeight: 700, fontSize: 12 }}>{p.number_injured} injured</span> : null}
                   </div>
                 ) : null}
 
                 {p.collision_id && (
-                  <div style={{ fontSize: 10, color: "#6b7280", marginTop: 8 }}>
+                  <div style={{ fontSize: 10, color: "rgb(var(--on-surface-variant))", marginTop: 8 }}>
                     Collision #{p.collision_id} · {p.data_source?.toUpperCase()}
                   </div>
                 )}

--- a/frontend/src/components/map/UnifiedSearchBar.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.tsx
@@ -341,7 +341,7 @@ export default function UnifiedSearchBar({
       </div>
 
       {/* ── Desktop: bottom controls (location + zoom) ── */}
-      <div className="hidden md:flex absolute bottom-6 right-4 z-[35] flex-col items-center gap-1 p-1 bg-white dark:bg-neutral-800 rounded-full shadow-lg">
+      <div className="hidden md:flex absolute bottom-6 right-4 z-[35] flex-col items-center gap-1 p-1 bg-surface-container-lowest rounded-full shadow-lg">
         <button
           onClick={onGeolocate}
           disabled={locating}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -220,14 +220,14 @@
 }
 
 .county-focus-tooltip {
-  background: rgba(0, 0, 0, 0.8);
+  background: rgb(var(--surface-container-low));
   border: none;
   border-radius: 4px;
-  color: white;
+  color: rgb(var(--on-surface));
   font-size: 12px;
   font-weight: 600;
   padding: 4px 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px rgba(var(--shadow-rgb), 0.3);
 }
 
 .county-focus-tooltip::before {


### PR DESCRIPTION
## Summary
Dark mode theme consistency fixes from MEGA 6 (#252). 5 components fixed.

### Changes
- **SimpleLineChart**: `stroke="white"` → `rgb(var(--surface))` (invisible in dark mode)
- **Leaflet tooltip**: Hardcoded `rgba(0,0,0,0.8)` → theme CSS variables
- **UnifiedSearchBar**: Desktop controls `bg-white dark:bg-neutral-800` → `bg-surface-container-lowest`
- **CrashDotLayer popup**: 7 hardcoded hex colors → CSS variable references (hit-run badge, date, labels, border, injured count, collision ID)
- **InlineChart**: Static 8-color palette → separate light/dark arrays matching StatsPage cause colors

## Test plan
- [x] Frontend tests pass (172/172)
- [ ] Toggle dark mode — all map popups, charts, and controls should adapt