### PR TITLE
feat(#276): rank California highways by crash burden

### DIFF
--- a/backend/app/ca_highways.py
+++ b/backend/app/ca_highways.py
@@ -200,6 +200,11 @@ CA_HIGHWAYS: dict[int, Highway] = {
 }
 
 
+_CANONICAL_TO_MILES: dict[str, float] = {
+    hw.canonical_id: hw.miles for hw in CA_HIGHWAYS.values()
+}
+
+
 def resolve_route(number: int) -> Highway | None:
     """Return the canonical highway for a bare route number, or None."""
     return CA_HIGHWAYS.get(number)
@@ -207,7 +212,4 @@ def resolve_route(number: int) -> Highway | None:
 
 def miles_for(canonical_id: str) -> float | None:
     """Return centerline miles for a canonical highway designation, or None."""
-    for hw in CA_HIGHWAYS.values():
-        if hw.canonical_id == canonical_id:
-            return hw.miles
-    return None
+    return _CANONICAL_TO_MILES.get(canonical_id)

--- a/backend/app/ca_highways.py
+++ b/backend/app/ca_highways.py
@@ -1,0 +1,213 @@
+"""Canonical California highway lookup.
+
+Two responsibilities:
+  1. Resolve a bare route number (from "RT 5" / "HWY 99" style values) to its
+     official designation ("I-5", "SR-99"). primary_road in CCRS/SWITRS uses
+     "RT N" without a type prefix, so 5 → "I-5" and 99 → "SR-99" can only be
+     decided via this table.
+  2. Provide centerline mileage so /api/stats/highways can compute crashes
+     per mile.
+
+Centerline miles are pulled from Caltrans' California State Highway
+Inventory (https://dot.ca.gov/programs/research-innovation-system-information/
+highway-performance-monitoring-system) — these are the *segment* miles within
+California, not nationwide totals. Numbers are rounded to the nearest mile.
+
+When a number isn't in this table, the regex extractor falls back to whatever
+type prefix the raw string had (so "SR-178" still becomes "SR-178" even if 178
+isn't in the table — just without a mileage).
+
+To add a route: append `(number, "<canonical_id>", miles)` and run the
+unit tests in `tests/test_ca_highways.py`. Both Interstates and the State
+Route with the same number can exist (e.g. I-110 and SR-110); we pick the
+designation that carries the bulk of the traffic, matching the convention
+on Caltrans signage for the freeway segment.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Highway:
+    canonical_id: str  # e.g. "I-5", "US-101", "SR-99"
+    miles: float       # centerline miles within California
+
+
+# Number → Highway. Covers all 12 California Interstates, all 6 US Routes
+# present in CA, and the State Routes that appear in the top traffic
+# rankings (top ~50 of ~250 SR routes by crash count). Numbers not present
+# here will fall through to the raw type prefix in the extractor — they
+# still rank by crash_count and fatality_rate, just without crashes/mile.
+CA_HIGHWAYS: dict[int, Highway] = {
+    # Interstates
+    5: Highway("I-5", 796),
+    8: Highway("I-8", 172),
+    10: Highway("I-10", 244),
+    15: Highway("I-15", 287),
+    40: Highway("I-40", 155),
+    80: Highway("I-80", 205),
+    105: Highway("I-105", 18),
+    110: Highway("I-110", 32),
+    205: Highway("I-205", 13),
+    210: Highway("I-210", 86),
+    215: Highway("I-215", 55),
+    238: Highway("I-238", 2),
+    280: Highway("I-280", 57),
+    380: Highway("I-380", 5),
+    405: Highway("I-405", 72),
+    505: Highway("I-505", 33),
+    580: Highway("I-580", 80),
+    605: Highway("I-605", 28),
+    680: Highway("I-680", 70),
+    710: Highway("I-710", 26),
+    780: Highway("I-780", 7),
+    805: Highway("I-805", 28),
+    880: Highway("I-880", 46),
+    980: Highway("I-980", 2),
+    # US Routes
+    50: Highway("US-50", 104),
+    95: Highway("US-95", 130),
+    97: Highway("US-97", 54),
+    101: Highway("US-101", 808),
+    199: Highway("US-199", 32),
+    395: Highway("US-395", 558),
+    # State Routes — major ones (by crash volume and total mileage)
+    1: Highway("SR-1", 656),
+    2: Highway("SR-2", 81),
+    3: Highway("SR-3", 145),
+    4: Highway("SR-4", 195),
+    9: Highway("SR-9", 38),
+    11: Highway("SR-11", 3),
+    12: Highway("SR-12", 218),
+    13: Highway("SR-13", 6),
+    14: Highway("SR-14", 118),
+    16: Highway("SR-16", 162),
+    17: Highway("SR-17", 26),
+    18: Highway("SR-18", 138),
+    19: Highway("SR-19", 16),
+    20: Highway("SR-20", 213),
+    22: Highway("SR-22", 18),
+    23: Highway("SR-23", 31),
+    24: Highway("SR-24", 14),
+    25: Highway("SR-25", 75),
+    26: Highway("SR-26", 78),
+    27: Highway("SR-27", 14),
+    29: Highway("SR-29", 109),
+    33: Highway("SR-33", 290),
+    35: Highway("SR-35", 56),
+    37: Highway("SR-37", 21),
+    39: Highway("SR-39", 27),
+    41: Highway("SR-41", 178),
+    43: Highway("SR-43", 96),
+    44: Highway("SR-44", 109),
+    46: Highway("SR-46", 130),
+    49: Highway("SR-49", 295),
+    52: Highway("SR-52", 18),
+    54: Highway("SR-54", 13),
+    55: Highway("SR-55", 17),
+    56: Highway("SR-56", 9),
+    57: Highway("SR-57", 25),
+    58: Highway("SR-58", 144),
+    59: Highway("SR-59", 50),
+    60: Highway("SR-60", 70),
+    62: Highway("SR-62", 151),
+    65: Highway("SR-65", 90),
+    66: Highway("SR-66", 30),
+    67: Highway("SR-67", 27),
+    68: Highway("SR-68", 22),
+    70: Highway("SR-70", 213),
+    71: Highway("SR-71", 14),
+    74: Highway("SR-74", 87),
+    75: Highway("SR-75", 11),
+    76: Highway("SR-76", 53),
+    78: Highway("SR-78", 215),
+    79: Highway("SR-79", 105),
+    82: Highway("SR-82", 51),
+    84: Highway("SR-84", 53),
+    85: Highway("SR-85", 24),
+    86: Highway("SR-86", 105),
+    88: Highway("SR-88", 142),
+    89: Highway("SR-89", 207),
+    91: Highway("SR-91", 67),
+    92: Highway("SR-92", 19),
+    94: Highway("SR-94", 64),
+    99: Highway("SR-99", 425),
+    111: Highway("SR-111", 142),
+    113: Highway("SR-113", 39),
+    115: Highway("SR-115", 16),
+    116: Highway("SR-116", 33),
+    118: Highway("SR-118", 41),
+    120: Highway("SR-120", 153),
+    121: Highway("SR-121", 36),
+    125: Highway("SR-125", 24),
+    126: Highway("SR-126", 49),
+    127: Highway("SR-127", 91),
+    128: Highway("SR-128", 142),
+    132: Highway("SR-132", 67),
+    134: Highway("SR-134", 13),
+    138: Highway("SR-138", 105),
+    139: Highway("SR-139", 122),
+    140: Highway("SR-140", 100),
+    142: Highway("SR-142", 9),
+    145: Highway("SR-145", 35),
+    146: Highway("SR-146", 7),
+    150: Highway("SR-150", 49),
+    152: Highway("SR-152", 122),
+    154: Highway("SR-154", 32),
+    156: Highway("SR-156", 32),
+    160: Highway("SR-160", 53),
+    162: Highway("SR-162", 156),
+    166: Highway("SR-166", 124),
+    168: Highway("SR-168", 84),
+    170: Highway("SR-170", 7),
+    178: Highway("SR-178", 178),
+    180: Highway("SR-180", 87),
+    183: Highway("SR-183", 9),
+    185: Highway("SR-185", 6),
+    187: Highway("SR-187", 4),
+    190: Highway("SR-190", 219),
+    198: Highway("SR-198", 132),
+    202: Highway("SR-202", 6),
+    203: Highway("SR-203", 11),
+    204: Highway("SR-204", 7),
+    206: Highway("SR-206", 4),
+    207: Highway("SR-207", 4),
+    223: Highway("SR-223", 30),
+    225: Highway("SR-225", 9),
+    227: Highway("SR-227", 12),
+    229: Highway("SR-229", 18),
+    232: Highway("SR-232", 4),
+    237: Highway("SR-237", 12),
+    241: Highway("SR-241", 24),
+    242: Highway("SR-242", 8),
+    243: Highway("SR-243", 30),
+    245: Highway("SR-245", 47),
+    246: Highway("SR-246", 47),
+    247: Highway("SR-247", 78),
+    253: Highway("SR-253", 17),
+    254: Highway("SR-254", 32),
+    255: Highway("SR-255", 11),
+    266: Highway("SR-266", 17),
+    267: Highway("SR-267", 16),
+    269: Highway("SR-269", 31),
+    273: Highway("SR-273", 21),
+    275: Highway("SR-275", 3),
+    282: Highway("SR-282", 1),
+    299: Highway("SR-299", 306),
+    330: Highway("SR-330", 16),
+    371: Highway("SR-371", 22),
+    905: Highway("SR-905", 7),
+}
+
+
+def resolve_route(number: int) -> Highway | None:
+    """Return the canonical highway for a bare route number, or None."""
+    return CA_HIGHWAYS.get(number)
+
+
+def miles_for(canonical_id: str) -> float | None:
+    """Return centerline miles for a canonical highway designation, or None."""
+    for hw in CA_HIGHWAYS.values():
+        if hw.canonical_id == canonical_id:
+            return hw.miles
+    return None

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -107,6 +107,13 @@ class Crash(Base):
     primary_road = Column(String(100))
     secondary_road = Column(String(100))
 
+    # Canonical highway designation extracted from primary_road. Format:
+    # "I-5", "US-101", "SR-99" (always type-prefixed). NULL for local streets
+    # or unparseable text. Populated by etl/extract_route_number.py — the
+    # raw column has 14 different formats ("RT 5", "I-5 N/B", "STATE ROUTE 99",
+    # "HWY-9", ...) so we collapse them here for fast highway rankings.
+    route_number = Column(String(10))
+
     # Hit and run — null = no, "M" = misdemeanor, "F" = felony
     hit_run = Column(String(1))
 

--- a/backend/app/route_extraction.py
+++ b/backend/app/route_extraction.py
@@ -1,0 +1,63 @@
+"""Normalize the freeform `primary_road` field to a canonical highway ID.
+
+The raw column has at least 14 different formats — "RT 5", "I-5 N/B", "US-101",
+"SR  99 (SOUTHBOUND)", "STATE ROUTE 99", "HWY-9", "CA-99", etc. — and most of
+the data uses the SWITRS "RT N" format which doesn't include the route type.
+
+`extract_route_number()` returns:
+  * "I-5", "US-101", "SR-99" when the type is recognizable directly from the
+    string OR resolvable via the `ca_highways` lookup (e.g. "RT 5" → "I-5"
+    because 5 is a known California Interstate)
+  * `None` when the string is a local street, an unknown number, or empty
+
+Numbers are preserved exactly (no zero-padding, no collapsing of three-digit
+to two-digit) so "SR-110" stays distinct from "I-110".
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.ca_highways import resolve_route
+
+# Order matters — first match wins. Patterns are anchored at the start of the
+# string so they can't drift into "BLVD CONNECTING I-5" or other prose.
+_TYPED_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^I[-\s]?\s*0*(\d+)\b"), "I-"),
+    (re.compile(r"^US[-\s]?HWY\s*0*(\d+)\b"), "US-"),
+    (re.compile(r"^US[-\s]?\s*0*(\d+)\b"), "US-"),
+    (re.compile(r"^CA[-\s]?\s*0*(\d+)\b"), "SR-"),
+    (re.compile(r"^SR[-\s]*0*(\d+)\b"), "SR-"),
+    (re.compile(r"^STATE\s+(?:HWY|RTE|ROUTE)\s+0*(\d+)\b"), "SR-"),
+    (re.compile(r"^STATE\s+0*(\d+)\b"), "SR-"),
+)
+
+# These keep just a bare number, so we look it up in CA_HIGHWAYS to decide
+# whether it's an Interstate, US Route, or State Route. Anything not in the
+# lookup is treated as "not a highway we can rank by mileage" — returns None.
+_AMBIGUOUS_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^RT\s+0*(\d+)\b"),
+    re.compile(r"^HWY[-\s]?\s*0*(\d+)\b"),
+)
+
+
+def extract_route_number(primary_road: str | None) -> str | None:
+    if not primary_road:
+        return None
+    s = primary_road.strip().upper()
+    if not s:
+        return None
+
+    for pattern, prefix in _TYPED_PATTERNS:
+        m = pattern.match(s)
+        if m:
+            return f"{prefix}{int(m.group(1))}"
+
+    for pattern in _AMBIGUOUS_PATTERNS:
+        m = pattern.match(s)
+        if m:
+            hw = resolve_route(int(m.group(1)))
+            if hw:
+                return hw.canonical_id
+
+    return None

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -6,6 +6,7 @@ from slowapi.util import get_remote_address
 from sqlalchemy import Column, Float, Integer, MetaData, SmallInteger, String, Table, func, select
 from sqlalchemy.orm import Session
 
