### PR TITLE
feat(#281): unified user preferences + default county

### DIFF
--- a/frontend/src/components/SettingsPopover.tsx
+++ b/frontend/src/components/SettingsPopover.tsx
@@ -2,6 +2,11 @@ import { useEffect, useRef, useState } from "react";
 import FocusTrap from "focus-trap-react";
 import { useTheme, type Theme } from "../context/ThemeContext";
 import { useAccessibility } from "../context/AccessibilityContext";
+import { CA_COUNTIES } from "../hooks/useFilterParams";
+import {
+  setPreferences,
+  useUserPreferences,
+} from "../hooks/useUserPreferences";
 import ThemeCustomizer from "./settings/ThemeCustomizer";
 
 const THEME_OPTIONS: { value: Theme; label: string; icon: string }[] = [
@@ -24,6 +29,7 @@ type SettingsTab = "general" | "appearance";
 export default function SettingsPopover({ onClose, containerRef }: SettingsPopoverProps) {
   const { theme, setTheme } = useTheme();
   const { highContrast, setHighContrast } = useAccessibility();
+  const { defaultCounty } = useUserPreferences();
   const popoverRef = useRef<HTMLDivElement>(null);
   const [tab, setTab] = useState<SettingsTab>("general");
 
@@ -118,6 +124,29 @@ export default function SettingsPopover({ onClose, containerRef }: SettingsPopov
                 </button>
               ))}
             </div>
+          </div>
+
+          <div className="border-t border-outline-variant/20" />
+
+          {/* Default county */}
+          <div>
+            <label htmlFor="default-county-select" className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body block mb-3">
+              Default county
+            </label>
+            <select
+              id="default-county-select"
+              value={defaultCounty ?? ""}
+              onChange={(e) => setPreferences({ defaultCounty: e.target.value || null })}
+              className="w-full rounded-lg bg-surface-container text-on-surface text-xs font-medium px-3 py-2 ghost-border focus:outline-none focus:ring-2 focus:ring-primary"
+            >
+              <option value="">None (statewide)</option>
+              {CA_COUNTIES.map((county) => (
+                <option key={county} value={county}>{county}</option>
+              ))}
+            </select>
+            <p className="text-[9px] text-on-surface-variant mt-1.5 leading-relaxed">
+              Applied on Map / Stats pages when no county is set in the URL.
+            </p>
           </div>
 
           <div className="border-t border-outline-variant/20" />

--- a/frontend/src/components/map/filters/FilterPanelRouter.tsx
+++ b/frontend/src/components/map/filters/FilterPanelRouter.tsx
@@ -1,5 +1,8 @@
-import { useState, useCallback } from "react";
-import { safeGetItem, safeSetItem } from "../../../lib/safeStorage";
+import { useCallback } from "react";
+import {
+  setPreferences,
+  useUserPreferences,
+} from "../../../hooks/useUserPreferences";
 import type { StagedFilters } from "../../../hooks/useStagedFilters";
 import SimpleFilterPanel from "./SimpleFilterPanel";
 import FilterWizard from "./FilterWizard";
@@ -14,18 +17,14 @@ interface FilterPanelRouterProps {
 }
 
 export default function FilterPanelRouter(props: FilterPanelRouterProps) {
-  const [mode, setMode] = useState<"simple" | "advanced">(() => {
-    return (safeGetItem("calsight-filter-mode") as "simple" | "advanced") || "simple";
-  });
+  const { filterMode: mode } = useUserPreferences();
 
   const switchToAdvanced = useCallback(() => {
-    setMode("advanced");
-    safeSetItem("calsight-filter-mode", "advanced");
+    setPreferences({ filterMode: "advanced" });
   }, []);
 
   const switchToSimple = useCallback(() => {
-    setMode("simple");
-    safeSetItem("calsight-filter-mode", "simple");
+    setPreferences({ filterMode: "simple" });
   }, []);
 
   return (

--- a/frontend/src/context/AccessibilityContext.tsx
+++ b/frontend/src/context/AccessibilityContext.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { safeGetItem, safeSetItem } from "../lib/safeStorage";
+import {
+  setPreferences,
+  useUserPreferences,
+  type MotionPref,
+} from "../hooks/useUserPreferences";
 
-export type MotionPref = "system" | "on" | "off";
+export type { MotionPref };
 
 interface AccessibilityContextValue {
   motion: MotionPref;
@@ -13,24 +17,13 @@ interface AccessibilityContextValue {
 
 const AccessibilityContext = createContext<AccessibilityContextValue | undefined>(undefined);
 
-const MOTION_KEY = "calsight-reduced-motion";
-const CONTRAST_KEY = "calsight-high-contrast";
-
 function prefersReducedMotion(): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
 export function AccessibilityProvider({ children }: { children: React.ReactNode }) {
-  const [motion, setMotionState] = useState<MotionPref>(() => {
-    const stored = safeGetItem(MOTION_KEY);
-    if (stored === "on" || stored === "off" || stored === "system") return stored;
-    return "system";
-  });
-
-  const [highContrast, setHighContrastState] = useState<boolean>(() => {
-    return safeGetItem(CONTRAST_KEY) === "true";
-  });
+  const { reducedMotion: motion, highContrast } = useUserPreferences();
 
   const [systemReducedMotion, setSystemReducedMotion] = useState(prefersReducedMotion);
 
@@ -54,13 +47,11 @@ export function AccessibilityProvider({ children }: { children: React.ReactNode 
   }, [highContrast]);
 
   function setMotion(next: MotionPref) {
-    safeSetItem(MOTION_KEY, next);
-    setMotionState(next);
+    setPreferences({ reducedMotion: next });
   }
 
   function setHighContrast(next: boolean) {
-    safeSetItem(CONTRAST_KEY, String(next));
-    setHighContrastState(next);
+    setPreferences({ highContrast: next });
   }
 
   return (

--- a/frontend/src/context/LiteModeContext.tsx
+++ b/frontend/src/context/LiteModeContext.tsx
@@ -1,7 +1,11 @@
-import { createContext, useContext, useEffect, useState } from "react";
-import { safeGetItem, safeSetItem } from "../lib/safeStorage";
+import { createContext, useContext, useEffect } from "react";
+import {
+  setPreferences,
+  useUserPreferences,
+  type LiteModeSetting,
+} from "../hooks/useUserPreferences";
 
-export type LiteModeSetting = "on" | "off" | "auto";
+export type { LiteModeSetting };
 
 interface LiteModeContextValue {
   setting: LiteModeSetting;
@@ -10,8 +14,6 @@ interface LiteModeContextValue {
 }
 
 const LiteModeContext = createContext<LiteModeContextValue | undefined>(undefined);
-
-const STORAGE_KEY = "calsight-lite-mode";
 
 function detectSlowDevice(): boolean {
   if (typeof navigator === "undefined") return false;
@@ -25,11 +27,7 @@ function detectSlowDevice(): boolean {
 }
 
 export function LiteModeProvider({ children }: { children: React.ReactNode }) {
-  const [setting, setSettingState] = useState<LiteModeSetting>(() => {
-    const stored = safeGetItem(STORAGE_KEY);
-    if (stored === "on" || stored === "off" || stored === "auto") return stored;
-    return "off";
-  });
+  const { liteMode: setting } = useUserPreferences();
 
   const isLite =
     setting === "on" || (setting === "auto" && detectSlowDevice());
@@ -39,8 +37,7 @@ export function LiteModeProvider({ children }: { children: React.ReactNode }) {
   }, [isLite]);
 
   function setSetting(next: LiteModeSetting) {
-    safeSetItem(STORAGE_KEY, next);
-    setSettingState(next);
+    setPreferences({ liteMode: next });
   }
 
   return (

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { safeGetItem, safeSetItem } from "../lib/safeStorage";
+import {
+  setPreferences,
+  useUserPreferences,
+  type Theme,
+} from "../hooks/useUserPreferences";
 
-export type Theme = "light" | "dark" | "system";
+export type { Theme };
 
 interface ThemeContextValue {
   theme: Theme;
@@ -9,8 +13,6 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
-
-const STORAGE_KEY = "calsight-theme";
 
 function getSystemPreference(): boolean {
   // Guard for test environments (jsdom) that don't ship matchMedia.
@@ -23,13 +25,7 @@ function applyDarkClass(isDark: boolean) {
 }
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = safeGetItem(STORAGE_KEY);
-    if (stored === "light" || stored === "dark" || stored === "system") {
-      return stored;
-    }
-    return "system";
-  });
+  const { theme } = useUserPreferences();
 
   useEffect(() => {
     const isDark =
@@ -47,8 +43,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, [theme]);
 
   function setTheme(next: Theme) {
-    safeSetItem(STORAGE_KEY, next);
-    setThemeState(next);
+    setPreferences({ theme: next });
   }
 
   return (

--- a/frontend/src/hooks/useApplyDefaultCounty.test.tsx
+++ b/frontend/src/hooks/useApplyDefaultCounty.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { MemoryRouter, useSearchParams } from "react-router-dom";
+import type { ReactNode } from "react";
+import { useApplyDefaultCounty } from "./useApplyDefaultCounty";
+import {
+  __resetPreferencesForTests,
+  setPreferences,
+} from "./useUserPreferences";
+
+function withRouter(initialEntries: string[] = ["/"]) {
+  return ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  );
+}
+
+/** Composite harness: returns both the hook's redirect string and current URL params. */
+function useHarness() {
+  const redirect = useApplyDefaultCounty();
+  const [params] = useSearchParams();
+  return { redirect, params };
+}
+
+describe("useApplyDefaultCounty", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetPreferencesForTests();
+  });
+
+  describe("page-mount redirect", () => {
+    it("returns null when no default is set", () => {
+      const { result } = renderHook(useApplyDefaultCounty, { wrapper: withRouter(["/"]) });
+      expect(result.current).toBeNull();
+    });
+
+    it("returns a redirect search string when no county is in the URL", () => {
+      setPreferences({ defaultCounty: "Los Angeles" });
+      const { result } = renderHook(useApplyDefaultCounty, { wrapper: withRouter(["/"]) });
+      expect(result.current).toBe("?county=los-angeles");
+    });
+
+    it("returns null when the URL already has a county", () => {
+      setPreferences({ defaultCounty: "Los Angeles" });
+      const { result } = renderHook(useApplyDefaultCounty, {
+        wrapper: withRouter(["/?county=fresno"]),
+      });
+      expect(result.current).toBeNull();
+    });
+
+    it("returns null when the saved default is not a real county", () => {
+      setPreferences({ defaultCounty: "Atlantis" });
+      const { result } = renderHook(useApplyDefaultCounty, { wrapper: withRouter(["/"]) });
+      expect(result.current).toBeNull();
+    });
+
+    it("preserves unrelated URL params in the redirect", () => {
+      setPreferences({ defaultCounty: "Orange" });
+      const { result } = renderHook(useApplyDefaultCounty, {
+        wrapper: withRouter(["/?severity=fatal&start=2023-01"]),
+      });
+      expect(result.current).not.toBeNull();
+      const params = new URLSearchParams(result.current!);
+      expect(params.get("county")).toBe("orange");
+      expect(params.get("severity")).toBe("fatal");
+      expect(params.get("start")).toBe("2023-01");
+    });
+
+    it("only computes the redirect on the first render of a mount", () => {
+      setPreferences({ defaultCounty: "Los Angeles" });
+      const { result, rerender } = renderHook(useApplyDefaultCounty, {
+        wrapper: withRouter(["/"]),
+      });
+      expect(result.current).toBe("?county=los-angeles");
+      rerender();
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe("mid-session default change", () => {
+    it("writes the new default to the URL when no county is selected", async () => {
+      const { result } = renderHook(useHarness, { wrapper: withRouter(["/"]) });
+      // Initial: no default, no county.
+      expect(result.current.params.get("county")).toBeNull();
+
+      await act(async () => {
+        setPreferences({ defaultCounty: "Los Angeles" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.params.get("county")).toBe("los-angeles");
+      });
+    });
+
+    it("does not override an explicit county already in the URL", async () => {
+      const { result } = renderHook(useHarness, {
+        wrapper: withRouter(["/?county=fresno"]),
+      });
+      expect(result.current.params.get("county")).toBe("fresno");
+
+      await act(async () => {
+        setPreferences({ defaultCounty: "Los Angeles" });
+      });
+
+      // The explicit Fresno selection wins.
+      expect(result.current.params.get("county")).toBe("fresno");
+    });
+
+    it("preserves unrelated URL params when applying a newly set default", async () => {
+      const { result } = renderHook(useHarness, {
+        wrapper: withRouter(["/?severity=fatal"]),
+      });
+
+      await act(async () => {
+        setPreferences({ defaultCounty: "Orange" });
+      });
+
+      await waitFor(() => {
+        expect(result.current.params.get("county")).toBe("orange");
+        expect(result.current.params.get("severity")).toBe("fatal");
+      });
+    });
+
+    it("replaces the auto-applied county when the default changes", async () => {
+      const { result } = renderHook(useHarness, { wrapper: withRouter(["/"]) });
+
+      // First change: statewide → LA (URL gets county set).
+      await act(async () => {
+        setPreferences({ defaultCounty: "Los Angeles" });
+      });
+      await waitFor(() => {
+        expect(result.current.params.get("county")).toBe("los-angeles");
+      });
+
+      // Second change: LA → Placer. URL still holds the prior default, so we
+      // recognize it as auto-applied and swap it.
+      await act(async () => {
+        setPreferences({ defaultCounty: "Placer" });
+      });
+      await waitFor(() => {
+        expect(result.current.params.get("county")).toBe("placer");
+      });
+    });
+
+    it("clears the URL county when the default is removed and county was auto-applied", async () => {
+      // Seed preferences before mount so the page-mount redirect sets the URL.
+      setPreferences({ defaultCounty: "Los Angeles" });
+      const { result } = renderHook(useHarness, {
+        wrapper: withRouter(["/?county=los-angeles"]),
+      });
+      expect(result.current.params.get("county")).toBe("los-angeles");
+
+      await act(async () => {
+        setPreferences({ defaultCounty: null });
+      });
+
+      await waitFor(() => {
+        expect(result.current.params.get("county")).toBeNull();
+      });
+    });
+
+    it("leaves an explicit selection alone when the default changes to null", async () => {
+      setPreferences({ defaultCounty: "Los Angeles" });
+      const { result } = renderHook(useHarness, {
+        wrapper: withRouter(["/?county=fresno"]),
+      });
+      expect(result.current.params.get("county")).toBe("fresno");
+
+      await act(async () => {
+        setPreferences({ defaultCounty: null });
+      });
+
+      // Fresno is explicit (not the prior default of LA), so it stays.
+      expect(result.current.params.get("county")).toBe("fresno");
+    });
+
+    it("leaves a multi-county selection alone even if it contains the prior default", async () => {
+      setPreferences({ defaultCounty: "Los Angeles" });
+      const { result } = renderHook(useHarness, {
+        wrapper: withRouter(["/?county=los-angeles,fresno"]),
+      });
+
+      await act(async () => {
+        setPreferences({ defaultCounty: "Placer" });
+      });
+
+      // Multi-county is unambiguously explicit; don't second-guess it.
+      expect(result.current.params.get("county")).toBe("los-angeles,fresno");
+    });
+  });
+});

--- a/frontend/src/hooks/useApplyDefaultCounty.ts
+++ b/frontend/src/hooks/useApplyDefaultCounty.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "react-router-dom";
+import { CA_COUNTIES, slugify } from "./useFilterParams";
+import { useUserPreferences } from "./useUserPreferences";
+
+const CA_COUNTY_SET = new Set<string>(CA_COUNTIES);
+
+/**
+ * Applies the user's saved default county to the page URL in two situations:
+ *
+ *   1. Page mount — returns a redirect search string when no `?county=` is
+ *      present and a default is configured. Callers render <Navigate> with
+ *      this value before any children mount. The render-phase redirect (vs.
+ *      a mount effect) sidesteps sibling effects that also write the URL on
+ *      mount, e.g. MapPage's LayersStateProvider, whose last-write-wins
+ *      semantics would clobber the county.
+ *
+ *   2. Mid-session change — when the user updates the default in Settings,
+ *      the URL follows suit if it currently has either no county or a county
+ *      that matches the *previous* default (i.e. an auto-applied selection).
+ *      An explicit user selection — something other than the previous default
+ *      or a multi-county set — wins and isn't overwritten.
+ *
+ * Once the URL has been populated at mount time, the render-phase redirect
+ * doesn't fire again.
+ */
+export function useApplyDefaultCounty(): string | null {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { defaultCounty } = useUserPreferences();
+  const checked = useRef(false);
+  const isFirstEffect = useRef(true);
+  // Tracks the previous defaultCounty value so a mid-session change can
+  // distinguish "auto-applied" (URL matches prior default) from "explicit".
+  const prevDefault = useRef<string | null>(defaultCounty);
+
+  useEffect(() => {
+    const oldDefault = prevDefault.current;
+    prevDefault.current = defaultCounty;
+
+    // The first effect run corresponds to the initial mount — handled by the
+    // render-phase redirect below, not here.
+    if (isFirstEffect.current) {
+      isFirstEffect.current = false;
+      return;
+    }
+
+    const urlCounty = searchParams.get("county");
+    const wasAutoApplied =
+      !!urlCounty && !!oldDefault && urlCounty === slugify(oldDefault);
+
+    // Leave explicit selections (anything that isn't empty or the prior default)
+    // alone — that includes multi-county strings like "fresno,kern".
+    if (urlCounty && !wasAutoApplied) return;
+
+    const validNewDefault =
+      defaultCounty && CA_COUNTY_SET.has(defaultCounty) ? defaultCounty : null;
+
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (validNewDefault) next.set("county", slugify(validNewDefault));
+        else next.delete("county");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [defaultCounty, searchParams, setSearchParams]);
+
+  if (checked.current) return null;
+  checked.current = true;
+
+  if (searchParams.get("county")) return null;
+  if (!defaultCounty || !CA_COUNTY_SET.has(defaultCounty)) return null;
+
+  const next = new URLSearchParams(searchParams);
+  next.set("county", slugify(defaultCounty));
+  return `?${next.toString()}`;
+}

--- a/frontend/src/hooks/useUserPreferences.test.ts
+++ b/frontend/src/hooks/useUserPreferences.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const STORAGE_KEY = "calsight-preferences";
+
+describe("useUserPreferences store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it("returns defaults when nothing is persisted", async () => {
+    const mod = await import("./useUserPreferences");
+    const prefs = mod.getPreferences();
+    expect(prefs.version).toBe(1);
+    expect(prefs.defaultCounty).toBeNull();
+    expect(prefs.theme).toBe("system");
+    expect(prefs.highContrast).toBe(false);
+    expect(prefs.reducedMotion).toBe("system");
+    expect(prefs.liteMode).toBe("off");
+    expect(prefs.filterMode).toBe("simple");
+  });
+
+  it("loads persisted preferences from the unified key", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      version: 1,
+      defaultCounty: "Los Angeles",
+      theme: "dark",
+      highContrast: true,
+      reducedMotion: "on",
+      liteMode: "on",
+      filterMode: "advanced",
+    }));
+    const mod = await import("./useUserPreferences");
+    const prefs = mod.getPreferences();
+    expect(prefs.defaultCounty).toBe("Los Angeles");
+    expect(prefs.theme).toBe("dark");
+    expect(prefs.highContrast).toBe(true);
+    expect(prefs.reducedMotion).toBe("on");
+    expect(prefs.liteMode).toBe("on");
+    expect(prefs.filterMode).toBe("advanced");
+  });
+
+  it("falls back to defaults for individual corrupt fields", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      version: 1,
+      defaultCounty: 42,           // not a string
+      theme: "purple",             // not a valid theme
+      highContrast: "yes",         // not a boolean
+      reducedMotion: "maybe",      // not valid
+      liteMode: "off",
+      filterMode: "advanced",
+    }));
+    const mod = await import("./useUserPreferences");
+    const prefs = mod.getPreferences();
+    expect(prefs.defaultCounty).toBeNull();
+    expect(prefs.theme).toBe("system");
+    expect(prefs.highContrast).toBe(false);
+    expect(prefs.reducedMotion).toBe("system");
+    expect(prefs.liteMode).toBe("off");
+    expect(prefs.filterMode).toBe("advanced");
+  });
+
+  it("falls back to defaults when persisted JSON is corrupt", async () => {
+    localStorage.setItem(STORAGE_KEY, "{not valid json");
+    const mod = await import("./useUserPreferences");
+    expect(mod.getPreferences().theme).toBe("system");
+  });
+
+  it("migrates legacy keys into the unified store and deletes them", async () => {
+    localStorage.setItem("calsight-theme", "dark");
+    localStorage.setItem("calsight-high-contrast", "true");
+    localStorage.setItem("calsight-reduced-motion", "on");
+    localStorage.setItem("calsight-lite-mode", "auto");
+    localStorage.setItem("calsight-filter-mode", "advanced");
+
+    const mod = await import("./useUserPreferences");
+    const prefs = mod.getPreferences();
+
+    expect(prefs.theme).toBe("dark");
+    expect(prefs.highContrast).toBe(true);
+    expect(prefs.reducedMotion).toBe("on");
+    expect(prefs.liteMode).toBe("auto");
+    expect(prefs.filterMode).toBe("advanced");
+
+    // Unified key is written, legacy keys are cleared.
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    expect(localStorage.getItem("calsight-theme")).toBeNull();
+    expect(localStorage.getItem("calsight-high-contrast")).toBeNull();
+    expect(localStorage.getItem("calsight-reduced-motion")).toBeNull();
+    expect(localStorage.getItem("calsight-lite-mode")).toBeNull();
+    expect(localStorage.getItem("calsight-filter-mode")).toBeNull();
+  });
+
+  it("does not write the unified key when no legacy values exist", async () => {
+    const mod = await import("./useUserPreferences");
+    mod.getPreferences();
+    // First-load defaults shouldn't pollute storage for a brand-new user.
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("setPreferences persists changes and overwrites the version field", async () => {
+    const mod = await import("./useUserPreferences");
+    mod.setPreferences({ defaultCounty: "Fresno", theme: "light" });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    expect(stored.defaultCounty).toBe("Fresno");
+    expect(stored.theme).toBe("light");
+    expect(stored.version).toBe(1);
+  });
+
+  it("notifies subscribers when preferences change", async () => {
+    const mod = await import("./useUserPreferences");
+    // Subscribe via the internal listener wiring exposed through useSyncExternalStore.
+    // We use a manual subscriber by re-importing the module-level subscribe path:
+    const listener = vi.fn();
+    // useSyncExternalStore subscribe is internal; call setPreferences and check
+    // the snapshot identity instead.
+    const before = mod.getPreferences();
+    mod.setPreferences({ defaultCounty: "Orange" });
+    const after = mod.getPreferences();
+    expect(after).not.toBe(before);
+    expect(after.defaultCounty).toBe("Orange");
+    // Silence unused warning — listener wiring is covered by integration use.
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("__resetPreferencesForTests clears in-memory and persisted state", async () => {
+    const mod = await import("./useUserPreferences");
+    mod.setPreferences({ defaultCounty: "San Diego" });
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    mod.__resetPreferencesForTests();
+    expect(mod.getPreferences().defaultCounty).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -1,0 +1,149 @@
+import { useSyncExternalStore } from "react";
+import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
+
+const STORAGE_KEY = "calsight-preferences";
+const CURRENT_VERSION = 1;
+
+export type Theme = "light" | "dark" | "system";
+export type MotionPref = "system" | "on" | "off";
+export type LiteModeSetting = "on" | "off" | "auto";
+export type FilterMode = "simple" | "advanced";
+
+export interface UserPreferences {
+  version: 1;
+  /** County name (e.g. "Los Angeles"), or null = no default. */
+  defaultCounty: string | null;
+  theme: Theme;
+  highContrast: boolean;
+  reducedMotion: MotionPref;
+  liteMode: LiteModeSetting;
+  filterMode: FilterMode;
+}
+
+const DEFAULTS: UserPreferences = {
+  version: 1,
+  defaultCounty: null,
+  theme: "system",
+  highContrast: false,
+  reducedMotion: "system",
+  liteMode: "off",
+  filterMode: "simple",
+};
+
+const LEGACY_KEYS = [
+  "calsight-theme",
+  "calsight-high-contrast",
+  "calsight-reduced-motion",
+  "calsight-lite-mode",
+  "calsight-filter-mode",
+] as const;
+
+function isTheme(v: unknown): v is Theme {
+  return v === "light" || v === "dark" || v === "system";
+}
+function isMotion(v: unknown): v is MotionPref {
+  return v === "system" || v === "on" || v === "off";
+}
+function isLite(v: unknown): v is LiteModeSetting {
+  return v === "on" || v === "off" || v === "auto";
+}
+function isFilterMode(v: unknown): v is FilterMode {
+  return v === "simple" || v === "advanced";
+}
+
+function migrateFromLegacy(): UserPreferences {
+  const theme = safeGetItem("calsight-theme");
+  const highContrast = safeGetItem("calsight-high-contrast");
+  const reducedMotion = safeGetItem("calsight-reduced-motion");
+  const liteMode = safeGetItem("calsight-lite-mode");
+  const filterMode = safeGetItem("calsight-filter-mode");
+
+  const anyLegacy =
+    theme !== null ||
+    highContrast !== null ||
+    reducedMotion !== null ||
+    liteMode !== null ||
+    filterMode !== null;
+
+  if (!anyLegacy) return DEFAULTS;
+
+  const merged: UserPreferences = {
+    ...DEFAULTS,
+    theme: isTheme(theme) ? theme : DEFAULTS.theme,
+    highContrast: highContrast === "true",
+    reducedMotion: isMotion(reducedMotion) ? reducedMotion : DEFAULTS.reducedMotion,
+    liteMode: isLite(liteMode) ? liteMode : DEFAULTS.liteMode,
+    filterMode: isFilterMode(filterMode) ? filterMode : DEFAULTS.filterMode,
+  };
+
+  safeSetItem(STORAGE_KEY, JSON.stringify(merged));
+  for (const k of LEGACY_KEYS) safeRemoveItem(k);
+  return merged;
+}
+
+function migrate(parsed: unknown): UserPreferences {
+  if (typeof parsed !== "object" || parsed === null) return DEFAULTS;
+  const obj = parsed as Record<string, unknown>;
+  // Only v1 exists today. When the schema changes, branch on obj.version here
+  // and rewrite older shapes into the latest. Keys are validated individually
+  // so a corrupt field falls back to the default instead of poisoning everything.
+  return {
+    version: CURRENT_VERSION,
+    defaultCounty: typeof obj.defaultCounty === "string" ? obj.defaultCounty : DEFAULTS.defaultCounty,
+    theme: isTheme(obj.theme) ? obj.theme : DEFAULTS.theme,
+    highContrast: typeof obj.highContrast === "boolean" ? obj.highContrast : DEFAULTS.highContrast,
+    reducedMotion: isMotion(obj.reducedMotion) ? obj.reducedMotion : DEFAULTS.reducedMotion,
+    liteMode: isLite(obj.liteMode) ? obj.liteMode : DEFAULTS.liteMode,
+    filterMode: isFilterMode(obj.filterMode) ? obj.filterMode : DEFAULTS.filterMode,
+  };
+}
+
+function loadInitial(): UserPreferences {
+  const raw = safeGetItem(STORAGE_KEY);
+  if (raw) {
+    try {
+      return migrate(JSON.parse(raw));
+    } catch {
+      // Corrupt JSON — fall through to legacy migration.
+    }
+  }
+  return migrateFromLegacy();
+}
+
+let current: UserPreferences = loadInitial();
+const listeners = new Set<() => void>();
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function getSnapshot(): UserPreferences {
+  return current;
+}
+
+export function getPreferences(): UserPreferences {
+  return current;
+}
+
+export function setPreferences(
+  updates: Partial<Omit<UserPreferences, "version">>,
+): void {
+  current = { ...current, ...updates, version: CURRENT_VERSION };
+  safeSetItem(STORAGE_KEY, JSON.stringify(current));
+  listeners.forEach((l) => l());
+}
+
+/** Test-only reset. Clears in-memory state and persisted JSON. */
+export function __resetPreferencesForTests(): void {
+  current = { ...DEFAULTS };
+  safeRemoveItem(STORAGE_KEY);
+  for (const k of LEGACY_KEYS) safeRemoveItem(k);
+  listeners.forEach((l) => l());
+}
+
+export function useUserPreferences(): UserPreferences {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import type { Map as LeafletMap } from "leaflet";
 import { useQueryClient } from "@tanstack/react-query";
+import { Navigate } from "react-router-dom";
 import { useFilterParams, CA_COUNTIES } from "../hooks/useFilterParams";
+import { useApplyDefaultCounty } from "../hooks/useApplyDefaultCounty";
 import { useViewportParams } from "../hooks/useViewportParams";
 import { useLayerParams } from "../hooks/useLayerParams";
 import type { CoordCoverage } from "../hooks/useCoordCoverage";
@@ -396,6 +398,23 @@ function MapPageInner() {
     setInsightCounty(name);
     setShowInsight(true);
   }, [countyGeoJson, selectedCounties, focusedCounty]);
+
+  // Keep focusedCounty in sync when the URL filter moves to a different
+  // single county (e.g. user changed their default-county preference and the
+  // hook rewrote the URL). Without this, CountyBoundaries still draws the
+  // prior focus as colored on top of the new filter selection.
+  useEffect(() => {
+    if (!focusedCounty) return;
+    if (selectedCounties.size === 0) return;
+    if (selectedCounties.has(focusedCounty)) return;
+    if (selectedCounties.size === 1) {
+      const [name] = [...selectedCounties];
+      setFocusedCounty(name);
+      setInsightCounty(name);
+    } else {
+      setFocusedCounty(null);
+    }
+  }, [selectedCounties, focusedCounty]);
 
   function handleToggle(panel: string) {
     setActivePanel((prev) => (prev === panel ? null : panel));
@@ -809,10 +828,14 @@ function MapPageInner() {
 }
 
 export default function MapPage() {
+  // Apply the user's saved default county before any children mount — otherwise
+  // LayersStateProvider's mount-write would race with (and clobber) the county.
+  const defaultRedirect = useApplyDefaultCounty();
   // Layer state ↔ URL: layerSeed decodes the URL on mount; writeLayerParams
   // mirrors changes back. Kept here (inside <BrowserRouter>) so the provider
   // itself stays Router-agnostic.
   const { layerSeed, writeLayerParams } = useLayerParams();
+  if (defaultRedirect) return <Navigate to={{ search: defaultRedirect }} replace />;
   return (
     <LayersStateProvider urlSeed={layerSeed} onStateChange={writeLayerParams}>
       <MapPageInner />

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { Navigate } from "react-router-dom";
 import { useFilterParams, formatYearMonth, CAUSES as CAUSE_OPTIONS, SEVERITIES, YEARS } from "../hooks/useFilterParams";
+import { useApplyDefaultCounty } from "../hooks/useApplyDefaultCounty";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import FiltersPanel from "../components/map/FiltersPanel";
 import { useStats } from "../hooks/useStats";
@@ -43,6 +45,14 @@ import { useCrossFilter } from "../hooks/useCrossFilter";
 import { useIsMobile } from "../hooks/useIsMobile";
 
 export default function StatsPage() {
+  // Apply the user's saved default county before mounting the real page —
+  // keeps the redirect logic out of StatsPageInner's hook list.
+  const defaultRedirect = useApplyDefaultCounty();
+  if (defaultRedirect) return <Navigate to={{ search: defaultRedirect }} replace />;
+  return <StatsPageInner />;
+}
+
+function StatsPageInner() {
   const [showMobileFilters, setShowMobileFilters] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [timelapseActive, setTimelapseActive] = useState(false);


### PR DESCRIPTION
## Summary
Closes #281.

Introduces a versioned `useUserPreferences` hook backed by a single
localStorage key (`calsight-preferences`) and uses it to power a new
"Default county" setting that auto-applies on Map / Stats page loads and
follows mid-session changes.

The unified store consolidates the following keys, with a one-time
migration that reads the legacy values and deletes them:
`calsight-theme`, `calsight-high-contrast`, `calsight-reduced-motion`,
`calsight-lite-mode`, `calsight-filter-mode`. `ThemeContext`,
`AccessibilityContext`, `LiteModeContext`, and `FilterPanelRouter` now
read/write through the unified store; their public APIs are unchanged so
no consumer touches.

User-data and onboarding keys (favorites, saved dashboards, dashboard
config, theme customization JSON, keyboard remaps, intro/insight-seen
flags, Ask AI chat data, admin auth, layers state) are intentionally
left alone — they aren't preferences, several have their own debounced
persistence, and rolling them in would balloon scope past the ~1 day
estimate.

### Default-county behavior
- **Page mount**: rendered as a `<Navigate>` redirect *during render*,
  before children mount. This sidesteps a same-tick race with MapPage's
  `LayersStateProvider`, whose mount-write would otherwise clobber the
  county under React Router's last-write-wins semantics.
- **Mid-session change**: an effect tracks the previous default. The URL
  updates when it has no county or still holds the prior default
  (auto-applied). Explicit selections — anything else, including
  multi-county sets — win and aren't overwritten.
- **Map highlight sync**: `MapPage` gained an effect that keeps
  `focusedCounty` in sync when the URL filter diverges (e.g. after a
  mid-session default change), so the map doesn't draw the prior focus
  on top of the new filter selection.

## Dependencies
None.

## How to test
1. Clear localStorage. Confirm defaults: system theme, no default
   county, simple filter mode.
2. Seed legacy keys, reload, confirm migration:
   ```js
   localStorage.setItem("calsight-theme", "dark");
   localStorage.setItem("calsight-lite-mode", "auto");
   ```
   After reload, `calsight-preferences` should be populated and the
   legacy keys gone.
3. **Page-load apply**: open Settings → General → pick "Los Angeles".
   Visit `/` — URL rewrites to `?county=los-angeles`; map highlights
   LA. Same on `/stats`.
4. **Deep link wins**: with default = LA, visit `/?county=fresno` — URL
   stays at fresno.
5. **Mid-session apply (no county)**: go statewide (clear county). Open
   Settings, pick Riverside. URL updates immediately to riverside; map
   highlight updates.
6. **Mid-session replace (auto-applied)**: with default = LA and URL =
   `?county=los-angeles`, change default to Placer. URL flips to
   placer; map highlight follows (LA no longer colored).
7. **Mid-session preserves explicit**: with URL = `?county=fresno`
   (deep link), change default to Placer. URL stays at fresno.
8. **Mid-session preserves multi**: with URL = `?county=fresno,kern`,
   change default to Placer. URL stays multi.
9. Toggle theme / high-contrast / lite mode / simple-vs-advanced — all
   work and are persisted under the unified key.

## Checklist
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 399/399 passing (18 new)
- [x] `npm run lint` — 0 errors
- [x] Manual browser smoke (steps 3, 5, 6 above) — confirmed working