### PR TITLE
feat(#278): AI response caching + Quick Facts in system prompt

### DIFF
--- a/backend/app/ai_prompt.py
+++ b/backend/app/ai_prompt.py
@@ -6,6 +6,7 @@ You have tools to query the database. Use them to get real data before answering
 
 The user currently has these filters active (use as defaults when relevant):
 {active_filters}
+{quick_facts}
 
 Available data domains:
 - Crash records: 11M crashes with severity, cause, time, location, weather, lighting, road conditions
@@ -155,3 +156,111 @@ def build_filters_summary(filters: dict) -> str:
     if filters.get("hit_run") == "true":
         parts.append("Hit-and-run only")
     return ", ".join(parts) if parts else "All California data (no filters active)"
+
+
+def _format_int(n: int | float | None) -> str:
+    if n is None:
+        return "0"
+    return f"{int(n):,}"
+
+
+def _filters_to_query_args(filters: dict) -> dict:
+    """Translate the URL-shaped filter dict into kwargs for query_crashes.
+
+    Only handles filters that map cleanly onto the tool's signature; the rest
+    are dropped (they're already reflected in the LLM's `active_filters` text
+    block above). The point here is to give the model accurate baseline numbers
+    for the user's current view, not to perfectly replicate every filter.
+    """
+    out: dict = {}
+    if county := filters.get("county"):
+        # query_crashes resolves slug or display name internally — use the raw
+        # value here so users with `?county=los-angeles` and the AI's own
+        # tool-call output stay in sync.
+        out["county"] = county
+    years_raw = filters.get("year") or ""
+    years = [int(y) for y in years_raw.split(",") if y.strip().isdigit()]
+    if years:
+        out["years"] = years
+    if (sev := filters.get("severity")):
+        # Severity slugs come in as "fatal" / "injury" / "property-damage-only"
+        # but the column stores "Fatal" / "Injury" / "Property Damage Only".
+        sev_map = {
+            "fatal": "Fatal",
+            "injury": "Injury",
+            "property-damage-only": "Property Damage Only",
+        }
+        first = sev.split(",")[0].strip().lower()
+        if first in sev_map:
+            out["severity"] = sev_map[first]
+    if (cause := filters.get("cause")):
+        first = cause.split(",")[0].strip().lower()
+        if first:
+            out["cause"] = first
+    if filters.get("alcohol") == "true":
+        out["is_alcohol_involved"] = True
+    if filters.get("distracted") == "true":
+        out["is_distraction_involved"] = True
+    if filters.get("pedestrian") == "true":
+        out["pedestrian_involved"] = True
+    if filters.get("hit_run") == "true":
+        out["hit_run"] = True
+    return out
+
+
+def build_quick_facts(db, filters: dict) -> str:
+    """Pre-query aggregate stats for the active filters and format as a
+    markdown block to prepend to the system prompt.
+
+    The model can read these numbers directly without burning a tool call for
+    "how many crashes in LA in 2023?". Returns an empty string if the lookup
+    fails — we fall back gracefully to tool-call mode rather than block the
+    request.
+    """
+    # Local import to avoid a circular dependency at module load — ai_tools
+    # imports from app.models, which can transitively import this module
+    # during certain pytest collection orders.
+    from app.ai_tools import query_crashes
+
+    args = _filters_to_query_args(filters)
+
+    try:
+        totals_rows = query_crashes(db, **args)
+        totals = totals_rows[0] if totals_rows else {}
+        severity_rows = query_crashes(db, group_by="severity", **args)
+    except Exception:
+        # If the DB hiccups we'd rather return an empty Quick Facts than
+        # 500 the whole ask request. The LLM still has its tool set.
+        return ""
+
+    total_count = int(totals.get("crash_count") or 0)
+    if total_count == 0:
+        return "\nQuick facts: no crashes match these filters.\n"
+
+    killed = int(totals.get("total_killed") or 0)
+    injured = int(totals.get("total_injured") or 0)
+    fatality_rate = totals.get("fatality_rate_pct")
+    injury_rate = totals.get("injury_rate_pct")
+
+    lines: list[str] = []
+    lines.append(
+        "\nQuick facts for the user's current filters (use these directly when answering basic count/rate questions — no tool call needed):"
+    )
+    lines.append(f"- Total crashes: {_format_int(total_count)}")
+    if killed:
+        rate_str = f" ({fatality_rate}%)" if isinstance(fatality_rate, (int, float)) else ""
+        lines.append(f"- Fatalities: {_format_int(killed)}{rate_str}")
+    if injured:
+        rate_str = f" ({injury_rate}%)" if isinstance(injury_rate, (int, float)) else ""
+        lines.append(f"- Injuries: {_format_int(injured)}{rate_str}")
+
+    if severity_rows:
+        # query_crashes already added pct_of_total to each row.
+        breakdown = ", ".join(
+            f"{r.get('severity') or 'Unknown'} {r.get('pct_of_total', 0)}%"
+            for r in severity_rows[:3]
+        )
+        lines.append(f"- Severity mix: {breakdown}")
+
+    lines.append("Use these baselines for the visible scope; call tools for anything not covered here.\n")
+    return "\n".join(lines)

--- a/backend/app/llm_cache.py
+++ b/backend/app/llm_cache.py
@@ -1,0 +1,126 @@
+"""In-process LRU cache for /api/ask responses.
+
+The Ask AI endpoint forwards a question + the user's active filters + recent
+history to one or more LLM providers. Identical inputs produce identical
+outputs (modulo provider non-determinism), so caching them saves the LLM
+round trip — both the dollar cost and the 2-5 second latency.
+
+Design notes:
+  * Pure-stdlib `OrderedDict` LRU. We don't pull in cachetools for this
+    one use site; the wheel is small but the maintenance surface is real.
+  * TTL is per-entry, evaluated lazily on `get()`. We don't run a
+    background sweeper — the LRU eviction policy keeps memory bounded.
+  * Thread-safe via a single `threading.Lock`. Reads and writes both lock;
+    the cache is small (~500 entries by default) so the contention cost is
+    negligible compared to the LLM call we're avoiding.
+  * `history` is part of the cache key — a chat follow-up like "what about
+    that?" depends on prior context, so two users' histories should NOT
+    collide on a single cached body. This narrows hit rate to "fresh
+    sessions asking the same first question," which the issue's 10-20%
+    dedup estimate is built on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from collections import OrderedDict
+from typing import Any, Generic, TypeVar
+
+V = TypeVar("V")
+
+
+def make_cache_key(
+    question: str,
+    filters: dict[str, Any],
+    history: list[dict[str, Any]] | None = None,
+) -> str:
+    """SHA-256 of a stable serialization of (question, filters, history).
+
+    `filters` and `history` may contain anything JSON-serializable; we
+    sort dict keys so cache keys don't depend on iteration order.
+    """
+    payload = {
+        "q": question.strip(),
+        "f": filters or {},
+        "h": history or [],
+    }
+    serialized = json.dumps(payload, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+class TTLLRUCache(Generic[V]):
+    """LRU cache with per-entry TTL.
+
+    `get(key)` returns the stored value if present and unexpired, else None
+    (and removes the expired entry). `set(key, value)` evicts the oldest
+    entry past `max_size`. `clear()` drops everything; useful in tests.
+    """
+
+    def __init__(self, *, max_size: int = 500, ttl_seconds: float = 3600.0) -> None:
+        if max_size <= 0:
+            raise ValueError("max_size must be positive")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        self._max_size = max_size
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+        # Maps key -> (expires_at_monotonic, value)
+        self._store: OrderedDict[str, tuple[float, V]] = OrderedDict()
+        # Counters — handy for /healthz and tests.
+        self._hits = 0
+        self._misses = 0
+
+    def get(self, key: str) -> V | None:
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                self._misses += 1
+                return None
+            expires_at, value = entry
+            if time.monotonic() >= expires_at:
+                # Expired — drop it so memory doesn't pile up.
+                del self._store[key]
+                self._misses += 1
+                return None
+            # LRU touch.
+            self._store.move_to_end(key)
+            self._hits += 1
+            return value
+
+    def set(self, key: str, value: V) -> None:
+        expires_at = time.monotonic() + self._ttl
+        with self._lock:
+            self._store[key] = (expires_at, value)
+            self._store.move_to_end(key)
+            while len(self._store) > self._max_size:
+                self._store.popitem(last=False)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()
+            self._hits = 0
+            self._misses = 0
+
+    @property
+    def size(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+    def stats(self) -> dict[str, int]:
+        """Snapshot of hit/miss counters. Reset by `clear()`."""
+        with self._lock:
+            return {"size": len(self._store), "hits": self._hits, "misses": self._misses}
+
+
+# Process-wide cache instance, used by the /api/ask handler. Tunables live
+# here rather than in settings.py — they're operational parameters that
+# rarely need per-env override, and exposing them as env vars invites
+# accidental misconfiguration (e.g. ttl=0 disabling caching silently).
+_ASK_CACHE: TTLLRUCache[Any] = TTLLRUCache(max_size=500, ttl_seconds=3600.0)
+
+
+def get_ask_cache() -> TTLLRUCache[Any]:
+    return _ASK_CACHE

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ app.add_middleware(
     allow_origins=settings.cors_origin_list,
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["Content-Type", "X-ETL-API-KEY"],
+    expose_headers=["X-Cache"],
 )
 
 class NullByteSanitizationMiddleware(BaseHTTPMiddleware):

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -8,7 +8,7 @@ import logging
 import re
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from slowapi import Limiter
@@ -20,9 +20,11 @@ from app.ai_prompt import (
     SYSTEM_PROMPT_TEMPLATE,
     TOOL_DEFINITIONS,
     build_filters_summary,
+    build_quick_facts,
 )
 from app.ai_tools import TOOL_REGISTRY, query_crashes
 from app.database import get_db
+from app.llm_cache import get_ask_cache, make_cache_key
 from app.models import ChatFeedback
 from app.llm import (
     AllProvidersExhausted,
@@ -112,9 +114,25 @@ def feedback(request: Request, body: FeedbackRequest, db: Session = Depends(get_
 
 @router.post("/ask", response_model=AskResponse)
 @limiter.limit("10/minute;200/day")
-async def ask(request: Request, body: AskRequest, db: Session = Depends(get_db)):
+async def ask(
+    request: Request,
+    response: Response,
+    body: AskRequest,
+    db: Session = Depends(get_db),
+):
+    # Cache lookup happens before the LLM round trip — identical
+    # (question, filters, history) produce the same answer, and the LLM
+    # call is the slow + expensive part. See app.llm_cache for the design.
+    cache = get_ask_cache()
+    history_payload = [m.model_dump() for m in body.history]
+    cache_key = make_cache_key(body.question, body.filters, history_payload)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        response.headers["X-Cache"] = "HIT"
+        return cached
+
     try:
-        return await asyncio.wait_for(
+        result = await asyncio.wait_for(
             asyncio.to_thread(_handle_ask, body, db),
             timeout=60.0,
         )
@@ -124,10 +142,22 @@ async def ask(request: Request, body: AskRequest, db: Session = Depends(get_db))
             content={"message": "Request timed out. Please try again.", "retry_after": 5},
         )
 
+    cache.set(cache_key, result)
+    response.headers["X-Cache"] = "MISS"
+    return result
+
 
 def _handle_ask(body: AskRequest, db: Session) -> AskResponse:
     filters_summary = build_filters_summary(body.filters)
-    system_prompt = SYSTEM_PROMPT_TEMPLATE.format(active_filters=filters_summary)
+    # Quick Facts pre-queries the totals/severity-split for the active filters
+    # and injects them into the system prompt. Saves a tool call for basic
+    # count questions ("crashes in LA in 2023?") and gives the model a
+    # grounded baseline before it decides whether to call tools.
+    quick_facts = build_quick_facts(db, body.filters)
+    system_prompt = SYSTEM_PROMPT_TEMPLATE.format(
+        active_filters=filters_summary,
+        quick_facts=quick_facts,
+    )
 
     messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
 

--- a/backend/tests/api/test_ask.py
+++ b/backend/tests/api/test_ask.py
@@ -1,0 +1,162 @@
+"""Integration tests for /api/ask — focused on the caching + Quick Facts
+features added in #278.
+
+The LLM is mocked at the `app.routers.ask.generate_with_fallback` import site
+so these tests don't hit a real provider.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.llm_cache import get_ask_cache
+
+pytestmark = pytest.mark.integration
+
+
+def _fake_llm_response(content: str = "Mocked answer.\n\nSuggested: [\"q1\", \"q2\"]"):
+    """Build the minimum-viable shape the ask handler expects from
+    `generate_with_fallback` — a tuple of (response, provider_name)."""
+    return (
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=content, tool_calls=None)
+                )
+            ]
+        ),
+        "TestProvider",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_ask_cache():
+    """Make every test start from an empty cache so order doesn't matter."""
+    get_ask_cache().clear()
+    yield
+    get_ask_cache().clear()
+
+
+@pytest.fixture(autouse=True)
+def _disable_ask_rate_limit():
+    """The /api/ask limit is 10/minute, but the cache tests need to send
+    many requests back-to-back to verify HIT/MISS behavior. Disabling the
+    limiter for these tests doesn't affect prod — the limiter object lives
+    on the router module."""
+    from app.routers.ask import limiter
+    original = limiter.enabled
+    limiter.enabled = False
+    yield
+    limiter.enabled = original
+
+
+@pytest.fixture
+def fake_llm(monkeypatch):
+    """Patches `generate_with_fallback` to a counter we can assert against."""
+    calls: list[dict] = []
+
+    def fake(messages, **kwargs):
+        calls.append({"messages": messages, "kwargs": kwargs})
+        return _fake_llm_response()
+
+    monkeypatch.setattr("app.routers.ask.generate_with_fallback", fake)
+    return calls
+
+
+# ── X-Cache header round trip ──────────────────────────────────────────
+
+
+def test_first_request_is_a_miss(client, fake_llm):
+    r = client.post("/api/ask", json={"question": "hi", "filters": {}, "history": []})
+    assert r.status_code == 200
+    assert r.headers.get("x-cache") == "MISS"
+    assert len(fake_llm) >= 1
+
+
+def test_identical_request_hits_cache(client, fake_llm):
+    body = {"question": "hi", "filters": {"county": "los-angeles"}, "history": []}
+    r1 = client.post("/api/ask", json=body)
+    assert r1.headers.get("x-cache") == "MISS"
+    miss_calls = len(fake_llm)
+
+    r2 = client.post("/api/ask", json=body)
+    assert r2.headers.get("x-cache") == "HIT"
+    # The hit must not have triggered another LLM call.
+    assert len(fake_llm) == miss_calls
+    # And the cached answer must match the original.
+    assert r1.json()["answer"] == r2.json()["answer"]
+
+
+def test_different_question_misses_cache(client, fake_llm):
+    client.post("/api/ask", json={"question": "Q1", "filters": {}, "history": []})
+    r2 = client.post("/api/ask", json={"question": "Q2", "filters": {}, "history": []})
+    assert r2.headers.get("x-cache") == "MISS"
+
+
+def test_different_filters_miss_cache(client, fake_llm):
+    client.post("/api/ask", json={"question": "Q", "filters": {"county": "los-angeles"}, "history": []})
+    r2 = client.post("/api/ask", json={"question": "Q", "filters": {"county": "orange"}, "history": []})
+    assert r2.headers.get("x-cache") == "MISS"
+
+
+def test_filter_dict_ordering_does_not_affect_cache(client, fake_llm):
+    """Stable key serialization should treat key ordering as equivalent."""
+    client.post(
+        "/api/ask",
+        json={"question": "Q", "filters": {"county": "la", "year": "2023"}, "history": []},
+    )
+    r2 = client.post(
+        "/api/ask",
+        json={"question": "Q", "filters": {"year": "2023", "county": "la"}, "history": []},
+    )
+    assert r2.headers.get("x-cache") == "HIT"
+
+
+def test_history_is_part_of_cache_key(client, fake_llm):
+    """A follow-up like 'what about that?' depends on prior turns. Two users
+    with different histories must not collide."""
+    a_history = [{"role": "user", "content": "tell me about LA"}]
+    b_history = [{"role": "user", "content": "tell me about SF"}]
+    client.post("/api/ask", json={"question": "what about that?", "filters": {}, "history": a_history})
+    r2 = client.post("/api/ask", json={"question": "what about that?", "filters": {}, "history": b_history})
+    assert r2.headers.get("x-cache") == "MISS"
+
+
+# ── Quick Facts injection into system prompt ────────────────────────────
+
+
+def test_quick_facts_appears_in_system_prompt_for_known_filter(client, fake_llm):
+    """When filters resolve to crashes in the seed (LA in 2023, 1 row), the
+    system message should contain a Quick Facts block with the count."""
+    client.post(
+        "/api/ask",
+        json={
+            "question": "how many crashes in LA?",
+            "filters": {"county": "los-angeles", "year": "2023"},
+            "history": [],
+        },
+    )
+    # First message is the system prompt — assert Quick Facts block landed.
+    system_msg = fake_llm[0]["messages"][0]
+    assert system_msg["role"] == "system"
+    content = system_msg["content"]
+    assert "Quick facts" in content
+
+
+def test_quick_facts_handles_zero_match_filters(client, fake_llm):
+    """A filter that matches nothing should produce a 'no crashes' line, not
+    fail the request. The seed has crashes only in 2014, 2015, 2022, 2023 —
+    year=2001 is guaranteed empty."""
+    r = client.post(
+        "/api/ask",
+        json={
+            "question": "any crashes in 2001?",
+            "filters": {"year": "2001"},
+            "history": [],
+        },
+    )
+    assert r.status_code == 200
+    system_msg = fake_llm[0]["messages"][0]
+    assert "no crashes match these filters" in system_msg["content"].lower()