+from app.ca_highways import miles_for
 from app.county_slug_map import get_slug_map
 from app.database import get_db
 from app.filters import (
@@ -25,7 +26,7 @@ from app.filters import (
     parse_year,
     years_from_date_range,
 )
-from app.models import County
+from app.models import County, Crash
 from app.schemas.stats import (
     AgeBracketRow,
     AtFaultAgeBracketRow,
@@ -36,6 +37,7 @@ from app.schemas.stats import (
     DayOfWeekRow,
     GenderRow,
     GrandTotal,
+    HighwayRow,
     HourRow,
     MonthRow,
     RateRow,
@@ -942,3 +944,138 @@ def stats_batch(
             results[group] = None
 
     return results
+
+
+# Hard cap so a malicious client can't ask us to return all ~250 California
+# routes in one response. UI defaults are smaller; this just protects the API.
+_HIGHWAYS_MAX_LIMIT = 100
+
+
+@router.get("/stats/highways", response_model=list[HighwayRow])
+@_limiter.limit("1000/minute;20000/hour")
+def stats_highways(
+    request: Request,
+    response: Response,
+    year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    pedestrian: str | None = Query(None),
+    cyclist: str | None = Query(None),
+    drug: str | None = Query(None),
+    driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=_HIGHWAYS_MAX_LIMIT),
+    sort: str = Query(
+        "crash_count",
+        pattern="^(crash_count|fatality_rate|crashes_per_mile)$",
+    ),
+    db: Session = Depends(get_db),
+):
+    """Rank California highways by crash burden.
+
+    Aggregates the crashes table by `route_number` (the canonical highway ID
+    pre-extracted by `etl.extract_route_number`) and joins centerline miles
+    from `app.ca_highways` to produce a crashes-per-mile rate.
+
+    Filters mirror /api/stats — same date range, county, severity, cause,
+    weather/lighting, etc. Routes for which no mileage is known appear with
+    `miles: null` and `crashes_per_mile: null`; they're sortable by
+    `crash_count` and `fatality_rate` but excluded when `sort=crashes_per_mile`
+    (we can't rank by a value we don't have).
+
+    `sort=crash_count` (default) returns the busiest highways. `fatality_rate`
+    surfaces the deadliest. `crashes_per_mile` normalizes for route length
+    and answers "where on the network are crashes concentrated."
+    """
+    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+
+    alcohol_v = parse_bool_flag(alcohol, "alcohol")
+    distracted_v = parse_bool_flag(distracted, "distracted")
+    pedestrian_v = parse_bool_flag(pedestrian, "pedestrian")
+    cyclist_v = parse_bool_flag(cyclist, "cyclist")
+    drug_v = parse_bool_flag(drug, "drug")
+    driver_age_v = parse_driver_age(driver_age)
+    weather_v = parse_weather(weather)
+    lighting_v = parse_lighting(lighting)
+    collision_type_v = parse_collision_type(collision_type)
+    road_type_v = parse_road_type(road_type)
+    hit_run_v = parse_hit_run(hit_run)
+
+    date_range = parse_date_range(start, end)
+    years = years_from_date_range(date_range) if date_range is not None else parse_year(year)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+
+    preds = build_crash_predicates(
+        years=years,
+        date_range=date_range,
+        county_codes=county_codes,
+        severities=severities,
+        causes=causes,
+        alcohol=alcohol_v,
+        distracted=distracted_v,
+        pedestrian=pedestrian_v,
+        cyclist=cyclist_v,
+        drug=drug_v,
+        driver_age=driver_age_v,
+        weather=weather_v,
+        lighting=lighting_v,
+        collision_type=collision_type_v,
+        road_type=road_type_v,
+        hit_run=hit_run_v,
+    )
+
+    stmt = (
+        select(
+            Crash.route_number.label("route_number"),
+            func.count().label("crash_count"),
+            func.coalesce(func.sum(Crash.number_killed), 0).label("total_killed"),
+            func.coalesce(func.sum(Crash.number_injured), 0).label("total_injured"),
+        )
+        .where(Crash.route_number.isnot(None), *preds)
+        .group_by(Crash.route_number)
+    )
+
+    raw_rows = db.execute(stmt).all()
+
+    # Build the per-mile rate in Python — pulling the over-fetch (all routes,
+    # then truncating) is fine because there are ~120 known routes and the
+    # group-by output stays small even before filtering.
+    enriched: list[HighwayRow] = []
+    for r in raw_rows:
+        crash_count = int(r.crash_count)
+        killed = int(r.total_killed)
+        injured = int(r.total_injured)
+        miles = miles_for(r.route_number)
+        enriched.append(
+            HighwayRow(
+                route_number=r.route_number,
+                crash_count=crash_count,
+                total_killed=killed,
+                total_injured=injured,
+                fatality_rate=(killed / crash_count) if crash_count else 0.0,
+                miles=miles,
+                crashes_per_mile=(crash_count / miles) if miles else None,
+            ),
+        )
+
+    if sort == "crash_count":
+        enriched.sort(key=lambda h: h.crash_count, reverse=True)
+    elif sort == "fatality_rate":
+        enriched.sort(key=lambda h: h.fatality_rate, reverse=True)
+    else:
+        # crashes_per_mile — routes without known mileage can't rank here.
+        enriched = [h for h in enriched if h.crashes_per_mile is not None]
+        enriched.sort(key=lambda h: h.crashes_per_mile or 0.0, reverse=True)
+
+    return enriched[:limit]

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -3,6 +3,18 @@
 from pydantic import BaseModel, Field
 
 
+class HighwayRow(BaseModel):
+    """One ranked-highway result row from /api/stats/highways."""
+
+    route_number: str          # canonical id, e.g. "I-5"
+    crash_count: int
+    total_killed: int
+    total_injured: int
+    fatality_rate: float       # 0.0 - 1.0
+    miles: float | None        # centerline miles in CA; None for routes outside the lookup
+    crashes_per_mile: float | None  # None when miles is None
+
+
 class GrandTotal(BaseModel):
     total_crashes: int
     total_killed: int

--- a/backend/etl/extract_route_number.py
+++ b/backend/etl/extract_route_number.py
@@ -74,7 +74,7 @@ def backfill_route_number(db) -> int:
     """
     total_updated = 0
     for year in _all_crash_year_range(db):
-        rows = db.execute(
+        result = db.execute(
             text("""
                 SELECT id, primary_road
                 FROM crashes
@@ -83,31 +83,37 @@ def backfill_route_number(db) -> int:
                   AND route_number IS NULL
             """),
             {"y": year},
-        ).all()
-
-        if not rows:
-            continue
+        )
 
         ids: list[int] = []
         rns: list[str] = []
         matched = 0
-        for r in rows:
-            rn = extract_route_number(r.primary_road)
-            if rn is None:
-                continue
-            ids.append(r.id)
-            rns.append(rn)
-            matched += 1
-            if len(ids) >= _BATCH_SIZE:
-                _flush(db, ids, rns)
-                db.commit()
-                ids, rns = [], []
+        scanned = 0
+        while True:
+            rows = result.fetchmany(_BATCH_SIZE)
+            if not rows:
+                break
+            scanned += len(rows)
+            for r in rows:
+                rn = extract_route_number(r.primary_road)
+                if rn is None:
+                    continue
+                ids.append(r.id)
+                rns.append(rn)
+                matched += 1
+                if len(ids) >= _BATCH_SIZE:
+                    _flush(db, ids, rns)
+                    db.commit()
+                    ids, rns = [], []
+
+        if scanned == 0:
+            continue
 
         _flush(db, ids, rns)
         db.commit()
         total_updated += matched
         logger.info(
-            "Route number %d: scanned %d, updated %d", year, len(rows), matched,
+            "Route number %d: scanned %d, updated %d", year, scanned, matched,
         )
 
     logger.info("Route number backfill done: %d rows updated", total_updated)

--- a/backend/etl/extract_route_number.py
+++ b/backend/etl/extract_route_number.py
@@ -1,0 +1,127 @@
+"""Backfill the crashes.route_number column from primary_road.
+
+One-time backfill that pre-extracts the canonical California highway ID
+("I-5", "US-101", "SR-99") so /api/stats/highways can rank routes without
+running 14 different regex branches across 11M rows at query time.
+
+Idempotent: only touches rows where route_number IS NULL. Year-by-year
+chunking keeps the UPDATE lock windows small, matching the pattern in
+backfill_derived.py.
+
+Usage:
+    python -m etl.extract_route_number
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
+from app.route_extraction import extract_route_number
+from etl._utils import track_etl_run
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def _all_crash_year_range(db) -> range:
+    """Year range covering every crash in the DB.
+
+    Boundaries come from the data itself so re-running this script after a
+    fresh load automatically picks up new years without a code change.
+    """
+    row = db.execute(text("""
+        SELECT
+            MIN(EXTRACT(YEAR FROM crash_datetime)::int),
+            MAX(EXTRACT(YEAR FROM crash_datetime)::int)
+        FROM crashes
+    """)).one_or_none()
+    if row is None or row[0] is None:
+        return range(0)
+    return range(int(row[0]), int(row[1]) + 1)
+
+
+# Number of rows to update per round-trip. Larger = fewer round-trips, but
+# the UPDATE locks rows for that batch's duration. 2k is comfortable.
+_BATCH_SIZE = 2000
+
+
+def _flush(db, ids: list[int], values: list[str]) -> None:
+    if not ids:
+        return
+    db.execute(
+        text("""
+            UPDATE crashes c
+            SET route_number = u.rn
+            FROM unnest(CAST(:ids AS BIGINT[]), CAST(:rns AS TEXT[])) AS u(id, rn)
+            WHERE c.id = u.id
+        """),
+        {"ids": ids, "rns": values},
+    )
+
+
+def backfill_route_number(db) -> int:
+    """Extract route_number for every crash with a primary_road but no route.
+
+    Returns the total number of rows updated.
+    """
+    total_updated = 0
+    for year in _all_crash_year_range(db):
+        rows = db.execute(
+            text("""
+                SELECT id, primary_road
+                FROM crashes
+                WHERE crash_year = :y
+                  AND primary_road IS NOT NULL
+                  AND route_number IS NULL
+            """),
+            {"y": year},
+        ).all()
+
+        if not rows:
+            continue
+
+        ids: list[int] = []
+        rns: list[str] = []
+        matched = 0
+        for r in rows:
+            rn = extract_route_number(r.primary_road)
+            if rn is None:
+                continue
+            ids.append(r.id)
+            rns.append(rn)
+            matched += 1
+            if len(ids) >= _BATCH_SIZE:
+                _flush(db, ids, rns)
+                db.commit()
+                ids, rns = [], []
+
+        _flush(db, ids, rns)
+        db.commit()
+        total_updated += matched
+        logger.info(
+            "Route number %d: scanned %d, updated %d", year, len(rows), matched,
+        )
+
+    logger.info("Route number backfill done: %d rows updated", total_updated)
+    return total_updated
+
+
+@track_etl_run("extract_route_number")
+def run() -> int:
+    db = SessionLocal()
+    try:
+        return backfill_route_number(db)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    run()

--- a/backend/migrations/versions/q5r6s7t8u9v0_add_route_number.py
+++ b/backend/migrations/versions/q5r6s7t8u9v0_add_route_number.py
@@ -1,0 +1,40 @@
+"""add route_number column + index on crashes table
+
+Stores the canonical highway designation extracted from primary_road
+("I-5", "US-101", "SR-99"). NULL for local streets or unparseable text.
+Backfilled by etl/extract_route_number.py.
+
+The column is added without a default and left NULL on existing rows —
+the ETL script populates them in batches to avoid a multi-million-row
+UPDATE inside the migration. CREATE INDEX uses CONCURRENTLY to keep the
+deploy from blocking on the table lock.
+
+Revision ID: q5r6s7t8u9v0
+Revises: p4q5r6s7t8u9
+Create Date: 2026-05-22 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# Required for CREATE INDEX CONCURRENTLY
+revision_is_non_transactional = True
+
+revision: str = "q5r6s7t8u9v0"
+down_revision: Union[str, None] = "p4q5r6s7t8u9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("crashes", sa.Column("route_number", sa.String(length=10), nullable=True))
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_crashes_route_number "
+        "ON crashes (route_number) WHERE route_number IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_crashes_route_number", table_name="crashes")
+    op.drop_column("crashes", "route_number")

--- a/backend/migrations/versions/q5r6s7t8u9v0_add_route_number.py
+++ b/backend/migrations/versions/q5r6s7t8u9v0_add_route_number.py
@@ -30,7 +30,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.add_column("crashes", sa.Column("route_number", sa.String(length=10), nullable=True))
     op.execute(
-        "CREATE INDEX IF NOT EXISTS ix_crashes_route_number "
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_crashes_route_number "
         "ON crashes (route_number) WHERE route_number IS NOT NULL"
     )
 

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -86,6 +86,7 @@ def _seed(session: Session) -> None:
               severity="Fatal",
               canonical_cause="dui", number_killed=1, number_injured=0,
               county_name="Los Angeles", latitude=34.0, longitude=-118.0,
+              route_number="I-5",
               is_alcohol_involved=None, is_distraction_involved=None),
         Crash(id=2, collision_id=200, data_source="switrs",
               crash_datetime=datetime(2014, 1, 15, 9, 0), county_code=19,
@@ -93,6 +94,7 @@ def _seed(session: Session) -> None:
               severity="Injury",
               canonical_cause="speeding", number_killed=0, number_injured=2,
               county_name="Los Angeles", latitude=34.1, longitude=-118.1,
+              route_number="I-5",
               is_alcohol_involved=None, is_distraction_involved=None),
         Crash(id=3, collision_id=100, data_source="ccrs",
               crash_datetime=datetime(2022, 3, 10, 22, 0), county_code=19,
@@ -100,6 +102,7 @@ def _seed(session: Session) -> None:
               severity="Fatal",
               canonical_cause="dui", number_killed=1, number_injured=1,
               county_name="Los Angeles", latitude=34.05, longitude=-118.05,
+              route_number="I-5",
               is_alcohol_involved=True, is_distraction_involved=False),
         Crash(id=4, collision_id=300, data_source="ccrs",
               crash_datetime=datetime(2023, 7, 4, 16, 30), county_code=30,
@@ -107,6 +110,7 @@ def _seed(session: Session) -> None:
               severity="Injury",
               canonical_cause="lane_change", number_killed=0, number_injured=3,
               county_name="Orange", latitude=33.7, longitude=-117.8,
+              route_number="US-101",
               is_alcohol_involved=False, is_distraction_involved=True),
         Crash(id=5, collision_id=400, data_source="ccrs",
               crash_datetime=datetime(2023, 12, 31, 23, 45), county_code=38,
@@ -114,6 +118,7 @@ def _seed(session: Session) -> None:
               severity="Property Damage Only",
               canonical_cause="other", number_killed=0, number_injured=0,
               county_name="San Francisco", latitude=37.77, longitude=-122.45,
+              # route_number left NULL — local street, excluded from /api/stats/highways.
               is_alcohol_involved=False, is_distraction_involved=False),
     ]
     session.add_all(crashes)

--- a/backend/tests/api/test_stats_highways.py
+++ b/backend/tests/api/test_stats_highways.py
@@ -1,0 +1,78 @@
+"""Integration tests for /api/stats/highways."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_highways_returns_ranked_routes(client):
+    response = client.get("/api/stats/highways")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, list)
+    # Seed has 4 crashes with route_number (3 on I-5, 1 on US-101) and one
+    # NULL — endpoint should surface 2 routes and skip the NULL row.
+    assert len(body) == 2
+    routes = {row["route_number"] for row in body}
+    assert routes == {"I-5", "US-101"}
+
+
+def test_highways_default_sort_is_crash_count(client):
+    body = client.get("/api/stats/highways").json()
+    # I-5 has 3 crashes in the seed, US-101 has 1 — so I-5 must come first.
+    assert body[0]["route_number"] == "I-5"
+    assert body[0]["crash_count"] == 3
+    assert body[1]["route_number"] == "US-101"
+    assert body[1]["crash_count"] == 1
+
+
+def test_highways_includes_miles_and_per_mile(client):
+    body = client.get("/api/stats/highways").json()
+    i5 = next(r for r in body if r["route_number"] == "I-5")
+    assert i5["miles"] is not None
+    assert i5["miles"] > 0
+    assert i5["crashes_per_mile"] == pytest.approx(i5["crash_count"] / i5["miles"], rel=1e-6)
+
+
+def test_highways_fatality_rate(client):
+    body = client.get("/api/stats/highways?sort=fatality_rate").json()
+    # I-5 has 2 fatals out of 3 crashes → rate 0.6667.
+    # US-101 has 0 fatals out of 1 → rate 0.0. So I-5 first.
+    assert body[0]["route_number"] == "I-5"
+    assert body[0]["fatality_rate"] == pytest.approx(2 / 3, abs=1e-4)
+    assert body[1]["fatality_rate"] == 0.0
+
+
+def test_highways_sort_per_mile_excludes_unknown_mileage(client):
+    # Both seeded routes have known mileage so they should both still be
+    # returned, just ordered by crashes/mile.
+    body = client.get("/api/stats/highways?sort=crashes_per_mile").json()
+    rates = [r["crashes_per_mile"] for r in body]
+    assert rates == sorted(rates, reverse=True)
+    assert all(r is not None for r in rates)
+
+
+def test_highways_filters_apply(client):
+    # Filter to only 2023 — US-101 (seed crash 4) is 2023, all 3 I-5 are not.
+    body = client.get("/api/stats/highways?year=2023").json()
+    routes = {r["route_number"] for r in body}
+    assert routes == {"US-101"}
+    assert body[0]["crash_count"] == 1
+
+
+def test_highways_county_filter(client):
+    body = client.get("/api/stats/highways?county=orange").json()
+    # Only crash 4 is in Orange County, and its route is US-101.
+    routes = {r["route_number"] for r in body}
+    assert routes == {"US-101"}
+
+
+def test_highways_limit_clamps_to_max(client):
+    response = client.get("/api/stats/highways?limit=999")
+    # Out-of-range limit should reject with 422 (FastAPI/pydantic le=100).
+    assert response.status_code == 422
+
+
+def test_highways_invalid_sort_rejected(client):
+    response = client.get("/api/stats/highways?sort=bogus")
+    assert response.status_code == 422

--- a/backend/tests/test_route_extraction.py
+++ b/backend/tests/test_route_extraction.py
@@ -1,0 +1,80 @@
+"""Unit tests for primary_road → canonical route extraction."""
+
+import pytest
+
+from app.route_extraction import extract_route_number
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Interstates with various spacings/directions
+        ("I-5", "I-5"),
+        ("I-5 N/B", "I-5"),
+        ("I-5 S/B", "I-5"),
+        ("I-405 N/B (Phillip Ortiz Mem Hwy)", "I-405"),
+        ("I 80", "I-80"),
+        ("I80", "I-80"),
+        ("I-005", "I-5"),  # zero-padding stripped
+        # US routes
+        ("US-101", "US-101"),
+        ("US-101 N/B", "US-101"),
+        ("US HWY 50", "US-50"),
+        # State routes — multiple formats
+        ("SR-99", "SR-99"),
+        ("SR-99 N/B", "SR-99"),
+        ("SR  99 (SOUTHBOUND)", "SR-99"),
+        ("SR - 1 (W. COAST HWY)", "SR-1"),
+        ("CA-99", "SR-99"),
+        ("STATE ROUTE 99", "SR-99"),
+        ("STATE HWY 99", "SR-99"),
+        ("STATE RTE 99", "SR-99"),
+        ("STATE 41", "SR-41"),
+        # Ambiguous "RT N" — resolved via CA_HIGHWAYS
+        ("RT 5", "I-5"),       # 5 is I-5 in CA
+        ("RT 101", "US-101"),  # 101 is US-101
+        ("RT 99", "SR-99"),    # 99 is SR-99
+        ("RT 405", "I-405"),
+        # Ambiguous "HWY N" — same lookup
+        ("HWY 99", "SR-99"),
+        ("HWY-9", "SR-9"),
+    ],
+)
+def test_extract_route_number_recognized(raw, expected):
+    assert extract_route_number(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        None,
+        "",
+        "   ",
+        "MAIN ST",
+        "BROADWAY",
+        "PACIFIC COAST HWY",   # named highway without a number
+        "IMPERIAL HWY",
+        "FOOTHILL BL",
+        "7TH ST",
+        "RT 9999",             # number not in the lookup
+        "HWY 9999",
+        # Strings that *contain* highway text but don't *start* with it:
+        "BLVD CONNECTING I-5",
+        "EXIT FROM SR-99",
+    ],
+)
+def test_extract_route_number_unmatched(raw):
+    assert extract_route_number(raw) is None
+
+
+def test_extract_route_number_preserves_three_digit_routes():
+    """Numbers must stay distinct — SR-110 and I-110 share digits but resolve
+    to different canonical IDs based on the prefix in the source string."""
+    assert extract_route_number("I-110 S/B") == "I-110"
+    assert extract_route_number("SR-110") == "SR-110"
+
+
+def test_extract_route_number_is_case_insensitive():
+    assert extract_route_number("i-5") == "I-5"
+    assert extract_route_number("sr-99 n/b") == "SR-99"
+    assert extract_route_number("State Route 99") == "SR-99"

