### PR TITLE
fix: CSP blocking icon font and inline scripts

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -8,5 +8,5 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.basemaps.cartocdn.com; connect-src 'self' https://api.calsight.org https://nominatim.openstreetmap.org https://*.basemaps.cartocdn.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.basemaps.cartocdn.com; connect-src 'self' https://api.calsight.org https://nominatim.openstreetmap.org https://*.basemaps.cartocdn.com https://fonts.googleapis.com https://fonts.gstatic.com; worker-src 'self'
   Permissions-Policy: camera=(), microphone=(), geolocation=(self)


### PR DESCRIPTION
## Summary
- Added `https://fonts.googleapis.com` and `https://fonts.gstatic.com` to CSP `connect-src` — the service worker fetches the font stylesheet via `fetch()` which is governed by `connect-src`, not `style-src`
- Added `'unsafe-inline'` to `script-src` — the theme detection and speculation rules scripts in `index.html` are inline

Without this fix, icons render as plain text ("filter_list", "search", etc.) and dark mode flash occurs on load.

## Root cause
The CSP added in PR #257 (MEGA 1 Security) only allowed fonts in `style-src` and `font-src`, but the PWA service worker (PR #245) intercepts font requests via `fetch()`, which requires `connect-src` permission.

Closes #247