### PR TITLE
fix(#282): require filter, rate-limit, and no-store on bulk PII endpo…

### DIFF
--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -395,7 +395,10 @@ def require_min_filter(
 
     Raises FilterError → 422 with the documented `{detail, filter}` envelope.
     """
-    if county_codes or years or date_range is not None or collision_id is not None:
+    if (county_codes is not None
+            or years is not None
+            or date_range is not None
+            or collision_id is not None):
         return
     raise FilterError(
         "filter",

--- a/backend/app/filters.py
+++ b/backend/app/filters.py
@@ -375,3 +375,31 @@ def build_crash_predicates(
         else:
             preds.append(Crash.hit_run.is_(None))
     return preds
+
+
+def require_min_filter(
+    *,
+    county_codes: set[int] | None,
+    years: set[int] | None,
+    date_range: DateRange | None,
+    collision_id: int | None = None,
+) -> None:
+    """Reject totally unfiltered bulk reads on PII-sensitive endpoints.
+
+    A pageable endpoint that exposes individual-level data (crash rows with
+    coords, or per-party/per-victim demographics) lowers the barrier to bulk
+    re-identification if it can be walked from offset=0 with no filter set.
+    Requiring at least one of county, year/date range, or a single-crash
+    collision_id keeps the result set narrow enough that scraping isn't a
+    one-curl operation.
+
+    Raises FilterError → 422 with the documented `{detail, filter}` envelope.
+    """
+    if county_codes or years or date_range is not None or collision_id is not None:
+        return
+    raise FilterError(
+        "filter",
+        "At least one filter is required: county, year, start/end, "
+        "or collision_id. Unfiltered bulk reads are not permitted on "
+        "this endpoint.",
+    )

--- a/backend/app/routers/crash_people.py
+++ b/backend/app/routers/crash_people.py
@@ -23,6 +23,7 @@ from app.filters import (
     parse_county_codes,
     parse_date_range,
     parse_year,
+    require_min_filter,
     years_from_date_range,
 )
 from app.models import Crash, CrashParty, CrashVictim
@@ -131,7 +132,7 @@ def _parse_gender(raw: str | None) -> set[str] | None:
 
 
 @router.get("/parties", response_model=PaginatedResponse[CrashPartyOut])
-@_limiter.limit("1000/minute;20000/hour")
+@_limiter.limit("60/minute;500/hour")
 def list_parties(
     request: Request,
     response: Response,
@@ -152,6 +153,12 @@ def list_parties(
 ):
     """Paginated cross-crash party query.
 
+    Requires at least one of `county`, `year`/`start`/`end`, or
+    `collision_id` to prevent unfiltered scraping of per-person rows.
+    Rate-limited tighter than the rest of the API (60/min) because each
+    response row is individual-level data even after age/sobriety
+    suppression.
+
     Filters:
       - `collision_id` + `data_source`: drill into one crash (same as
         /api/crashes/{collision_id}/parties but with paging)
@@ -168,6 +175,21 @@ def list_parties(
     age_min_v, age_max_v = _parse_age_range(age_min, age_max)
     gender_set = _parse_gender(gender)
 
+    date_range = parse_date_range(start, end)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    join_years: set[int] | None = None
+    if date_range is not None:
+        join_years = years_from_date_range(date_range)
+    elif year:
+        join_years = parse_year(year)
+
+    require_min_filter(
+        county_codes=county_codes,
+        years=join_years,
+        date_range=date_range,
+        collision_id=collision_id,
+    )
+
     q = db.query(CrashParty)
 
     if collision_id is not None:
@@ -175,26 +197,17 @@ def list_parties(
     if data_source is not None:
         q = q.filter(CrashParty.data_source == data_source)
 
-    date_range = parse_date_range(start, end)
-    needs_join = bool(county) or bool(year) or date_range is not None
+    needs_join = bool(county_codes) or join_years is not None
     if needs_join:
         q = q.join(
             Crash,
             (Crash.collision_id == CrashParty.collision_id)
             & (Crash.data_source == CrashParty.data_source),
         )
-        if county:
-            codes = parse_county_codes(county, get_slug_map(db))
-            if codes:
-                q = q.filter(Crash.county_code.in_(codes))
-        if date_range is not None:
-            years = years_from_date_range(date_range)
-            if years:
-                q = q.filter(Crash.crash_year.in_(years))
-        elif year:
-            years = parse_year(year)
-            if years:
-                q = q.filter(Crash.crash_year.in_(years))
+        if county_codes:
+            q = q.filter(Crash.county_code.in_(county_codes))
+        if join_years:
+            q = q.filter(Crash.crash_year.in_(join_years))
 
     if gender_set:
         q = q.filter(CrashParty.gender.in_(gender_set))
@@ -217,7 +230,7 @@ def list_parties(
 
 
 @router.get("/victims", response_model=PaginatedResponse[CrashVictimOut])
-@_limiter.limit("1000/minute;20000/hour")
+@_limiter.limit("60/minute;500/hour")
 def list_victims(
     request: Request,
     response: Response,
@@ -238,6 +251,10 @@ def list_victims(
 ):
     """Paginated cross-crash victim query (injured + killed + witnesses).
 
+    Requires at least one of `county`, `year`/`start`/`end`, or
+    `collision_id`. Same tighter rate limit as /api/parties for the same
+    reason — each row is individual-level data.
+
     Filters: same shape as /api/parties, plus `person_type` (Driver,
     Pedestrian, Bicyclist, Passenger) and `injury_severity` (Fatal,
     Severe, Possible, etc. — raw CCRS values; not the same vocabulary
@@ -250,6 +267,21 @@ def list_victims(
     age_min_v, age_max_v = _parse_age_range(age_min, age_max)
     gender_set = _parse_gender(gender)
 
+    date_range = parse_date_range(start, end)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    join_years: set[int] | None = None
+    if date_range is not None:
+        join_years = years_from_date_range(date_range)
+    elif year:
+        join_years = parse_year(year)
+
+    require_min_filter(
+        county_codes=county_codes,
+        years=join_years,
+        date_range=date_range,
+        collision_id=collision_id,
+    )
+
     q = db.query(CrashVictim)
 
     if collision_id is not None:
@@ -257,26 +289,17 @@ def list_victims(
     if data_source is not None:
         q = q.filter(CrashVictim.data_source == data_source)
 
-    date_range = parse_date_range(start, end)
-    needs_join = bool(county) or bool(year) or date_range is not None
+    needs_join = bool(county_codes) or join_years is not None
     if needs_join:
         q = q.join(
             Crash,
             (Crash.collision_id == CrashVictim.collision_id)
             & (Crash.data_source == CrashVictim.data_source),
         )
-        if county:
-            codes = parse_county_codes(county, get_slug_map(db))
-            if codes:
-                q = q.filter(Crash.county_code.in_(codes))
-        if date_range is not None:
-            years = years_from_date_range(date_range)
-            if years:
-                q = q.filter(Crash.crash_year.in_(years))
-        elif year:
-            years = parse_year(year)
-            if years:
-                q = q.filter(Crash.crash_year.in_(years))
+        if county_codes:
+            q = q.filter(Crash.county_code.in_(county_codes))
+        if join_years:
+            q = q.filter(Crash.crash_year.in_(join_years))
 
     if gender_set:
         q = q.filter(CrashVictim.gender.in_(gender_set))

--- a/backend/app/routers/crashes.py
+++ b/backend/app/routers/crashes.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session
 from app.county_slug_map import get_slug_map
 from app.database import get_db
 from app.filters import (
-    FilterError,
     build_crash_predicates,
     parse_bool_flag,
     parse_cause,
@@ -26,6 +25,7 @@ from app.filters import (
     parse_severity,
     parse_weather,
     parse_year,
+    require_min_filter,
 )
 from app.models import Crash
 from app.schemas.common import PaginatedResponse
@@ -36,11 +36,14 @@ logger = logging.getLogger(__name__)
 
 # Bounded cost for `?include_total=true` on the 11M-row crashes table.
 # Two layers of defense, because neither is enough alone on B1ms Azure:
-#   1. Filter requirement — unfiltered COUNT(*) takes minutes; we reject
-#      `include_total=true` unless at least one filter is set.
-#   2. statement_timeout — even with filters, broad combinations (e.g.
-#      year + severity only) can take >60s without a covering index
-#      (#106). The timeout caps the worst case and returns total=null.
+#   1. require_min_filter (security + performance) — rejects requests with
+#      no county/year/date_range. Originally protected the unfiltered
+#      COUNT(*) path; #282 extended it to all reads so individual crash
+#      rows (lat/lng + alcohol/distraction flags) can't be walked from
+#      offset=0 without first narrowing the slice.
+#   2. statement_timeout — even with a county/year filter, broad
+#      combinations can take >60s without a covering index (#106). The
+#      timeout caps the worst case and returns total=null.
 # The real fix is covering-index work on the `crashes` table — see #106.
 # Future bulk/export endpoints (see #57) should use their own longer budget.
 COUNT_STATEMENT_TIMEOUT_MS = 5000
@@ -88,11 +91,16 @@ def list_crashes(
       - `distracted=true|false`  (CCRS 2016+ only)
 
     Sorted by `crash_datetime DESC, id DESC`. `total` is `null` by default;
-    set `?include_total=true` to get a count — this requires at least one
-    filter (year, county, severity, cause, alcohol, distracted) to keep the
-    query bounded. For aggregate totals across all crashes, use `/api/stats`.
+    set `?include_total=true` to get a count.
+
+    At least one of `county`, `year`, `start`/`end` is required — unfiltered
+    paginated reads of individual crash rows (lat/lng + alcohol/distraction
+    flags) lower the barrier to bulk re-identification. For aggregate totals
+    across all crashes, use `/api/stats`.
+
+    Cache-Control: `no-store` so a public CDN can't memoize individual rows.
     """
-    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+    response.headers["Cache-Control"] = "no-store"
 
     date_range = parse_date_range(start, end)
     years = parse_year(year) if date_range is None else None
@@ -111,21 +119,11 @@ def list_crashes(
     road_type_v = parse_road_type(road_type)
     hit_run_v = parse_hit_run(hit_run)
 
-    if include_total and not any([
-        date_range is not None, years, county_codes, severities, causes,
-        alcohol_v is not None, distracted_v is not None,
-        pedestrian_v is not None, cyclist_v is not None,
-        drug_v is not None, driver_age_v is not None,
-        weather_v, lighting_v, collision_type_v,
-        road_type_v is not None, hit_run_v is not None,
-    ]):
-        raise FilterError(
-            "include_total",
-            "include_total=true requires at least one filter (start/end, "
-            "year, county, severity, cause, alcohol, distracted, pedestrian, "
-            "cyclist, drug, driver_age). Unbounded COUNT(*) over 11M crashes "
-            "is too slow. For aggregate totals, use /api/stats.",
-        )
+    require_min_filter(
+        county_codes=county_codes,
+        years=years,
+        date_range=date_range,
+    )
 
     preds = build_crash_predicates(
         years=years,

--- a/backend/tests/api/test_crash_people.py
+++ b/backend/tests/api/test_crash_people.py
@@ -5,6 +5,11 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
+# Covers the CCRS-era seeded crashes, where all parties/victims live. Required
+# minimum filter as of #282 — /api/parties and /api/victims need at least one
+# of county / year / start-end / collision_id.
+CCRS_YEARS = "year=2022,2023"
+
 
 # ── Drill-down (B1) ───────────────────────────────────────────────────
 
@@ -53,7 +58,7 @@ def test_drill_down_victims_empty_for_pdo_crash(client):
 
 
 def test_parties_pagination(client):
-    response = client.get("/api/parties?limit=2")
+    response = client.get(f"/api/parties?{CCRS_YEARS}&limit=2")
     assert response.status_code == 200
     body = response.json()
     assert body["limit"] == 2
@@ -62,20 +67,20 @@ def test_parties_pagination(client):
 
 
 def test_parties_filter_by_gender(client):
-    response = client.get("/api/parties?gender=f")
+    response = client.get(f"/api/parties?{CCRS_YEARS}&gender=f")
     body = response.json()
     assert all(p["gender"] == "F" for p in body["items"])
 
 
 def test_parties_filter_by_age_range(client):
-    response = client.get("/api/parties?age_min=20&age_max=30")
+    response = client.get(f"/api/parties?{CCRS_YEARS}&age_min=20&age_max=30")
     body = response.json()
     for p in body["items"]:
         assert p["age_bracket"] is None or p["age_bracket"] in ("16-24", "25-34")
 
 
 def test_parties_filter_at_fault(client):
-    response = client.get("/api/parties?at_fault=true")
+    response = client.get(f"/api/parties?{CCRS_YEARS}&at_fault=true")
     body = response.json()
     assert all(p["at_fault"] is True for p in body["items"])
 
@@ -97,34 +102,64 @@ def test_parties_collision_id_filter(client):
 
 
 def test_parties_rejects_bad_age_range(client):
-    response = client.get("/api/parties?age_min=50&age_max=20")
+    response = client.get(f"/api/parties?{CCRS_YEARS}&age_min=50&age_max=20")
     assert response.status_code == 422
     assert response.json()["filter"] == "age_min"
 
 
 def test_parties_rejects_unknown_gender(client):
-    response = client.get("/api/parties?gender=z")
+    response = client.get(f"/api/parties?{CCRS_YEARS}&gender=z")
     assert response.status_code == 422
     assert response.json()["filter"] == "gender"
 
 
+def test_parties_requires_minimum_filter(client):
+    """Per #282 — bulk /api/parties without a filter returns 422."""
+    response = client.get("/api/parties")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "filter"
+
+
+def test_parties_collision_id_alone_is_sufficient(client):
+    """collision_id targets a single crash, so a county/year filter isn't
+    additionally required."""
+    response = client.get("/api/parties?collision_id=100&data_source=ccrs")
+    assert response.status_code == 200
+
+
+def test_parties_cache_header_is_no_store(client):
+    response = client.get(f"/api/parties?{CCRS_YEARS}")
+    assert response.headers.get("cache-control") == "no-store"
+
+
 def test_victims_pagination(client):
-    response = client.get("/api/victims?limit=2")
+    response = client.get(f"/api/victims?{CCRS_YEARS}&limit=2")
     body = response.json()
     assert body["limit"] == 2
     assert body["total"] is None
 
 
 def test_victims_filter_injury_severity(client):
-    response = client.get("/api/victims?injury_severity=Fatal")
+    response = client.get(f"/api/victims?{CCRS_YEARS}&injury_severity=Fatal")
     body = response.json()
     assert all(v["injury_severity"] == "Fatal" for v in body["items"])
 
 
 def test_victims_filter_person_type(client):
-    response = client.get("/api/victims?person_type=Pedestrian")
+    response = client.get(f"/api/victims?{CCRS_YEARS}&person_type=Pedestrian")
     body = response.json()
     assert all(v["person_type"] == "Pedestrian" for v in body["items"])
+
+
+def test_victims_requires_minimum_filter(client):
+    response = client.get("/api/victims")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "filter"
+
+
+def test_victims_cache_header_is_no_store(client):
+    response = client.get(f"/api/victims?{CCRS_YEARS}")
+    assert response.headers.get("cache-control") == "no-store"
 
 
 def test_victims_county_filter_via_join(client):

--- a/backend/tests/api/test_crashes.py
+++ b/backend/tests/api/test_crashes.py
@@ -4,9 +4,13 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
+# Covers every seeded crash year. /api/crashes requires a county/year/date_range
+# filter as of #282 to prevent unfiltered bulk reads of per-crash rows.
+ALL_YEARS = "year=2014,2015,2022,2023"
+
 
 def test_crashes_returns_items_and_pagination(client):
-    response = client.get("/api/crashes?limit=10")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&limit=10")
     assert response.status_code == 200
     body = response.json()
     assert body["limit"] == 10
@@ -28,25 +32,25 @@ def test_crashes_filter_by_county(client):
 
 
 def test_crashes_filter_by_severity_fatal(client):
-    response = client.get("/api/crashes?severity=fatal")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&severity=fatal")
     body = response.json()
     assert all(c["severity"] == "Fatal" for c in body["items"])
 
 
 def test_crashes_filter_by_cause_dui(client):
-    response = client.get("/api/crashes?cause=dui")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&cause=dui")
     body = response.json()
     assert all(c["canonical_cause"] == "dui" for c in body["items"])
 
 
 def test_crashes_filter_cause_lane_change_translates_hyphen(client):
-    response = client.get("/api/crashes?cause=lane-change")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&cause=lane-change")
     body = response.json()
     assert all(c["canonical_cause"] == "lane_change" for c in body["items"])
 
 
 def test_crashes_alcohol_flag_excludes_switrs(client):
-    response = client.get("/api/crashes?alcohol=true")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&alcohol=true")
     body = response.json()
     ids = {c["id"] for c in body["items"]}
     assert 3 in ids
@@ -55,7 +59,7 @@ def test_crashes_alcohol_flag_excludes_switrs(client):
 
 
 def test_crashes_distracted_flag(client):
-    response = client.get("/api/crashes?distracted=true")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&distracted=true")
     body = response.json()
     ids = {c["id"] for c in body["items"]}
     # Only crash id=4 was seeded with is_distraction_involved=True.
@@ -81,7 +85,7 @@ def test_crashes_rejects_unknown_county(client):
 
 
 def test_crashes_sort_descending_by_datetime(client):
-    response = client.get("/api/crashes?limit=10")
+    response = client.get(f"/api/crashes?{ALL_YEARS}&limit=10")
     body = response.json()
     dts = [c["crash_datetime"] for c in body["items"]]
     assert dts == sorted(dts, reverse=True)
@@ -106,21 +110,34 @@ def test_crashes_join_key_is_collision_plus_source(client):
     assert any(c["collision_id"] == 100 for c in r2)
 
 
-def test_crashes_cache_header(client):
+def test_crashes_cache_header_is_no_store(client):
+    """Per #282 — public CDNs shouldn't memoize per-crash rows."""
+    response = client.get(f"/api/crashes?{ALL_YEARS}")
+    assert response.headers.get("cache-control") == "no-store"
+
+
+def test_crashes_requires_minimum_filter(client):
+    """Per #282 — unfiltered bulk reads of crash rows are rejected.
+    At least one of county / year / start+end is required."""
     response = client.get("/api/crashes")
-    assert response.headers.get("cache-control") == "public, max-age=3600, stale-while-revalidate=86400"
-
-
-def test_crashes_include_total_without_filter_returns_422(client):
-    """Unfiltered include_total=true is rejected — would require a multi-minute
-    COUNT(*) over 11M rows. Users should add a filter or use /api/stats for
-    aggregate totals. Proper fix is the covering index in #106."""
-    response = client.get("/api/crashes?include_total=true")
     assert response.status_code == 422
     body = response.json()
-    assert body["filter"] == "include_total"
-    assert "at least one filter" in body["detail"]
-    assert "/api/stats" in body["detail"]
+    assert body["filter"] == "filter"
+    assert "county" in body["detail"]
+
+
+def test_crashes_requires_filter_even_for_include_total(client):
+    """Same minimum-filter requirement applies regardless of include_total."""
+    response = client.get("/api/crashes?include_total=true")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "filter"
+
+
+def test_crashes_accepts_other_filters_alongside_minimum(client):
+    """severity / cause / alcohol filters are still valid — they just can't
+    appear alone without one of county / year / date range."""
+    response = client.get(f"/api/crashes?{ALL_YEARS}&severity=fatal")
+    assert response.status_code == 200
 
 
 def test_crashes_include_total_timeout_returns_null(client, monkeypatch):

--- a/frontend/src/components/map/DataExportPanel.tsx
+++ b/frontend/src/components/map/DataExportPanel.tsx
@@ -65,8 +65,10 @@ export default function DataExportPanel() {
   const scope = useMemo(() => computeFilterScope(filterState), [filterState]);
   const filterQs = useMemo(() => buildFilterQS(searchParams), [searchParams]);
 
-  // CSV requires at least one filter (matches /api/crashes?include_total=true).
-  const csvBlocked = activeFormat === "csv" && !scope.hasAnyFilter;
+  // CSV export hits /api/crashes, which requires a county or date filter
+  // (per #282). Other narrowings (severity/cause/flags) aren't enough on
+  // their own — the backend rejects unfiltered bulk reads.
+  const csvBlocked = activeFormat === "csv" && !scope.hasScopeFilter;
   const isRunning = phase.kind === "running";
 
   // Snapshot the latest values on a ref so the event handler always reads
@@ -85,7 +87,7 @@ export default function DataExportPanel() {
       try {
         if (fmt === "csv") {
           if (blocked) {
-            failExport("csv", "Apply at least one filter to export a CSV.");
+            failExport("csv", "Pick a county or date range before exporting a CSV.");
             return;
           }
           abortRef.current?.abort();
@@ -269,7 +271,7 @@ export default function DataExportPanel() {
       {csvBlocked && phase.kind === "idle" && (
         <div className="bg-surface-container rounded-lg p-4 text-[11px] text-on-surface-variant leading-snug">
           <span className="material-symbols-outlined text-base align-middle mr-1">info</span>
-          CSV export requires at least one filter (county, year, severity, etc.) so the file stays a sensible size.
+          CSV export needs a county or date-range filter — that keeps the file small enough to download and prevents bulk re-identification of individual rows.
         </div>
       )}
     </div>

--- a/frontend/src/lib/export/filterSummary.test.ts
+++ b/frontend/src/lib/export/filterSummary.test.ts
@@ -138,6 +138,28 @@ describe("computeFilterScope", () => {
     expect(s.rows.find((r) => r.label === "Road type")).toBeUndefined();
   });
 
+  it("hasScopeFilter is only true when a county or date range is set", () => {
+    // No filters at all
+    expect(computeFilterScope(empty).hasScopeFilter).toBe(false);
+
+    // Other filters alone don't count — they don't narrow the row set
+    // enough for /api/crashes (per #282 server-side rule).
+    expect(computeFilterScope({ ...empty, severities: new Set(["Fatal"]) }).hasScopeFilter).toBe(false);
+    expect(computeFilterScope({ ...empty, weather: new Set(["rain"]) }).hasScopeFilter).toBe(false);
+    expect(computeFilterScope({ ...empty, alcohol: true }).hasScopeFilter).toBe(false);
+
+    // County alone is enough
+    expect(computeFilterScope({ ...empty, counties: new Set(["Los Angeles"]) }).hasScopeFilter).toBe(true);
+
+    // Date range alone is enough
+    expect(
+      computeFilterScope({
+        ...empty,
+        dateRange: { start: { year: 2023, month: 1 }, end: null },
+      }).hasScopeFilter,
+    ).toBe(true);
+  });
+
   it("handles open-ended date ranges", () => {
     const startOnly = computeFilterScope({
       ...empty,

--- a/frontend/src/lib/export/filterSummary.ts
+++ b/frontend/src/lib/export/filterSummary.ts
@@ -53,9 +53,13 @@ const ROAD_TYPE_LABELS: Record<string, string> = {
 };
 
 export type FilterScope = {
-  /** Was this dimension narrowed at all? Used to gate the CSV
-   *  "must filter first" precondition. */
+  /** Was any dimension narrowed at all? Used for display copy. */
   hasAnyFilter: boolean;
+  /** Has the user narrowed to a county OR a date range? CSV export requires
+   *  this — the backend's /api/crashes endpoint rejects unfiltered bulk
+   *  reads per #282 to prevent unrestricted scraping of per-row coords +
+   *  alcohol/distraction flags. */
+  hasScopeFilter: boolean;
   /** {label, value} pairs for table-style rendering. */
   rows: { label: string; value: string }[];
   /** Compact one-line description, e.g. "Los Angeles · 2022-01 → 2023-12 · Fatal" */
@@ -181,6 +185,10 @@ export function computeFilterScope(state: FilterState): FilterScope {
     state.collisionType.size > 0 ||
     state.roadType != null;
 
+  // Backend gate for /api/crashes — only county or date narrows the row set
+  // enough to allow a bulk read; severity/cause/flag-only filters don't.
+  const hasScopeFilter = state.dateRange != null || state.counties.size > 0;
+
   const oneLineParts: string[] = [];
   if (state.counties.size > 0) oneLineParts.push(countyLabel);
   if (state.dateRange) oneLineParts.push(dateLabel);
@@ -207,5 +215,5 @@ export function computeFilterScope(state: FilterState): FilterScope {
     return parts.length > 0 ? `_${parts.join("_")}` : "";
   })();
 
-  return { hasAnyFilter, rows, oneLine, filenameSuffix };
+  return { hasAnyFilter, hasScopeFilter, rows, oneLine, filenameSuffix };
 }


### PR DESCRIPTION
## Summary
  Closes #282.

  ZAP DAST flagged 6 endpoints for potential PII re-identification. The
  age/sobriety field-level suppression and per-row `Cache-Control:
  no-store` on parties/victims already shipped in a prior PR — this PR
  closes the remaining gaps:

  1. **Minimum filter required on bulk endpoints.** `/api/crashes`,
     `/api/parties`, `/api/victims` now reject requests with no
     `county`, `year`, `start`/`end`, or `collision_id`. Unfiltered
     pagination of per-row data was the main re-identification vector.
  2. **Tighter rate limit on `/api/parties` and `/api/victims`.**
     `1000/minute;20000/hour` → `60/minute;500/hour`. Drill-down
     endpoints (`/crashes/{id}/...`) keep the higher limit — they
     return only the parties of one crash and pose less aggregation
     risk.
  3. **`Cache-Control: no-store` on `/api/crashes`.** Was
     `public, max-age=3600` — a public CDN could memoize individual
     rows including coordinates and alcohol/distraction flags. Bulk
     parties/victims were already `no-store`.
  4. **Frontend gate matches server rule.** `FilterScope` gains a
     `hasScopeFilter` boolean (county or date range set). The CSV
     export gate uses it so the frontend pre-flight catches what the
     server would have rejected. Other filters (severity, cause, etc.)
     still count as "any filter" for display copy but don't unlock CSV
     on their own.

  ### What I did NOT do, and why
  - **Auth gate (issue fix #1)**: API keys conflict with CalSight's
    public-data-explorer mission. The combination of no-store + minimum
    filter + tighter rate limit substantially raises the bar for bulk
    re-identification without gating public access. Worth a separate
    conversation if Jeff wants to revisit.
  - **ZAP false-positive suppression (issue fix #7)**: no ZAP
    configuration exists in the repo. CI runs CodeQL + Bandit + npm
    audit; the DAST scan that produced the original report must have
    been external. There's nothing to suppress.
  - **age_bracket / impaired / no-store on parties/victims (issue fixes
    #2, #3, #5)**: already shipped — see
    `backend/app/schemas/crash_people.py`. Confirmed via existing tests.

  ## Dependencies
  None.

  ## How to test
  1. **Backend rejects unfiltered bulk**:
     - `curl http://localhost:8000/api/crashes` → 422
     - `curl http://localhost:8000/api/parties` → 422
     - `curl http://localhost:8000/api/victims` → 422
     - All return `{detail: "At least one filter is required…", filter: "filter"}`
  2. **With a county or year, they succeed**:
     - `curl 'http://localhost:8000/api/crashes?county=los-angeles'` → 200
     - `curl 'http://localhost:8000/api/parties?year=2023'` → 200
  3. **Single-crash drill-down via collision_id is sufficient for parties/victims**:
     - `curl 'http://localhost:8000/api/parties?collision_id=100&data_source=ccrs'` → 200
  4. **Cache header**:
     - `curl -I 'http://localhost:8000/api/crashes?county=los-angeles' | grep -i cache-control`
       → `Cache-Control: no-store`
  5. **Frontend CSV export**:
     - Open Data Export panel with no county/date — CSV is gated with
       "Pick a county or date range before exporting a CSV."
     - Pick a county or date — CSV unlocks; download succeeds.

  ## Checklist
  - [x] `pytest tests/` — 511/511 passing (10 new)
  - [x] `npm test` — 406/406 passing (1 new)
  - [x] `npx tsc --noEmit` clean
  - [x] `ruff check` clean
  - [ ] Manual smoke (steps 1–5 above)