### PR TITLE
fix(#298): heatmap follows multi-county filter, auto-disables at 3+

### DIFF
--- a/frontend/src/hooks/useAutoDisableHeatmap.test.ts
+++ b/frontend/src/hooks/useAutoDisableHeatmap.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAutoDisableHeatmap } from "./useAutoDisableHeatmap";
+
+interface RenderArgs {
+  selectedCountiesSize: number;
+  heatmapCountyOn: boolean;
+  heatmapStatewideOn: boolean;
+}
+
+function renderTarget(initial: RenderArgs) {
+  const setHeatmapCounty = vi.fn<(on: boolean) => void>();
+  const setHeatmapStatewide = vi.fn<(on: boolean) => void>();
+  const utils = renderHook<
+    ReturnType<typeof useAutoDisableHeatmap>,
+    RenderArgs
+  >(
+    ({ selectedCountiesSize, heatmapCountyOn, heatmapStatewideOn }) =>
+      useAutoDisableHeatmap({
+        selectedCountiesSize,
+        heatmapCountyOn,
+        heatmapStatewideOn,
+        setHeatmapCounty,
+        setHeatmapStatewide,
+      }),
+    { initialProps: initial },
+  );
+  return { ...utils, setHeatmapCounty, setHeatmapStatewide };
+}
+
+describe("useAutoDisableHeatmap", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does nothing when fewer than 3 counties are selected", () => {
+    const { result, setHeatmapCounty, setHeatmapStatewide } = renderTarget({
+      selectedCountiesSize: 2,
+      heatmapCountyOn: true,
+      heatmapStatewideOn: false,
+    });
+    expect(setHeatmapCounty).not.toHaveBeenCalled();
+    expect(setHeatmapStatewide).not.toHaveBeenCalled();
+    expect(result.current.noteVisible).toBe(false);
+  });
+
+  it("auto-disables both heatmap layers and shows the note when crossing to 3", () => {
+    const { result, rerender, setHeatmapCounty, setHeatmapStatewide } = renderTarget({
+      selectedCountiesSize: 2,
+      heatmapCountyOn: true,
+      heatmapStatewideOn: false,
+    });
+
+    act(() => {
+      rerender({ selectedCountiesSize: 3, heatmapCountyOn: true, heatmapStatewideOn: false });
+    });
+
+    expect(setHeatmapCounty).toHaveBeenCalledWith(false);
+    expect(setHeatmapStatewide).toHaveBeenCalledWith(false);
+    expect(result.current.noteVisible).toBe(true);
+  });
+
+  it("does not re-disable if the user manually re-enables the layer", () => {
+    const { rerender, setHeatmapCounty, setHeatmapStatewide } = renderTarget({
+      selectedCountiesSize: 3,
+      heatmapCountyOn: true,
+      heatmapStatewideOn: false,
+    });
+
+    expect(setHeatmapCounty).toHaveBeenCalledTimes(1);
+    expect(setHeatmapStatewide).toHaveBeenCalledTimes(1);
+    setHeatmapCounty.mockClear();
+    setHeatmapStatewide.mockClear();
+
+    // Simulate user manually flipping the heatmap layer back on while still
+    // at 3+ counties — the hook should respect that, not fight it.
+    act(() => {
+      rerender({ selectedCountiesSize: 3, heatmapCountyOn: true, heatmapStatewideOn: false });
+    });
+
+    expect(setHeatmapCounty).not.toHaveBeenCalled();
+    expect(setHeatmapStatewide).not.toHaveBeenCalled();
+  });
+
+  it("resets the auto-disable lock when the selection drops below 3", () => {
+    const { rerender, setHeatmapCounty } = renderTarget({
+      selectedCountiesSize: 3,
+      heatmapCountyOn: true,
+      heatmapStatewideOn: false,
+    });
+    expect(setHeatmapCounty).toHaveBeenCalledTimes(1);
+    setHeatmapCounty.mockClear();
+
+    // Drop below threshold — lock resets.
+    act(() => {
+      rerender({ selectedCountiesSize: 2, heatmapCountyOn: true, heatmapStatewideOn: false });
+    });
+    expect(setHeatmapCounty).not.toHaveBeenCalled();
+
+    // Cross back above with heatmap on — should auto-disable again.
+    act(() => {
+      rerender({ selectedCountiesSize: 3, heatmapCountyOn: true, heatmapStatewideOn: false });
+    });
+    expect(setHeatmapCounty).toHaveBeenCalledWith(false);
+  });
+
+  it("does not fire when 3+ counties are selected but no heatmap layer is on", () => {
+    const { result, setHeatmapCounty, setHeatmapStatewide } = renderTarget({
+      selectedCountiesSize: 4,
+      heatmapCountyOn: false,
+      heatmapStatewideOn: false,
+    });
+    expect(setHeatmapCounty).not.toHaveBeenCalled();
+    expect(setHeatmapStatewide).not.toHaveBeenCalled();
+    expect(result.current.noteVisible).toBe(false);
+  });
+
+  it("auto-dismisses the note after 5 seconds", () => {
+    const { result } = renderTarget({
+      selectedCountiesSize: 3,
+      heatmapCountyOn: true,
+      heatmapStatewideOn: false,
+    });
+    expect(result.current.noteVisible).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.noteVisible).toBe(false);
+  });
+
+  it("dismissNote() hides the note immediately", () => {
+    const { result } = renderTarget({
+      selectedCountiesSize: 3,
+      heatmapCountyOn: true,
+      heatmapStatewideOn: false,
+    });
+    expect(result.current.noteVisible).toBe(true);
+
+    act(() => {
+      result.current.dismissNote();
+    });
+    expect(result.current.noteVisible).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useAutoDisableHeatmap.ts
+++ b/frontend/src/hooks/useAutoDisableHeatmap.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+
+interface AutoDisableArgs {
+  selectedCountiesSize: number;
+  heatmapCountyOn: boolean;
+  heatmapStatewideOn: boolean;
+  setHeatmapCounty: (on: boolean) => void;
+  setHeatmapStatewide: (on: boolean) => void;
+}
+
+/**
+ * When 3+ counties are selected the per-county heatmap becomes unreadable
+ * (point density on top of a multi-county choropleth). This hook auto-turns-off
+ * both heatmap layers on the transition from <3 to ≥3 and exposes a
+ * dismissable notice for the user.
+ *
+ * The auto-disable fires once per "too many" episode — tracked via a ref so we
+ * don't immediately re-disable when the user manually re-enables the layer.
+ * The ref resets when the selection drops back below 3.
+ */
+export function useAutoDisableHeatmap({
+  selectedCountiesSize,
+  heatmapCountyOn,
+  heatmapStatewideOn,
+  setHeatmapCounty,
+  setHeatmapStatewide,
+}: AutoDisableArgs) {
+  const autoDisabledRef = useRef(false);
+  const [noteVisible, setNoteVisible] = useState(false);
+
+  useEffect(() => {
+    const tooMany = selectedCountiesSize >= 3;
+    if (!tooMany) {
+      autoDisabledRef.current = false;
+      return;
+    }
+    if (autoDisabledRef.current) return;
+    if (!heatmapCountyOn && !heatmapStatewideOn) return;
+    autoDisabledRef.current = true;
+    setHeatmapCounty(false);
+    setHeatmapStatewide(false);
+    setNoteVisible(true);
+  }, [
+    selectedCountiesSize,
+    heatmapCountyOn,
+    heatmapStatewideOn,
+    setHeatmapCounty,
+    setHeatmapStatewide,
+  ]);
+
+  useEffect(() => {
+    if (!noteVisible) return;
+    const t = setTimeout(() => setNoteVisible(false), 5000);
+    return () => clearTimeout(t);
+  }, [noteVisible]);
+
+  return { noteVisible, dismissNote: () => setNoteVisible(false) };
+}

--- a/frontend/src/lib/map/heatmapDetail.test.ts
+++ b/frontend/src/lib/map/heatmapDetail.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { selectHeatmapDetailSlugs } from "./heatmapDetail";
+
+describe("selectHeatmapDetailSlugs", () => {
+  it("returns the URL filter's slug when one county is selected", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: false,
+        focusedCounty: null,
+        compareCounty: null,
+        selectedCounties: new Set(["Sacramento"]),
+      }),
+    ).toEqual(["sacramento"]);
+  });
+
+  it("returns both slugs when two counties are selected via the URL filter", () => {
+    const out = selectHeatmapDetailSlugs({
+      compareMode: false,
+      focusedCounty: null,
+      compareCounty: null,
+      selectedCounties: new Set(["Sacramento", "Los Angeles"]),
+    });
+    expect(out.sort()).toEqual(["los-angeles", "sacramento"]);
+  });
+
+  it("returns [] when 3+ counties are selected — auto-disable handles those", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: false,
+        focusedCounty: null,
+        compareCounty: null,
+        selectedCounties: new Set(["Sacramento", "Los Angeles", "Fresno"]),
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns [] when no counties are selected and we aren't in compareMode", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: false,
+        focusedCounty: null,
+        compareCounty: null,
+        selectedCounties: new Set(),
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores selectedCounties in compareMode and uses focused/compare instead", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: true,
+        focusedCounty: "Sacramento",
+        compareCounty: "Fresno",
+        selectedCounties: new Set(["Los Angeles", "Orange", "San Diego"]),
+      }),
+    ).toEqual(["sacramento", "fresno"]);
+  });
+
+  it("returns just the focused county in compareMode when no compare is set", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: true,
+        focusedCounty: "Sacramento",
+        compareCounty: null,
+        selectedCounties: new Set(),
+      }),
+    ).toEqual(["sacramento"]);
+  });
+
+  it("returns [] in compareMode when neither focus nor compare is set", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: true,
+        focusedCounty: null,
+        compareCounty: null,
+        selectedCounties: new Set(),
+      }),
+    ).toEqual([]);
+  });
+
+  it("slugifies multi-word county names with spaces", () => {
+    expect(
+      selectHeatmapDetailSlugs({
+        compareMode: false,
+        focusedCounty: null,
+        compareCounty: null,
+        selectedCounties: new Set(["San Francisco"]),
+      }),
+    ).toEqual(["san-francisco"]);
+  });
+});

