### PR TITLE
feat(#275): complete bidirectional Map ↔ Stats deep linking

### DIFF
--- a/frontend/src/components/map/AiInsightCard.test.tsx
+++ b/frontend/src/components/map/AiInsightCard.test.tsx
@@ -136,4 +136,47 @@ describe("AiInsightCard", () => {
     await expandCard();
     expect(screen.getByText("N/A")).toBeInTheDocument();
   });
+
+  it("View Stats link drills into the county and carries active filters", async () => {
+    render(
+      <MemoryRouter initialEntries={["/?severity=fatal&start=2020-01&alcohol=true"]}>
+        <AiInsightCard
+          onClose={vi.fn()}
+          countyName="Los Angeles"
+          data={POINT_A}
+          measureLabel="Per 100k"
+          compareMode={false}
+          onCompare={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+    await expandCard();
+    const link = screen.getByRole("link", { name: /view stats/i });
+    const url = new URL(link.getAttribute("href")!, "http://localhost");
+    expect(url.pathname).toBe("/stats");
+    // drill_county (not the plain county filter) so Stats opens the drill
+    // breadcrumb — which surfaces the "Show on Map" round-trip link.
+    expect(url.searchParams.get("drill_county")).toBe("los-angeles");
+    expect(url.searchParams.get("county")).toBeNull();
+    // Active filters carry over.
+    expect(url.searchParams.get("severity")).toBe("fatal");
+    expect(url.searchParams.get("start")).toBe("2020-01");
+    expect(url.searchParams.get("alcohol")).toBe("true");
+  });
+
+  it("hides View Stats link in compare mode", () => {
+    render(
+      <MemoryRouter><AiInsightCard
+        onClose={vi.fn()}
+        countyName="Los Angeles"
+        data={POINT_A}
+        measureLabel="Per 100k"
+        compareMode={true}
+        onCompare={vi.fn()}
+        compareCountyName="Orange"
+        compareData={POINT_B}
+      /></MemoryRouter>,
+    );
+    expect(screen.queryByRole("link", { name: /view stats/i })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -305,11 +305,15 @@ export default function AiInsightCard({
                 {!compareMode && data && (() => {
                   const filterQs = buildFilterQS(searchParams);
                   const extra = new URLSearchParams(filterQs);
-                  extra.delete("county"); // county set explicitly below
+                  extra.delete("county"); // drill_county (below) carries the county
                   const tail = extra.toString();
+                  // Navigate via drill_county, not the county filter param, so
+                  // Stats opens drilled into this county — that surfaces the
+                  // breadcrumb's "Show on Map" link for the round trip back.
+                  const countySlug = countyName.toLowerCase().replace(/ /g, "-");
                   return (
                     <Link
-                      to={`/stats?county=${countyName.toLowerCase().replace(/ /g, "-")}${tail ? `&${tail}` : ""}`}
+                      to={`/stats?drill_county=${countySlug}${tail ? `&${tail}` : ""}`}
                       className="w-full bg-surface-container text-on-surface py-2 rounded-lg text-[11px] font-bold tracking-widest uppercase hover:opacity-90 transition-opacity flex items-center justify-center gap-1"
                     >
                       <span className="material-symbols-outlined text-sm">bar_chart</span>

--- a/frontend/src/components/stats/DrillBreadcrumb.test.tsx
+++ b/frontend/src/components/stats/DrillBreadcrumb.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import DrillBreadcrumb from "./DrillBreadcrumb";
+
+describe("DrillBreadcrumb", () => {
+  it("renders nothing at the state level", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DrillBreadcrumb
+          drillState={{ level: "state", county: null }}
+          onDrillUp={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the drilled county name", () => {
+    render(
+      <MemoryRouter>
+        <DrillBreadcrumb
+          drillState={{ level: "county", county: "Fresno" }}
+          onDrillUp={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Fresno County")).toBeInTheDocument();
+  });
+
+  it("calls onDrillUp when California is clicked", async () => {
+    const onDrillUp = vi.fn();
+    render(
+      <MemoryRouter>
+        <DrillBreadcrumb
+          drillState={{ level: "county", county: "Fresno" }}
+          onDrillUp={onDrillUp}
+        />
+      </MemoryRouter>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "California" }));
+    expect(onDrillUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("Show on Map link targets the county and carries active filters", () => {
+    render(
+      <MemoryRouter initialEntries={["/stats?drill_county=fresno&severity=fatal&cause=dui"]}>
+        <DrillBreadcrumb
+          drillState={{ level: "county", county: "Fresno" }}
+          onDrillUp={vi.fn()}
+        />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: /show fresno county on map/i });
+    const url = new URL(link.getAttribute("href")!, "http://localhost");
+    expect(url.pathname).toBe("/");
+    expect(url.searchParams.get("county")).toBe("fresno");
+    // Stats-internal drill_county param is dropped, not carried to the map.
+    expect(url.searchParams.get("drill_county")).toBeNull();
+    // Active filters carry over.
+    expect(url.searchParams.get("severity")).toBe("fatal");
+    expect(url.searchParams.get("cause")).toBe("dui");
+  });
+});

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -364,6 +364,25 @@ function MapPageInner() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Deep-link entry: arriving with a single ?county= filter (e.g. from the
+  // Stats page "Show on Map" link) should focus that county — zoom to it and
+  // open its insight card — not merely tick it in the filter panel.
+  // The guard arms on the first render the county GeoJSON is ready (so
+  // CountyBoundaries' fitBounds has a layer to use) and never re-fires, so
+  // later filter-panel changes don't trigger an unexpected focus/zoom.
+  const deepLinkCountyHandledRef = useRef(false);
+  useEffect(() => {
+    if (deepLinkCountyHandledRef.current) return;
+    if (!countyGeoJson) return;
+    deepLinkCountyHandledRef.current = true;
+    if (focusedCounty) return;
+    if (selectedCounties.size !== 1) return;
+    const [name] = [...selectedCounties];
+    setFocusedCounty(name);
+    setInsightCounty(name);
+    setShowInsight(true);
+  }, [countyGeoJson, selectedCounties, focusedCounty]);
+
   function handleToggle(panel: string) {
     setActivePanel((prev) => (prev === panel ? null : panel));
   }


### PR DESCRIPTION
## What

  Closes #275. Both deep-link buttons already existed, but the round trip was broken:

  - **`AiInsightCard` "View Stats"** linked to `/stats?county=<slug>` — worked as a
    filter, but landed on Stats with no return path (the "Show on Map" button lives
    only in the drill breadcrumb, which `?county=` doesn't render).
  - **`DrillBreadcrumb` "Show on Map"** linked to `/?county=<slug>` — but MapPage's
    `focusedCounty` is local state never seeded from the URL, so the map only ticked
    a checkbox in a hidden filter panel: no zoom, no insight card.

  Changes:
  - `AiInsightCard` — "View Stats" now navigates via `drill_county` instead of the
    `county` filter param, so Stats opens *drilled* into the county. That renders
    the breadcrumb, which already carries the "Show on Map" return link.
  - `MapPage` — a single `?county=` deep link now focuses that county on mount;
    `CountyBoundaries.fitBounds` then zooms the camera. The guard arms once the
    county GeoJSON is ready and never re-fires, so later filter-panel edits don't
    trigger an unexpected focus/zoom.

  Result: a clean loop — Map county → View Stats (drilled) → Show on Map
  (focused + zoomed) → View Stats… — with all active filters carried in the URL
  both directions via `buildFilterQS`.

  Known boundary (pre-existing, not a regression): StatsPage's query consumes
  date/severity/cause/county/alcohol/distracted/pedestrian/cyclist/drug. The other
  `buildFilterQS` keys (`driver_age`, `weather`, `lighting`, `collision_type`,
  `road_type`, `hit_run`) ride along in the URL but don't affect Stats results —
  Stats would need those filter dimensions added, which is out of scope for #275.

  ## Dependencies

  None. Frontend-only — no new packages, no migrations, no backend changes.

  ## How to test

  Manual:
  1. `docker-compose up --build` (or `npm run dev` in `frontend/`).
  2. On the Map, click a county → expand the insight card → click **View Stats**.
     Stats opens drilled into that county; the breadcrumb shows `California /
     <County> County`.
  3. Click **Show on Map** in the breadcrumb. The Map opens focused on that county
     — camera zoomed, insight card open.
  4. Apply filters (year/severity/cause) before each hop and confirm they persist
     across both navigations.
  5. Paste `/?county=fresno` directly into the address bar → the Map loads focused
     on Fresno.

  Automated:
  - `npm test` — full suite green (363 tests). New coverage: `AiInsightCard.test.tsx`
    (View Stats drills + carries filters; hidden in compare mode) and the new
    `DrillBreadcrumb.test.tsx` (4 tests: state-level renders nothing, county name,
    drill-up callback, "Show on Map" carries filters and drops `drill_county`).

  ## Checklist

  - [x] `npx tsc --noEmit` passes
  - [x] `npm run lint` passes
  - [x] `npm test` passes (363 tests)
  - [x] `npm run build` succeeds
  - [x] No backend / DB / migration changes
  - [x] New tests added for both navigation directions