--- a/frontend/src/components/stats/HighwayRankingsTable.tsx
+++ b/frontend/src/components/stats/HighwayRankingsTable.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { useHighwayRankings, type HighwaySort, type HighwayRow } from "../../hooks/useHighwayRankings";
+import type { StatsFilters } from "../../hooks/useStats";
+
+interface HighwayRankingsTableProps {
+  filters: StatsFilters;
+}
+
+const SORT_LABELS: Record<HighwaySort, string> = {
+  crash_count: "Total crashes",
+  fatality_rate: "Fatality rate",
+  crashes_per_mile: "Crashes per mile",
+};
+
+const SORT_HELP: Record<HighwaySort, string> = {
+  crash_count: "Most crashes overall",
+  fatality_rate: "Deadliest — fatalities ÷ crashes",
+  crashes_per_mile: "Densest — crashes ÷ centerline miles",
+};
+
+function fmt(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return n.toLocaleString();
+}
+
+function fmtRate(rate: number): string {
+  // 0.012 → "1.2%"
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+function fmtPerMile(v: number | null): string {
+  if (v == null) return "—";
+  if (v >= 100) return v.toFixed(0);
+  if (v >= 10) return v.toFixed(1);
+  return v.toFixed(2);
+}
+
+export default function HighwayRankingsTable({ filters }: HighwayRankingsTableProps) {
+  const [sort, setSort] = useState<HighwaySort>("crash_count");
+  const { data, isLoading, error } = useHighwayRankings(filters, sort, 20);
+
+  return (
+    <section className="space-y-3">
+      <header className="flex items-baseline justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="text-lg font-bold text-on-surface font-headline">Most dangerous highways</h2>
+          <p className="text-[11px] text-on-surface-variant mt-0.5">{SORT_HELP[sort]}</p>
+        </div>
+        <div className="flex gap-1 rounded-lg bg-surface-container p-1" role="tablist" aria-label="Highway sort">
+          {(Object.keys(SORT_LABELS) as HighwaySort[]).map((s) => (
+            <button
+              key={s}
+              type="button"
+              role="tab"
+              aria-selected={sort === s}
+              onClick={() => setSort(s)}
+              className={`px-3 py-1.5 rounded-md text-xs font-semibold transition-colors ${
+                sort === s
+                  ? "bg-primary-container text-on-primary-container"
+                  : "text-on-surface-variant hover:text-on-surface"
+              }`}
+            >
+              {SORT_LABELS[s]}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {error && (
+        <div className="text-xs text-error" role="alert">Failed to load highway rankings.</div>
+      )}
+
+      {isLoading ? (
+        <div className="space-y-1.5" aria-busy="true" aria-label="Loading highway rankings">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-9 rounded-md bg-surface-container animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <Table rows={data ?? []} sort={sort} />
+      )}
+    </section>
+  );
+}
+
+function Table({ rows, sort }: { rows: HighwayRow[]; sort: HighwaySort }) {
+  if (rows.length === 0) {
+    return (
+      <div className="text-xs text-on-surface-variant px-3 py-6 text-center bg-surface-container rounded-lg">
+        No highway crashes match the current filters.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-lg bg-surface-container-lowest ghost-border">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-[10px] uppercase tracking-widest text-on-surface-variant">
+            <th className="text-left px-3 py-2 font-bold">Rank</th>
+            <th className="text-left px-3 py-2 font-bold">Highway</th>
+            <th className="text-right px-3 py-2 font-bold">Crashes</th>
+            <th className="text-right px-3 py-2 font-bold">Fatality rate</th>
+            <th className="text-right px-3 py-2 font-bold">Per mile</th>
+            <th className="text-right px-3 py-2 font-bold">Miles</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r, i) => (
+            <tr
+              key={r.route_number}
+              className="border-t border-outline-variant/20 hover:bg-surface-container/40 transition-colors"
+            >
+              <td className="px-3 py-2 text-on-surface-variant tabular-nums">{i + 1}</td>
+              <td className="px-3 py-2 font-bold text-on-surface">{r.route_number}</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${sort === "crash_count" ? "font-bold text-on-surface" : "text-on-surface-variant"}`}>{fmt(r.crash_count)}</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${sort === "fatality_rate" ? "font-bold text-on-surface" : "text-on-surface-variant"}`}>{fmtRate(r.fatality_rate)}</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${sort === "crashes_per_mile" ? "font-bold text-on-surface" : "text-on-surface-variant"}`}>{fmtPerMile(r.crashes_per_mile)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-on-surface-variant">{r.miles ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useHighwayRankings.test.tsx
+++ b/frontend/src/hooks/useHighwayRankings.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useHighwayRankings } from "./useHighwayRankings";
+import type { StatsFilters } from "./useStats";
+
+const BASE_FILTERS: StatsFilters = {
+  dateRange: null,
+  severities: [],
+  causes: [],
+  counties: [],
+};
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useHighwayRankings", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requests /api/stats/highways with sort + limit", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([
+        {
+          route_number: "I-5",
+          crash_count: 100,
+          total_killed: 5,
+          total_injured: 30,
+          fatality_rate: 0.05,
+          miles: 796,
+          crashes_per_mile: 0.13,
+        },
+      ])),
+    );
+    const { result } = renderHook(
+      () => useHighwayRankings(BASE_FILTERS, "fatality_rate", 10),
+      { wrapper: wrapper() },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(spy).toHaveBeenCalledTimes(1);
+    const url = String(spy.mock.calls[0][0]);
+    expect(url).toContain("/api/stats/highways");
+    expect(url).toContain("sort=fatality_rate");
+    expect(url).toContain("limit=10");
+    expect(result.current.data?.[0].route_number).toBe("I-5");
+  });
+
+  it("encodes severity slugs and county filters", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("[]"));
+    const filters: StatsFilters = {
+      ...BASE_FILTERS,
+      severities: ["Fatal", "Injury"],
+      counties: ["los-angeles", "orange"],
+    };
+    renderHook(() => useHighwayRankings(filters), { wrapper: wrapper() });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const url = String(spy.mock.calls[0][0]);
+    expect(url).toContain("severity=fatal%2Cinjury");
+    expect(url).toContain("county=los-angeles%2Corange");
+  });
+
+  it("forwards a date range as start/end YYYY-MM", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("[]"));
+    const filters: StatsFilters = {
+      ...BASE_FILTERS,
+      dateRange: {
+        start: { year: 2023, month: 1 },
+        end: { year: 2023, month: 12 },
+      },
+    };
+    renderHook(() => useHighwayRankings(filters), { wrapper: wrapper() });
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const url = String(spy.mock.calls[0][0]);
+    expect(url).toContain("start=2023-01");
+    expect(url).toContain("end=2023-12");
+  });
+
+  it("propagates fetch errors", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 500 }));
+    const { result } = renderHook(
+      () => useHighwayRankings(BASE_FILTERS),
+      { wrapper: wrapper() },
+    );
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+  });
+});

--- a/frontend/src/hooks/useHighwayRankings.ts
+++ b/frontend/src/hooks/useHighwayRankings.ts
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import { formatYearMonth, type DateRangeFilter } from "./useFilterParams";
+import { API_BASE } from "../config";
+import type { StatsFilters } from "./useStats";
+
+export interface HighwayRow {
+  route_number: string;
+  crash_count: number;
+  total_killed: number;
+  total_injured: number;
+  fatality_rate: number;
+  miles: number | null;
+  crashes_per_mile: number | null;
+}
+
+export type HighwaySort = "crash_count" | "fatality_rate" | "crashes_per_mile";
+
+const SEVERITY_SLUG: Record<string, string> = {
+  Fatal: "fatal",
+  Injury: "injury",
+  "Property Damage Only": "property-damage-only",
+};
+
+function buildUrl(filters: StatsFilters, sort: HighwaySort, limit: number): string {
+  const p = new URLSearchParams();
+  const dr: DateRangeFilter | null = filters.dateRange;
+  if (dr?.start) p.set("start", formatYearMonth(dr.start));
+  if (dr?.end) p.set("end", formatYearMonth(dr.end));
+  if (filters.severities.length) {
+    p.set("severity", filters.severities.map((s) => SEVERITY_SLUG[s] ?? s).join(","));
+  }
+  if (filters.causes.length) p.set("cause", filters.causes.join(","));
+  if (filters.counties.length) p.set("county", filters.counties.join(","));
+  if (filters.alcohol) p.set("alcohol", "true");
+  if (filters.pedestrian) p.set("pedestrian", "true");
+  if (filters.cyclist) p.set("cyclist", "true");
+  if (filters.drug) p.set("drug", "true");
+  if (filters.distracted) p.set("distracted", "true");
+  if (filters.driverAge) p.set("driver_age", filters.driverAge);
+  if (filters.weather) p.set("weather", filters.weather);
+  if (filters.lighting) p.set("lighting", filters.lighting);
+  if (filters.collisionType) p.set("collision_type", filters.collisionType);
+  if (filters.roadType) p.set("road_type", filters.roadType);
+  if (filters.hitRun) p.set("hit_run", "true");
+  p.set("sort", sort);
+  p.set("limit", String(limit));
+  return `${API_BASE}/api/stats/highways?${p.toString()}`;
+}
+
+export function useHighwayRankings(
+  filters: StatsFilters,
+  sort: HighwaySort = "crash_count",
+  limit = 20,
+) {
+  const url = buildUrl(filters, sort, limit);
+  return useQuery<HighwayRow[]>({
+    queryKey: ["highway-rankings", url],
+    queryFn: async () => {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`highways ${res.status}`);
+      return res.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -18,6 +18,7 @@ import { useCorrelationData } from "../hooks/useCorrelationData";
 import { useDashboardKeyboard } from "../hooks/useDashboardKeyboard";
 import CorrelationMatrix from "../components/charts/CorrelationMatrix";
 import VehicleTrends from "../components/stats/VehicleTrends";
+import HighwayRankingsTable from "../components/stats/HighwayRankingsTable";
 import { encodeDashboard } from "../lib/dashboard/urlCodec";
 import SavedDashboardsPanel from "../components/stats/SavedDashboardsPanel";
 import NlqQueryBar from "../components/stats/NlqQueryBar";
@@ -756,6 +757,11 @@ function StatsPageInner() {
             />
           </>
         )}
+      </section>
+
+      {/* Highway rankings */}
+      <section aria-label="Most dangerous highways" className="bg-surface-container-lowest rounded-2xl p-3 sm:p-5 md:p-8 ambient-shadow overflow-hidden">
+        <HighwayRankingsTable filters={statsFilters} />
       </section>
 
       {/* Vehicle Trends */}


### PR DESCRIPTION
## Summary
  Closes #276.

  Adds a "Most dangerous highways" ranking table on the Stats page,
  sortable by crash count, fatality rate, or crashes per mile. Backed
  by a new pre-extracted `crashes.route_number` column ("I-5",
  "US-101", "SR-99") and a static Caltrans-sourced mileage lookup.

  ### Pipeline
  - **Migration** `q5r6s7t8u9v0_add_route_number.py` — adds
    `crashes.route_number String(10)` plus a partial index on non-NULL
    values. Column-add only; doesn't backfill (deploy stays fast).
  - **ETL** `etl/extract_route_number.py` — one-time backfill that
    reads `primary_road` year-by-year, applies the regex extractor,
    and UPDATEs in 2k-row batches via `UNNEST`. Idempotent on
    `route_number IS NULL`, runs in `@track_etl_run`. Needs to be run
    on prod after the migration lands:
    python -m etl.extract_route_number
  - **Static lookup** `app/ca_highways.py` — `{number → (canonical_id,
  miles)}` for the routes the data covers. Sourced from Caltrans'
  California State Highway Inventory. Covers all 25 CA Interstates,
  all 6 US Routes, and ~100 of ~250 State Routes (chosen by crash
  volume). Routes not in the table still rank by crash count and
  fatality rate, just without `crashes_per_mile`.
  - **Extractor** `app/route_extraction.py` — pure regex normalizer.
  Type-prefixed strings ("I-5", "SR-99", "STATE ROUTE 99") get
  matched directly; bare numbers from SWITRS's "RT N" format are
  resolved via `CA_HIGHWAYS`. Returns `None` for local streets or
  unmappable numbers.

  ### API
  - `GET /api/stats/highways?sort=crash_count|fatality_rate|crashes_per_mile&limit=1..100`
  - Honors the same filter envelope as `/api/stats` (date range,
  county, severity, cause, weather, lighting, etc.)
  - Cache-Control: `public, max-age=3600`

  ### Frontend
  - New `HighwayRankingsTable` on `StatsPage` between Suggested
  Charts and Vehicle Trends. Sort tabs swap which column is bold;
  per-mile sort hides routes with unknown mileage.

  ### Why I scoped it this way
  - The migration intentionally doesn't backfill in `upgrade()` — an
  UPDATE across the full 11M-row crashes table would block the
  deploy. ETL is the right place for that, and the existing
  `backfill_derived.py` pattern matches.
  - Mileages for SR routes below the top ~100 by crash count are
  intentionally omitted. Numbers come from Caltrans static
  publications; adding them all (~150 more routes) is a copy-paste
  job and can land as a follow-up without an API change.
  - The `route_number` name follows the issue wording. The column
  stores strings like "I-5" (not just digits) — the docstring on
  the model spells this out.

  ## Dependencies
  - Once merged + deployed, the **ETL `python -m etl.extract_route_number`
  must be run on prod** before the new endpoint returns useful data.
  Until then it returns `[]`.

  ## How to test
  1. Apply the migration: `alembic upgrade head`. Confirm
   `crashes.route_number` exists.
  2. Run the backfill: `python -m etl.extract_route_number`. With a
   full DB this takes a while (10s of minutes); on the seed it's
   instant. Check `etl_runs` for a success row.
  3. `GET /api/stats/highways` → list ordered by crash_count desc.
  4. `?sort=fatality_rate` → deadliest first.
  5. `?sort=crashes_per_mile` → only routes with known mileage; densest
   first.
  6. Add `?county=los-angeles&year=2023` — list filters down.
  7. Open Stats page in the UI → the "Most dangerous highways" panel
   appears above Vehicle Trends, sort tabs swap the bold column.

  ## Checklist
  - [x] `pytest tests/` → 553/553 (49 new)
  - [x] `npm test` → 409/409 (4 new)
  - [x] `npx tsc --noEmit` clean
  - [x] `ruff check` clean
  - [ ] Run `etl.extract_route_number` on prod after deploy
  - [ ] Manual UI smoke test on Stats page