--- a/frontend/src/lib/map/heatmapDetail.ts
+++ b/frontend/src/lib/map/heatmapDetail.ts
@@ -1,0 +1,32 @@
+/**
+ * Pick the county slugs whose detail-heatmap should be loaded.
+ *
+ * - In compareMode the explicit focused/compare pair drives the heatmap so the
+ *   pair-compare workflow keeps its established behavior.
+ * - Otherwise the URL filter wins (capped at 2 — useAutoDisableHeatmap covers
+ *   the 3+ case by turning the heatmap layers off).
+ *
+ * Returns slugified county names (lowercase, spaces → hyphens). The result
+ * is stable: `compareMode` with both null returns []; out-of-range selection
+ * sizes return [].
+ */
+export function selectHeatmapDetailSlugs(args: {
+  compareMode: boolean;
+  focusedCounty: string | null;
+  compareCounty: string | null;
+  selectedCounties: ReadonlySet<string>;
+}): string[] {
+  const { compareMode, focusedCounty, compareCounty, selectedCounties } = args;
+  if (compareMode) {
+    const slugs: string[] = [];
+    if (focusedCounty) slugs.push(slugify(focusedCounty));
+    if (compareCounty) slugs.push(slugify(compareCounty));
+    return slugs;
+  }
+  if (selectedCounties.size === 0 || selectedCounties.size > 2) return [];
+  return [...selectedCounties].map(slugify);
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, "-");
+}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -4,6 +4,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Navigate } from "react-router-dom";
 import { useFilterParams, CA_COUNTIES } from "../hooks/useFilterParams";
 import { useApplyDefaultCounty } from "../hooks/useApplyDefaultCounty";
