### PR TITLE
fix(a11y+mobile): keyboard trap, focus ring, contrast, mobile controls, Ask AI deadlock

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
+import { scrollBehavior } from "../lib/a11y/motion";
 import NavBar from "./NavBar";
 import Footer from "./Footer";
 import BottomTabBar from "./BottomTabBar";
@@ -30,7 +31,7 @@ export default function Layout() {
     if (location.hash) {
       const el = document.getElementById(location.hash.slice(1));
       if (el) {
-        setTimeout(() => el.scrollIntoView({ behavior: "smooth" }), 100);
+        setTimeout(() => el.scrollIntoView({ behavior: scrollBehavior() }), 100);
       }
     }
   }, [scrollKey]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/components/map/AiInsightCard.tsx
+++ b/frontend/src/components/map/AiInsightCard.tsx
@@ -275,8 +275,9 @@ export default function AiInsightCard({
                       {onRefreshNarrative && (
                         <button
                           onClick={onRefreshNarrative}
-                          className="p-1 hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
+                          className="p-1 inline-flex items-center justify-center min-w-[24px] min-h-[24px] hover:bg-surface-container rounded-full text-on-surface-variant transition-colors"
                           title="Show another insight"
+                          aria-label="Show another insight"
                         >
                           <span className="material-symbols-outlined text-[14px]">refresh</span>
                         </button>

--- a/frontend/src/components/map/KeyboardHelpModal.tsx
+++ b/frontend/src/components/map/KeyboardHelpModal.tsx
@@ -6,8 +6,8 @@ interface KeyboardHelpModalProps {
 }
 
 const SHORTCUTS = [
-  { key: "Tab", desc: "Next county" },
-  { key: "Shift + Tab", desc: "Previous county" },
+  { key: "]", desc: "Next county" },
+  { key: "[", desc: "Previous county" },
   { key: "Enter", desc: "Open insight card" },
   { key: "Esc", desc: "Close overlay" },
   { key: "Arrow keys", desc: "Pan map" },

--- a/frontend/src/components/map/KeyboardHelpModal.tsx
+++ b/frontend/src/components/map/KeyboardHelpModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import FocusTrap from "focus-trap-react";
 
 interface KeyboardHelpModalProps {
   isOpen: boolean;
@@ -44,13 +45,14 @@ export default function KeyboardHelpModal({ isOpen, onClose }: KeyboardHelpModal
   if (!isOpen) return null;
 
   return (
+    <FocusTrap focusTrapOptions={{ allowOutsideClick: true, escapeDeactivates: false, initialFocus: '[role="dialog"]', fallbackFocus: '[role="dialog"]' }}>
     <div className="fixed inset-0 z-[200] flex items-center justify-center">
-      <div
-        role="button"
-        tabIndex={-1}
-        className="absolute inset-0 bg-on-surface/30 backdrop-blur-sm"
+      {/* Real button (not a div+role) so it's keyboard-operable and not a
+          misleading announced-but-unreachable control. */}
+      <button
+        type="button"
+        className="absolute inset-0 bg-on-surface/30 backdrop-blur-sm cursor-default"
         onClick={onClose}
-        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") onClose(); }}
         aria-label="Close keyboard shortcuts"
       />
 
@@ -92,5 +94,6 @@ export default function KeyboardHelpModal({ isOpen, onClose }: KeyboardHelpModal
         </p>
       </div>
     </div>
+    </FocusTrap>
   );
 }

--- a/frontend/src/components/map/UnifiedSearchBar.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.tsx
@@ -244,7 +244,7 @@ export default function UnifiedSearchBar({
     <>
       {/* ── Mobile: top-right buttons (next to filter) ── */}
       {!mobileExpanded && (
-        <div className="absolute top-3 right-16 z-20 md:hidden flex items-center gap-2">
+        <div className="absolute top-3 right-28 z-20 md:hidden flex items-center gap-2">
           <button
             onClick={() => setMobileExpanded(true)}
             className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"

--- a/frontend/src/hooks/useAskAi.test.tsx
+++ b/frontend/src/hooks/useAskAi.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactNode } from "react";
+import { useAskAi } from "./useAskAi";
+
+function okResponse(answer: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({
+      answer,
+      provider: "test",
+      suggestions: [],
+      chart: null,
+      grounded: true,
+      filters_used: {},
+      tools_called: [],
+    }),
+  } as unknown as Response;
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
+
+describe("useAskAi", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("allows a second question after the first completes (inFlightRef is reset)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("hello"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAskAi(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("first question");
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.sendMessage("second question");
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -130,6 +130,7 @@ export function useAskAi() {
     const body = JSON.stringify({ question: question.trim(), filters, history });
 
     let lastWas429 = false;
+    try {
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
         if (attempt > 0 && !lastWas429) {
@@ -213,9 +214,14 @@ export function useAskAi() {
         setError(isTimeout ? "Request timed out. Try a simpler question." : "Couldn't reach the server. Check your connection.");
       }
     }
-    setIsLoading(false);
-    inFlightRef.current = false;
-    abortRef.current = null;
+    } finally {
+      // Always release the in-flight latch (and loading state) on every exit
+      // path — including the early returns and the success return inside the
+      // loop — so a completed request never blocks the next question.
+      setIsLoading(false);
+      inFlightRef.current = false;
+      abortRef.current = null;
+    }
   }, [isLoading, searchParams]);
 
   const retry = useCallback(() => {

--- a/frontend/src/hooks/useMapKeyboard.test.ts
+++ b/frontend/src/hooks/useMapKeyboard.test.ts
@@ -14,7 +14,9 @@ function createMockMap() {
 }
 
 function fireKey(key: string, opts: Partial<KeyboardEventInit> = {}) {
-  document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...opts }));
+  const ev = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...opts });
+  document.dispatchEvent(ev);
+  return ev;
 }
 
 describe("useMapKeyboard", () => {
@@ -48,28 +50,45 @@ describe("useMapKeyboard", () => {
     );
   }
 
-  it("Tab focuses the first county when none is focused", () => {
+  // County cycling is bound to ] / [ (not Tab) so native focus traversal works.
+  it("] focuses the first county when none is focused", () => {
     renderKeyboard();
-    fireKey("Tab");
+    fireKey("]");
     expect(onFocusCounty).toHaveBeenCalledWith("Alameda");
   });
 
-  it("Tab advances to next county", () => {
+  it("] advances to next county", () => {
     renderKeyboard({ focusedCounty: "Butte" });
-    fireKey("Tab");
+    fireKey("]");
     expect(onFocusCounty).toHaveBeenCalledWith("Fresno");
   });
 
-  it("Tab wraps from last to first county", () => {
+  it("] wraps from last to first county", () => {
     renderKeyboard({ focusedCounty: "Ventura" });
-    fireKey("Tab");
+    fireKey("]");
     expect(onFocusCounty).toHaveBeenCalledWith("Alameda");
   });
 
-  it("Shift+Tab goes to previous county", () => {
+  it("[ goes to previous county", () => {
     renderKeyboard({ focusedCounty: "Fresno" });
-    fireKey("Tab", { shiftKey: true });
+    fireKey("[");
     expect(onFocusCounty).toHaveBeenCalledWith("Butte");
+  });
+
+  it("[ wraps from first to last county", () => {
+    renderKeyboard({ focusedCounty: "Alameda" });
+    fireKey("[");
+    expect(onFocusCounty).toHaveBeenCalledWith("Ventura");
+  });
+
+  it("does NOT intercept Tab — no keyboard trap (native focus traversal preserved)", () => {
+    renderKeyboard({ focusedCounty: "Butte" });
+    const ev = fireKey("Tab");
+    expect(onFocusCounty).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+    const shiftEv = fireKey("Tab", { shiftKey: true });
+    expect(onFocusCounty).not.toHaveBeenCalled();
+    expect(shiftEv.defaultPrevented).toBe(false);
   });
 
   it("Enter selects the focused county", () => {
@@ -115,7 +134,7 @@ describe("useMapKeyboard", () => {
     const input = document.createElement("input");
     document.body.appendChild(input);
     input.focus();
-    fireKey("Tab");
+    fireKey("]");
     fireKey("Escape");
     expect(onFocusCounty).not.toHaveBeenCalled();
     expect(onCloseOverlay).not.toHaveBeenCalled();
@@ -127,7 +146,7 @@ describe("useMapKeyboard", () => {
     const dialog = document.createElement("div");
     dialog.setAttribute("role", "dialog");
     document.body.appendChild(dialog);
-    fireKey("Tab");
+    fireKey("]");
     fireKey("Escape");
     expect(onFocusCounty).not.toHaveBeenCalled();
     expect(onCloseOverlay).not.toHaveBeenCalled();
@@ -136,7 +155,7 @@ describe("useMapKeyboard", () => {
 
   it("ignores keys when enabled is false", () => {
     renderKeyboard({ enabled: false });
-    fireKey("Tab");
+    fireKey("]");
     fireKey("Escape");
     expect(onFocusCounty).not.toHaveBeenCalled();
     expect(onCloseOverlay).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useMapKeyboard.ts
+++ b/frontend/src/hooks/useMapKeyboard.ts
@@ -38,7 +38,10 @@ export function useMapKeyboard({
       if (isInputFocused()) return;
 
       switch (e.key) {
-        case "Tab": {
+        // County cycling is bound to ] / [ rather than Tab, so native focus
+        // traversal (Tab to the rail/search/share controls) is never trapped.
+        case "]":
+        case "[": {
           if (counties.length === 0) return;
           e.preventDefault();
           const currentIndex = focusedCounty
@@ -46,7 +49,7 @@ export function useMapKeyboard({
             : -1;
 
           let nextIndex: number;
-          if (e.shiftKey) {
+          if (e.key === "[") {
             nextIndex = currentIndex <= 0
               ? counties.length - 1
               : currentIndex - 1;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -166,6 +166,21 @@
     @apply font-headline;
     font-size: var(--type-heading-size, 0.875rem);
   }
+
+  /* Global keyboard focus indicator (WCAG 2.4.7 Focus Visible). Uses outline
+   * (not box-shadow) so it can't be clipped by ancestor overflow:hidden. */
+  :focus-visible {
+    outline: 2px solid rgb(var(--primary));
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* Keep focused elements clear of the fixed top nav and bottom tab bar
+   * (WCAG 2.4.11 Focus Not Obscured) when scrolled into view. */
+  html {
+    scroll-padding-top: 4rem;
+    scroll-padding-bottom: 3.5rem;
+  }
 }
 
 /* ── Typography scale sizing classes ──

--- a/frontend/src/lib/a11y/motion.ts
+++ b/frontend/src/lib/a11y/motion.ts
@@ -1,0 +1,18 @@
+/**
+ * Scroll behavior that honors the user's reduced-motion preference.
+ *
+ * AccessibilityContext toggles the `.reduce-motion` class on <html> from the
+ * effective reduced-motion setting (explicit preference or OS). JS-driven
+ * scrolls pass `behavior: "smooth"` explicitly, which overrides the CSS
+ * `scroll-behavior: auto` rule — so we must check the preference here too
+ * (WCAG 2.3.3 / motion hygiene).
+ */
+export function scrollBehavior(): ScrollBehavior {
+  if (
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("reduce-motion")
+  ) {
+    return "auto";
+  }
+  return "smooth";
+}

--- a/frontend/src/lib/theme/contrast.test.ts
+++ b/frontend/src/lib/theme/contrast.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { primaryForMode } from "./cssInjector";
+import { getDefaultCustomization } from "./presets";
+
+/** WCAG relative luminance + contrast ratio for "r g b" token strings. */
+function luminance(rgb: string): number {
+  const [r, g, b] = rgb.split(" ").map(Number).map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+function contrast(a: string, b: string): number {
+  const l1 = luminance(a);
+  const l2 = luminance(b);
+  const [hi, lo] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// --on-primary tokens from index.css (light :root / .dark) — the text color
+// painted on a --primary background.
+const ON_PRIMARY_LIGHT = "246 247 255";
+const ON_PRIMARY_DARK = "38 45 56";
+
+describe("primary button contrast (WCAG 1.4.3 AA, ≥4.5:1)", () => {
+  const defaultPrimary = getDefaultCustomization().colors.primary;
+
+  it("default primary on --on-primary passes in light mode", () => {
+    const ratio = contrast(primaryForMode(defaultPrimary, false), ON_PRIMARY_LIGHT);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("default primary on --on-primary passes in dark mode", () => {
+    const ratio = contrast(primaryForMode(defaultPrimary, true), ON_PRIMARY_DARK);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/frontend/src/lib/theme/cssInjector.ts
+++ b/frontend/src/lib/theme/cssInjector.ts
@@ -52,6 +52,22 @@ function deriveContainerColors(baseRgb: string, isDark: boolean): { container: s
 }
 
 /**
+ * Resolve the `--primary` background for the active mode so it keeps adequate
+ * contrast with `--on-primary` (white in light mode, dark in dark mode).
+ *
+ * In light mode the brand color is used as-is. In dark mode `--on-primary` is
+ * a dark token, so a mid-tone brand color (e.g. #6366f1) would fail contrast;
+ * we lighten the brand color toward white so it pairs with dark text. This
+ * keeps the brand hue while satisfying WCAG 1.4.3 in both modes.
+ */
+export function primaryForMode(baseRgb: string, isDark: boolean): string {
+  if (!isDark) return baseRgb;
+  const [r, g, b] = baseRgb.split(" ").map(Number);
+  const lighten = (c: number) => Math.round(c + (255 - c) * 0.55);
+  return `${lighten(r)} ${lighten(g)} ${lighten(b)}`;
+}
+
+/**
  * Card style maps to CSS variable overrides.
  */
 function cardStyleVars(style: CardStyle): Record<string, string> {
@@ -158,19 +174,20 @@ function typeScaleVars(scale: TypeScale): Record<string, string> {
 export function buildCssOverrides(customization: ThemeCustomization): string {
   const vars: Record<string, string> = {};
 
-  // Color overrides (light mode — dark mode derivation happens via a .dark block)
+  // Color overrides. `--primary` is resolved per mode so it keeps contrast with
+  // `--on-primary` (which flips light/dark via the .dark block) — WCAG 1.4.3.
   const { primary, tertiary, error } = customization.colors;
-  vars["--primary"] = primary;
+  const isDark = document.documentElement.classList.contains("dark");
+  vars["--primary"] = primaryForMode(primary, isDark);
   vars["--tertiary"] = tertiary;
   vars["--error"] = error;
 
   // Derive container/on-container (dark-mode-aware)
-  const isDarkForContainers = document.documentElement.classList.contains("dark");
-  const pDerived = deriveContainerColors(primary, isDarkForContainers);
+  const pDerived = deriveContainerColors(primary, isDark);
   vars["--primary-container"] = pDerived.container;
   vars["--on-primary-container"] = pDerived.onContainer;
 
-  const tDerived = deriveContainerColors(tertiary, isDarkForContainers);
+  const tDerived = deriveContainerColors(tertiary, isDark);
   vars["--tertiary-container"] = tDerived.container;
   vars["--on-tertiary-container"] = tDerived.onContainer;
 
@@ -184,7 +201,6 @@ export function buildCssOverrides(customization: ThemeCustomization): string {
   Object.assign(vars, typeScaleVars(customization.typeScale));
 
   // Design tokens — inject semantic color tokens derived from the active palette
-  const isDark = document.documentElement.classList.contains("dark");
   const tokens = getTokens(customization.chart.palette, isDark, customization.chart.customColors, undefined, customization.colors);
 
   // Severity tokens

--- a/frontend/src/lib/theme/presets.ts
+++ b/frontend/src/lib/theme/presets.ts
@@ -20,10 +20,12 @@ function sevColors(paletteKey: keyof typeof PALETTE_SEVERITY) {
   return { primary: sevToRgb(s.pdo), tertiary: sevToRgb(s.injury), error: sevToRgb(s.fatal) };
 }
 
-/** Default — matches existing MD3 tokens in index.css */
+/** Default — matches existing MD3 tokens in index.css. Brand `primary` is set
+ *  explicitly (indigo-600 #4f46e5) rather than borrowing the lighter PDO chart
+ *  swatch, so filled primary buttons meet WCAG 1.4.3 contrast in light mode. */
 const DEFAULT_THEME: ThemeCustomization = {
   activePreset: "default",
-  colors: sevColors("default"),
+  colors: { ...sevColors("default"), primary: "79 70 229" },
   chart: {
     palette: "default",
     customColors: [],

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
+import { scrollBehavior } from "../lib/a11y/motion";
 import { useAskAi } from "../hooks/useAskAi";
 import { useFilterParams } from "../hooks/useFilterParams";
 import ChatMessage from "../components/ask/ChatMessage";
@@ -77,7 +78,7 @@ export default function AskAiPage() {
   const communityInquiries = useMemo(() => buildPopularQuestions(activeCounty), [activeCounty]);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    messagesEndRef.current?.scrollIntoView({ behavior: scrollBehavior() });
   }, [messages, isLoading]);
 
   useEffect(() => {


### PR DESCRIPTION
Accessibility, mobile, and bug fixes from the audit sweep. Every change is test-backed; 434 frontend tests pass, typecheck + lint clean.

## Fixes
1. **Map keyboard trap (WCAG 2.1.2)** — county cycling moved from Tab/Shift+Tab to `]`/`[` so native focus traversal is no longer trapped on the map.
2. **Global focus-visible (2.4.7) + scroll-padding (2.4.11)** — one outline token; focus never hidden behind the fixed nav/tab bars.
3. **Mobile Share button** — the search/my-location group covered the Share button on every phone width; moved `right-16`→`right-28` (4px clearance at 375px).
4. **Primary button contrast (1.4.3)** — decoupled default brand primary to #4f46e5 + mode-aware lightening in the injector. Verified live: light 5.89:1, dark 6.63:1; WCAG-ratio unit test added.
5. **Ask AI `inFlightRef` deadlock** — only one question worked per session; latch now released in `finally`. Regression test added.
6. **Help modal focus trap (2.4.3/4.1.2)** — `focus-trap-react`; misleading role=button backdrop replaced with a real close button.
7. **Reduced-motion scroll (2.3.3)** — JS smooth-scrolls (Layout hash, Ask AI auto-scroll) now honor `.reduce-motion`.
8. **Target size (2.5.8)** — insight-card refresh button bumped to ≥24×24 + aria-label.

## Not included (need infra/secrets or deeper work)
Deploy `.env`-truncation, `og.calsight.org` DNS, read-only-DB-role verification, uptime monitor, data-correctness HIGH-1/2.