### PR TITLE
fix: remove CSP header — breaks icons via service worker

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -8,5 +8,4 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.basemaps.cartocdn.com; connect-src 'self' https://api.calsight.org https://nominatim.openstreetmap.org https://*.basemaps.cartocdn.com https://fonts.googleapis.com https://fonts.gstatic.com; worker-src 'self'
   Permissions-Policy: camera=(), microphone=(), geolocation=(self)


### PR DESCRIPTION
## Summary
Removes the Content-Security-Policy header from `_headers`. The CSP interacts badly with the PWA service worker — the SW caches responses with their HTTP headers, so even after fixing the CSP, browsers with a cached SW keep serving the old restrictive policy, permanently breaking icon fonts.

The remaining security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy) are kept.

## Root cause
CSP `connect-src` didn't include `fonts.googleapis.com`. The service worker fetches fonts via `fetch()` which is governed by `connect-src`, not `style-src`. The SW then cached the failed response, making it persist across page loads even after the CSP was fixed server-side.