+import { useAutoDisableHeatmap } from "../hooks/useAutoDisableHeatmap";
+import { selectHeatmapDetailSlugs } from "../lib/map/heatmapDetail";
 import { useViewportParams } from "../hooks/useViewportParams";
 import { useLayerParams } from "../hooks/useLayerParams";
 import type { CoordCoverage } from "../hooks/useCoordCoverage";
@@ -124,16 +126,31 @@ function MapPageInner() {
   usePrefetchFacets();
   const { data: countyGeoJson } = useCountyGeoJson();
 
-  const { measure, otherLayers, heatmapResolution, palette, choroplethOn } = useLayersState();
+  const { measure, otherLayers, heatmapResolution, palette, choroplethOn, setOtherLayer } = useLayersState();
 
-  const useCountyDetail = !!focusedCounty && otherLayers.heatmapCounty && (!compareMode || !!compareCounty);
+  const heatmapDetailSlugs = selectHeatmapDetailSlugs({
+    compareMode,
+    focusedCounty,
+    compareCounty,
+    selectedCounties,
+  });
 
-  const heatmapCountySlugs = useCountyDetail ? (() => {
-    const slugs: string[] = [];
-    if (focusedCounty) slugs.push(focusedCounty.toLowerCase().replace(/\s+/g, "-"));
-    if (compareCounty) slugs.push(compareCounty.toLowerCase().replace(/\s+/g, "-"));
-    return slugs.join(",") || null;
-  })() : null;
+  const useCountyDetail =
+    heatmapDetailSlugs.length > 0
+    && otherLayers.heatmapCounty
+    && (!compareMode || !!compareCounty);
+
+  const heatmapCountySlugs = useCountyDetail ? heatmapDetailSlugs.join(",") || null : null;
+
+  const setHeatmapCounty = useCallback((on: boolean) => setOtherLayer("heatmapCounty", on), [setOtherLayer]);
+  const setHeatmapStatewide = useCallback((on: boolean) => setOtherLayer("heatmapStatewide", on), [setOtherLayer]);
+  const { noteVisible: showHeatmapAutoDisableNote, dismissNote: dismissHeatmapAutoDisableNote } = useAutoDisableHeatmap({
+    selectedCountiesSize: selectedCounties.size,
+    heatmapCountyOn: otherLayers.heatmapCounty,
+    heatmapStatewideOn: otherLayers.heatmapStatewide,
+    setHeatmapCounty,
+    setHeatmapStatewide,
+  });
 
   const effectiveResolution = useCountyDetail
     ? "raw" as const
@@ -616,6 +633,27 @@ function MapPageInner() {
           onClear={handleClearAll}
           searchOpen={mobileSearchOpen}
         />
+
+        {showHeatmapAutoDisableNote && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="hidden md:flex absolute top-20 right-4 z-20 max-w-xs items-start gap-2 bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-xl px-3 py-2 ambient-shadow"
+          >
+            <span className="material-symbols-outlined text-[14px] text-primary shrink-0 mt-0.5">info</span>
+            <div className="flex-1 text-[11px] text-on-surface leading-snug">
+              <span className="font-bold">Heatmap turned off.</span>{" "}
+              <span className="text-on-surface-variant">Too many counties selected — re-enable from the Layers panel.</span>
+            </div>
+            <button
+              onClick={dismissHeatmapAutoDisableNote}
+              className="text-on-surface-variant hover:text-on-surface transition-colors -mr-1"
+              aria-label="Dismiss"
+            >
+              <span className="material-symbols-outlined text-[14px]">close</span>
+            </button>
+          </div>
+        )}
 
         {!choroplethData.isLoading
           && !choroplethData.isError


### PR DESCRIPTION
## Summary
  Closes #298.

  When the map is in heatmap mode and a second county is added via the
  filter panel, the heatmap now expands to cover both counties. At 3+
  selected counties — where per-county point density makes the map
  unreadable — both heatmap layers auto-disable and a brief dismissable
  note explains why.

  ### What was actually broken
  The reporter framed this as "clicks don't register," but the click and
  URL toggle were already working. The visual misled them:
  - `MapPage.tsx` derived heatmap detail counties only from `focusedCounty`
    and `compareCounty`, never from `selectedCounties`. Adding a second
    county via the filter updated the URL but didn't update the heatmap
    scope.
  - `CountyBoundaries.tsx` zeroes choropleth fill while heatmap is on, by
    design — so the newly added county appeared as a bare outline with no
    data, looking identical to an unselected county.

  ### Changes
  - New pure helper `selectHeatmapDetailSlugs` — returns slugs from the
    URL filter (capped at 2) or, in compareMode, the explicit focus/compare
    pair. Returns `[]` at 0 or 3+, which causes `useCountyDetail` to fall
    through.
  - New hook `useAutoDisableHeatmap` — on the transition from <3 to ≥3
    selected counties, disables both heatmap layers and shows a 5-second
    dismissable note. Tracks "we already auto-disabled this episode" via a
    ref so it doesn't fight a user who manually re-enables; resets when
    the selection drops back below 3.

  ### Out of scope
  - The acceptance criteria also mention "zoom out to fit" when 2 counties
    are selected. The existing `fitBounds` only fires on initial
    deep-link mount and on compareMode pair changes; auto-fitting on every
    filter-driven multi-select would surprise users. Worth a follow-up
    issue if desired.

  ## Dependencies
  None.

  ## How to test
  1. Visit `/` with no county selected; confirm the statewide heatmap
     loads normally.
  2. Pick "Sacramento" in the filter. Heatmap scopes to Sacramento.
  3. Add "Los Angeles" via the filter. Heatmap now covers both counties.
  4. Add "Fresno" — the heatmap layers turn off; a pill appears at the
     top-right reading "Heatmap turned off. Too many counties selected —
     re-enable from the Layers panel." The note auto-dismisses after 5s.
  5. Open the Layers panel; the heatmap toggle is off. Flip it back on
     manually — it stays on (no auto-disable refight).
  6. Remove counties back to 2 — heatmap re-honors the toggle state.
  7. Enter compareMode and pick a compare county; heatmap follows the
     focus/compare pair, unaffected by the URL filter.

  ## Checklist
  - [x] `npx tsc --noEmit` clean
  - [x] `npm test` — 420/420 passing (15 new)
  - [x] `npm run lint` — 0 errors
  - [ ] Manual browser smoke (steps 2–6 above)