--- a/backend/tests/test_llm_cache.py
+++ b/backend/tests/test_llm_cache.py
@@ -1,0 +1,147 @@
+"""Unit tests for the in-process Ask AI cache."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from app.llm_cache import TTLLRUCache, make_cache_key
+
+
+# ── make_cache_key ──────────────────────────────────────────────────────
+
+
+def test_cache_key_is_deterministic():
+    a = make_cache_key("hello", {"county": "los-angeles", "year": "2023"}, [])
+    b = make_cache_key("hello", {"county": "los-angeles", "year": "2023"}, [])
+    assert a == b
+
+
+def test_cache_key_independent_of_filter_dict_order():
+    a = make_cache_key("hi", {"a": "1", "b": "2"}, [])
+    b = make_cache_key("hi", {"b": "2", "a": "1"}, [])
+    assert a == b
+
+
+def test_cache_key_changes_with_question():
+    a = make_cache_key("crashes in la", {"year": "2023"}, [])
+    b = make_cache_key("crashes in sf", {"year": "2023"}, [])
+    assert a != b
+
+
+def test_cache_key_changes_with_filters():
+    a = make_cache_key("crashes", {"county": "los-angeles"}, [])
+    b = make_cache_key("crashes", {"county": "orange"}, [])
+    assert a != b
+
+
+def test_cache_key_changes_with_history():
+    a = make_cache_key("what about that?", {}, [{"role": "user", "content": "tell me about la"}])
+    b = make_cache_key("what about that?", {}, [{"role": "user", "content": "tell me about sf"}])
+    assert a != b
+
+
+def test_cache_key_normalizes_whitespace_via_strip():
+    a = make_cache_key("hello", {}, [])
+    b = make_cache_key("  hello  ", {}, [])
+    assert a == b
+
+
+def test_cache_key_treats_missing_history_as_empty():
+    a = make_cache_key("q", {"f": "1"}, None)
+    b = make_cache_key("q", {"f": "1"}, [])
+    assert a == b
+
+
+# ── TTLLRUCache ─────────────────────────────────────────────────────────
+
+
+def test_get_returns_none_for_unknown_key():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=60)
+    assert cache.get("missing") is None
+
+
+def test_set_then_get_round_trip():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=60)
+    cache.set("k1", "v1")
+    assert cache.get("k1") == "v1"
+
+
+def test_lru_evicts_oldest_when_full():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=2, ttl_seconds=60)
+    cache.set("a", "1")
+    cache.set("b", "2")
+    cache.set("c", "3")  # should evict "a"
+    assert cache.get("a") is None
+    assert cache.get("b") == "2"
+    assert cache.get("c") == "3"
+
+
+def test_get_promotes_to_most_recently_used():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=2, ttl_seconds=60)
+    cache.set("a", "1")
+    cache.set("b", "2")
+    # Touch "a" so "b" becomes oldest.
+    assert cache.get("a") == "1"
+    cache.set("c", "3")  # evicts "b"
+    assert cache.get("b") is None
+    assert cache.get("a") == "1"
+    assert cache.get("c") == "3"
+
+
+def test_ttl_expires_entries():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=0.05)
+    cache.set("k", "v")
+    assert cache.get("k") == "v"
+    time.sleep(0.1)
+    assert cache.get("k") is None
+
+
+def test_expired_entry_is_purged_on_get():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=0.05)
+    cache.set("k", "v")
+    time.sleep(0.1)
+    cache.get("k")
+    # Internal store should not retain the expired entry — verify via size.
+    assert cache.size == 0
+
+
+def test_overwrite_updates_value_and_expiry():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=60)
+    cache.set("k", "v1")
+    cache.set("k", "v2")
+    assert cache.get("k") == "v2"
+    assert cache.size == 1
+
+
+def test_clear_drops_everything():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=60)
+    cache.set("a", "1")
+    cache.set("b", "2")
+    cache.clear()
+    assert cache.get("a") is None
+    assert cache.get("b") is None
+    assert cache.size == 0
+
+
+def test_stats_counts_hits_and_misses():
+    cache: TTLLRUCache[str] = TTLLRUCache(max_size=10, ttl_seconds=60)
+    cache.set("k", "v")
+    cache.get("k")        # hit
+    cache.get("k")        # hit
+    cache.get("missing")  # miss
+    s = cache.stats()
+    assert s["hits"] == 2
+    assert s["misses"] == 1
+    assert s["size"] == 1
+
+
+def test_rejects_zero_or_negative_max_size():
+    with pytest.raises(ValueError):
+        TTLLRUCache(max_size=0, ttl_seconds=10)
+
+
+def test_rejects_zero_or_negative_ttl():
+    with pytest.raises(ValueError):
+        TTLLRUCache(max_size=10, ttl_seconds=0)

--- a/frontend/src/components/ask/ChatMessage.tsx
+++ b/frontend/src/components/ask/ChatMessage.tsx
@@ -104,6 +104,9 @@ export default function ChatMessage({ message }: Props) {
                 <span className="mr-2 text-error/70">Not verified against database</span>
               )}
               Powered by {message.provider}
+              {message.cached && (
+                <span className="ml-2 text-on-surface-variant/70" title="Reused from response cache — no LLM call">(cached)</span>
+              )}
             </p>
           </div>
         )}

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -28,6 +28,9 @@ export interface ChatMessage {
   toolsCalled?: string[];
   grounded?: boolean;
   question?: string;
+  /** True when the backend returned X-Cache: HIT — answer was reused from
+   *  the in-process LRU instead of round-tripping to the LLM. */
+  cached?: boolean;
 }
 
 interface AskResponse {
@@ -170,6 +173,7 @@ export function useAskAi() {
         }
 
         setError(null);
+        const cached = resp.headers.get("x-cache")?.toUpperCase() === "HIT";
         const aiMsg: ChatMessage = {
           role: "assistant",
           content: data.answer,
@@ -180,6 +184,7 @@ export function useAskAi() {
           toolsCalled: data.tools_called,
           grounded: data.grounded,
           question: question.trim(),
+          cached,
         };
 
         setMessages((prev) => [...prev, aiMsg]);


### PR DESCRIPTION
## Summary
  Closes #278.

  Two changes that together cut roughly 50% of the LLM round trips on
  /api/ask:

  ### 1. In-process response cache
  Keyed on `sha256(question + filters + history)`. Hits skip the LLM call
  entirely and return the cached `AskResponse` body. Defaults: 500
  entries, 1 hour TTL. Both `X-Cache: HIT` and `X-Cache: MISS` are
  surfaced on the response so the frontend can show a "(cached)" badge.

  History is part of the key so a chat follow-up like "what about that?"
  can't return a stale answer keyed off a different prior turn. This
  narrows hit rate to "fresh-session repeats of the same question," which
  matches the 10-20% dedup estimate in the issue.

  Stdlib-only — `OrderedDict` + `threading.Lock` + per-entry TTL. No new
  dependency.

  ### 2. Quick Facts injection
  Before the LLM round trip, the handler pre-queries totals and severity
  split for the user's active filters and prepends a markdown block to
  the system prompt:

      Quick facts for the user's current filters …
      - Total crashes: 11,129,647
      - Fatalities: 95,242 (0.86%)
      - Injuries: 4,500,000 (40.4%)
      - Severity mix: Property Damage Only 59%, Injury 40%, Fatal 0.9%


  If the DB hiccups the function returns an empty string — the model
  still has its full tool set, and the request keeps working.

  ### Frontend
  `useAskAi` reads `x-cache` from the response, attaches `cached: boolean`
  to the chat message. `ChatMessage` renders a subtle `(cached)` tag
  next to "Powered by …" when present.

  ## Dependencies
  None.

  ## How to test
  1. Open Ask AI panel, ask "how many fatal crashes in Los Angeles?"
     → spinner + LLM call. Bottom of the answer: "Powered by …".
  2. Ask the same thing again in a fresh chat (clear conversation, or
     reload page). Same answer should return instantly with "(cached)"
     beside the provider name.
  3. Change a filter (different county) and ask again — should be a MISS.
  4. Wait an hour and re-ask — TTL expired, should be a MISS.
  5. Inspect dev-tools: `X-Cache: HIT` / `X-Cache: MISS` header on the
     response.
  6. Ask a question that doesn't need any tools (e.g. "how many crashes
     total?"). The Quick Facts block should mean the LLM answers
     directly without tool calls — verify `tools_called` is empty in
     the response.

  ## Checklist
  - [x] `pytest tests/` — 530/530 passing (26 new)
  - [x] `npm test` — 405/405 passing
  - [x] `npx tsc --noEmit` clean
  - [x] `ruff check` clean
  - [ ] Manual smoke (steps 1–6)