### PR TITLE
fix: AI content quality — DOW mapping, deterministic seeding, LLM data gaps

### DIFF
--- a/backend/etl/generate_fun_facts.py
+++ b/backend/etl/generate_fun_facts.py
@@ -16,6 +16,7 @@ Usage
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import random
 
@@ -28,8 +29,8 @@ from app.models import County, CountyInsightCard, StatewideInsight
 
 logger = logging.getLogger(__name__)
 
-DOW_NAMES = {0: "Sunday", 1: "Monday", 2: "Tuesday", 3: "Wednesday",
-             4: "Thursday", 5: "Friday", 6: "Saturday"}
+DOW_NAMES = {0: "Monday", 1: "Tuesday", 2: "Wednesday", 3: "Thursday",
+             4: "Friday", 5: "Saturday", 6: "Sunday"}
 MONTH_NAMES = {1: "January", 2: "February", 3: "March", 4: "April",
                5: "May", 6: "June", 7: "July", 8: "August",
                9: "September", 10: "October", 11: "November", 12: "December"}
@@ -339,7 +340,7 @@ def _compose_quirky(name: str, s: dict) -> str:
             )
 
     # Pick the most interesting 1-2
-    random.seed(hash(name))
+    random.seed(int(hashlib.md5(name.encode()).hexdigest(), 16))
     random.shuffle(options)
     return " ".join(options[:2]) if options else (
         f"{name} County saw {_fmt(s['tc'])} crashes and {_fmt(s['tk'])} fatalities — "

--- a/backend/etl/generate_llm_cards.py
+++ b/backend/etl/generate_llm_cards.py
@@ -223,6 +223,46 @@ def _build_stats_string(db: Session, county_code: int, year: int) -> str | None:
         if demo.poverty_rate is not None:
             parts.append(f"poverty={demo.poverty_rate:.1f}%")
 
+    inv = db.execute(text("""
+        SELECT
+            COALESCE(SUM(CASE WHEN pedestrian_involved THEN 1 ELSE 0 END), 0) AS ped,
+            COALESCE(SUM(CASE WHEN cyclist_involved THEN 1 ELSE 0 END), 0) AS cyc,
+            COALESCE(SUM(CASE WHEN hit_run IS NOT NULL THEN 1 ELSE 0 END), 0) AS hr,
+            COALESCE(SUM(CASE WHEN canonical_cause = 'speeding' THEN 1 ELSE 0 END), 0) AS spd
+        FROM crashes WHERE county_code = :c AND crash_year = :y
+    """), {"c": county_code, "y": year}).first()
+    if inv:
+        parts.append(f"pedestrian_crashes={inv.ped}")
+        parts.append(f"cyclist_crashes={inv.cyc}")
+        parts.append(f"hit_run_crashes={inv.hr}")
+        parts.append(f"speeding_crashes={inv.spd}")
+
+    monthly = db.execute(text("""
+        SELECT crash_month, COUNT(*) AS cnt
+        FROM crashes WHERE county_code = :c AND crash_year = :y AND crash_month IS NOT NULL
+        GROUP BY crash_month ORDER BY crash_month
+    """), {"c": county_code, "y": year}).all()
+    if monthly:
+        month_names = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+        parts.append("monthly=" + ",".join(f"{month_names[r.crash_month-1]}:{r.cnt}" for r in monthly))
+
+    dow = db.execute(text("""
+        SELECT day_of_week_num, COUNT(*) AS cnt
+        FROM crashes WHERE county_code = :c AND crash_year = :y AND day_of_week_num IS NOT NULL
+        GROUP BY day_of_week_num ORDER BY day_of_week_num
+    """), {"c": county_code, "y": year}).all()
+    if dow:
+        dow_names = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+        parts.append("day_of_week=" + ",".join(f"{dow_names[r.day_of_week_num]}:{r.cnt}" for r in dow))
+
+    night = db.execute(text("""
+        SELECT COUNT(*) AS cnt
+        FROM crashes WHERE county_code = :c AND crash_year = :y
+            AND crash_hour IS NOT NULL AND (crash_hour >= 20 OR crash_hour < 6)
+    """), {"c": county_code, "y": year}).scalar() or 0
+    if t.tc > 0:
+        parts.append(f"nighttime_crashes={night}({round(night/t.tc*100,1)}%)")
+
     return ", ".join(parts)
 
 


### PR DESCRIPTION
## Summary
- Wrong day-of-week names in fun facts — generate_fun_facts.py mapped Sunday=0 but DB stores Monday=0. Fixed.
- Non-deterministic fun fact selection — switched from hash() to hashlib.md5 for stable seeding.
- LLM prompts hallucinating missing data — added pedestrian/cyclist/hit-run/speeding counts, monthly/DOW breakdown, and nighttime % to the stats string so all 28 prompt angles have the data they reference.

## Test plan
- [ ] Re-run generate_fun_facts and verify day names
- [ ] Re-run generate_llm_cards and verify insights cite real numbers
- [ ] Needs testing

Closes #308 (partial)