### PR TITLE
Sprint 4 polish: polar palette, OG fallback, print CSS

### DIFF
--- a/frontend/src/components/charts/SimplePolarArea.tsx
+++ b/frontend/src/components/charts/SimplePolarArea.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useCallback, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
 import { useDesignTokens } from "../../hooks/useDesignTokens";
 import { useTextScale } from "../../hooks/useTextScale";
+import { CHART_PALETTES, paletteColor } from "../../lib/theme/palettes";
 
 interface PolarItem {
   label: string;
@@ -16,18 +17,12 @@ interface SimplePolarAreaProps {
   title?: string;
 }
 
-const FALLBACK_COLORS = [
-  "#2563eb", "#dc2626", "#059669", "#7c3aed", "#d97706",
-  "#0891b2", "#e11d48", "#4f46e5", "#0d9488", "#ca8a04",
-  "#6366f1", "#0284c7",
-];
-
 export default function SimplePolarArea({ data, height = 220, renderTooltip, title }: SimplePolarAreaProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
   const titleId = useId();
   const tokens = useDesignTokens();
-  const paletteColors = tokens.chart.categorical.length > 0 ? tokens.chart.categorical : FALLBACK_COLORS;
+  const palette = tokens.chart.categorical.length > 0 ? tokens.chart.categorical : CHART_PALETTES.default;
   const ts = useTextScale();
 
   const handleMouseMove = useCallback((e: React.MouseEvent<SVGPathElement>, idx: number) => {
@@ -57,7 +52,7 @@ export default function SimplePolarArea({ data, height = 220, renderTooltip, tit
           const y2 = cy + r * Math.sin(endAngle);
           const large = sliceAngle > Math.PI ? 1 : 0;
           const path = `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${large} 1 ${x2} ${y2} Z`;
-          const color = d.color ?? paletteColors[i % paletteColors.length];
+          const color = d.color ?? paletteColor(palette, i);
           const isHovered = hover?.idx === i;
           return (
             <path

--- a/frontend/src/components/seo/MetaTags.tsx
+++ b/frontend/src/components/seo/MetaTags.tsx
@@ -23,7 +23,7 @@ const OG_WORKER_URL = "https://og.calsight.org";
 const DEFAULT_TITLE = "CalSight — California Crash Data Explorer";
 const DEFAULT_DESCRIPTION =
   "Explore 11 million California traffic crashes with interactive maps, AI-powered insights, and demographic analysis. Filter by county, cause, severity, and year.";
-const DEFAULT_OG_IMAGE = `${OG_WORKER_URL}/og`;
+const DEFAULT_OG_IMAGE = `${OG_WORKER_URL}/og?title=California+Crash+Data+Explorer&subtitle=11M%2B+crashes+%E2%80%A2+58+counties+%E2%80%A2+2001%E2%80%93present`;
 
 export interface MetaTagsProps {
   title?: string;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -541,7 +541,14 @@
   .correlation-controls,
   .correlation-tooltip,
   .chart-config-panel,
-  .add-chart-card {
+  .add-chart-card,
+  .drag-handle,
+  [aria-label="Time-lapse controls"],
+  [aria-label="Natural language chart query"],
+  [aria-label="Show chart"],
+  [aria-label="View data"],
+  [aria-label*="Download"],
+  [aria-label*="Playback speed"] {
     display: none !important;
   }
 
@@ -734,6 +741,7 @@
   }
   .chart-card-themed svg {
     width: 100% !important;
+    max-width: 100% !important;
     height: auto !important;
     max-height: 280px;
   }
@@ -789,13 +797,15 @@
 
   .chart-card-themed,
   .group\/card {
-    break-inside: auto !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
     margin-bottom: 8px;
   }
 
   .grid-cols-1 > div,
   section > .grid > div {
-    break-inside: auto !important;
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
   }
 
   /* Allow breaks between major sections */
@@ -819,11 +829,11 @@
     break-after: avoid !important;
   }
 
-  /* ── Grid Layout: 2-up for print ──
-   * Charts print in a 2-column layout for density while maintaining readability. */
+  /* ── Grid Layout: single-column for print ──
+   * Charts print in a single column to avoid overflow and page-break issues. */
   .grid {
     display: grid !important;
-    grid-template-columns: repeat(2, 1fr) !important;
+    grid-template-columns: 1fr !important;
     gap: 8px !important;
   }
 
@@ -857,6 +867,12 @@
   * {
     animation: none !important;
     transition: none !important;
+  }
+
+  /* Reset chart entrance animation state so cards are fully visible */
+  .chart-card-enter {
+    opacity: 1 !important;
+    transform: none !important;
   }
 
   /* ── Remove max-height limits on lollipop/hbar containers */
@@ -1016,14 +1032,20 @@ body.print-mode [aria-label*="Explain"] {
 body.print-mode .correlation-controls,
 body.print-mode .correlation-tooltip,
 body.print-mode .chart-config-panel,
-body.print-mode .add-chart-card {
+body.print-mode .add-chart-card,
+body.print-mode .drag-handle,
+body.print-mode [aria-label="Time-lapse controls"],
+body.print-mode [aria-label="Natural language chart query"],
+body.print-mode [aria-label="Show chart"],
+body.print-mode [aria-label="View data"],
+body.print-mode [aria-label*="Download"],
+body.print-mode [aria-label*="Playback speed"] {
   display: none !important;
 }
 body.print-mode section:empty,
 body.print-mode [aria-label="Anomaly detection"],
 body.print-mode [aria-label="Key findings"],
 body.print-mode [aria-label="Suggested charts"],
-body.print-mode [aria-label="Natural language query"],
 body.print-mode [aria-live="polite"],
 body.print-mode [role="status"] {
   display: none !important;
@@ -1068,8 +1090,8 @@ body.print-mode svg tspan {
 
 body.print-mode .chart-card-themed,
 body.print-mode .group\/card {
-  page-break-inside: avoid;
-  break-inside: avoid;
+  page-break-inside: avoid !important;
+  break-inside: avoid !important;
   margin-bottom: 8px;
 }
 body.print-mode .grid {
@@ -1117,8 +1139,14 @@ body.print-mode * {
 }
 body.print-mode .chart-card-enter {
   animation: none !important;
+  opacity: 1 !important;
+  transform: none !important;
 }
 body.print-mode svg * {
   animation: none !important;
   transition: none !important;
+}
+body.print-mode .chart-card-themed svg {
+  max-width: 100% !important;
+  height: auto !important;
 }


### PR DESCRIPTION
## Summary
- **fix: polar chart palette** — replaced hardcoded `FALLBACK_COLORS` with shared `CHART_PALETTES.default` so the polar area chart matches the design token system
- **fix(seo): OG fallback image** — default og:image now uses the worker URL with title/subtitle params (1200x630) instead of a bare URL
- **fix(print): chart overflow** — `break-inside: avoid` on chart cards, single-column grid, SVG scales to fit, interactive controls hidden, animation state reset

## Test plan
- [x] 377/377 vitest pass
- [x] 27/27 Playwright e2e pass
- [x] Zero console errors on all pages
- [x] Demographics preset polar chart uses token palette
- [ ] Print preview: charts single-column, no page breaks mid-chart, no toolbar buttons