### PR TITLE
fix(stats): keep NULL involvement as its own bucket in mv_crashes_wide

### DIFF
--- a/backend/migrations/versions/s7t8u9v0w1x2_fix_mv_wide_involvement_null_buckets.py
+++ b/backend/migrations/versions/s7t8u9v0w1x2_fix_mv_wide_involvement_null_buckets.py
@@ -1,0 +1,146 @@
+"""Fix mv_crashes_wide: involvement flags must keep NULL as its own bucket
+
+HIGH-1 data-correctness bug. The involvement flags (f_alcohol, f_distracted,
+f_pedestrian, f_cyclist, f_drug) were encoded 2-valued:
+
+    CASE WHEN pedestrian_involved THEN 1 ELSE 0 END
+
+In SQL, a NULL boolean falls through to ELSE, so the ~6.8M SWITRS rows where
+involvement is genuinely *unknown* were stamped 0 ("false"). A `=false` filter
+on /api/stats (which reads this MV) therefore counted those unknowns, while
+/api/crashes (raw table, `column IS FALSE`) excluded them — the two endpoints
+disagreed by ~2.7x.
+
+Fix: encode the involvement flags 3-valued, exactly like is_highway directly
+above them (NULL -> -1). A `f_* = 0` (false) or `f_* = 1` (true) filter then
+excludes unknowns, matching the `.is_(False)` / `.is_(True)` semantics on the
+raw table. No router/filters.py change is needed — the == 0 / == 1 comparisons
+in stats.py already do the right thing once -1 means "unknown".
+
+This is a structural redefinition only (the GROUP BY now buckets unknowns into
+their own group). The MV is recreated WITH NO DATA; the deploy/ETL refresh step
+repopulates it. On prod, follow with:
+    REFRESH MATERIALIZED VIEW mv_crashes_wide;
+
+Revision ID: s7t8u9v0w1x2
+Revises: r6s7t8u9v0w1
+Create Date: 2026-06-26 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+
+revision: str = "s7t8u9v0w1x2"
+down_revision: Union[str, None] = "r6s7t8u9v0w1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_crashes_wide")
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_crashes_wide AS
+        SELECT
+            county_code,
+            crash_year,
+            severity,
+            COALESCE(canonical_cause, 'uncategorized')    AS canonical_cause,
+            COALESCE(canonical_weather, 'unknown')        AS canonical_weather,
+            COALESCE(canonical_lighting, 'unknown')       AS canonical_lighting,
+            COALESCE(canonical_collision_type, 'unknown')  AS canonical_collision_type,
+            CASE WHEN is_highway IS NULL THEN -1 WHEN is_highway THEN 1 ELSE 0 END AS is_highway,
+            CASE WHEN is_alcohol_involved     IS NULL THEN -1 WHEN is_alcohol_involved     THEN 1 ELSE 0 END AS f_alcohol,
+            CASE WHEN is_distraction_involved IS NULL THEN -1 WHEN is_distraction_involved THEN 1 ELSE 0 END AS f_distracted,
+            CASE WHEN pedestrian_involved     IS NULL THEN -1 WHEN pedestrian_involved     THEN 1 ELSE 0 END AS f_pedestrian,
+            CASE WHEN cyclist_involved        IS NULL THEN -1 WHEN cyclist_involved        THEN 1 ELSE 0 END AS f_cyclist,
+            CASE WHEN is_drug_involved        IS NULL THEN -1 WHEN is_drug_involved        THEN 1 ELSE 0 END AS f_drug,
+            CASE WHEN hit_run IS NOT NULL     THEN 1 ELSE 0 END AS f_hit_run,
+            CASE
+                WHEN at_fault_driver_age BETWEEN 16 AND 21 THEN 1
+                WHEN at_fault_driver_age BETWEEN 22 AND 34 THEN 2
+                WHEN at_fault_driver_age BETWEEN 35 AND 49 THEN 3
+                WHEN at_fault_driver_age BETWEEN 50 AND 64 THEN 4
+                WHEN at_fault_driver_age >= 65 THEN 5
+                ELSE 0
+            END                                           AS age_bracket,
+            day_of_week_num,
+            crash_month,
+            crash_hour,
+            COUNT(*)                                      AS crash_count,
+            COALESCE(SUM(number_killed), 0)               AS total_killed,
+            COALESCE(SUM(number_injured), 0)              AS total_injured
+        FROM crashes
+        WHERE crash_year IS NOT NULL
+        GROUP BY
+            county_code, crash_year, severity, canonical_cause,
+            canonical_weather, canonical_lighting, canonical_collision_type,
+            is_highway, f_alcohol, f_distracted, f_pedestrian, f_cyclist, f_drug,
+            f_hit_run, age_bracket,
+            day_of_week_num, crash_month, crash_hour
+        WITH NO DATA
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX ix_mv_crashes_wide_pk
+        ON mv_crashes_wide (
+            county_code, crash_year, severity, canonical_cause,
+            canonical_weather, canonical_lighting, canonical_collision_type,
+            is_highway, f_alcohol, f_distracted, f_pedestrian, f_cyclist, f_drug,
+            f_hit_run, age_bracket,
+            day_of_week_num, crash_month, crash_hour
+        )
+    """)
+
+
+def downgrade() -> None:
+    # Restore the prior 2-valued involvement encoding (NULL collapses to 0).
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_crashes_wide")
+    op.execute("""
+        CREATE MATERIALIZED VIEW mv_crashes_wide AS
+        SELECT
+            county_code,
+            crash_year,
+            severity,
+            COALESCE(canonical_cause, 'uncategorized')    AS canonical_cause,
+            COALESCE(canonical_weather, 'unknown')        AS canonical_weather,
+            COALESCE(canonical_lighting, 'unknown')       AS canonical_lighting,
+            COALESCE(canonical_collision_type, 'unknown')  AS canonical_collision_type,
+            CASE WHEN is_highway IS NULL THEN -1 WHEN is_highway THEN 1 ELSE 0 END AS is_highway,
+            CASE WHEN is_alcohol_involved     THEN 1 ELSE 0 END AS f_alcohol,
+            CASE WHEN is_distraction_involved THEN 1 ELSE 0 END AS f_distracted,
+            CASE WHEN pedestrian_involved     THEN 1 ELSE 0 END AS f_pedestrian,
+            CASE WHEN cyclist_involved        THEN 1 ELSE 0 END AS f_cyclist,
+            CASE WHEN is_drug_involved        THEN 1 ELSE 0 END AS f_drug,
+            CASE WHEN hit_run IS NOT NULL     THEN 1 ELSE 0 END AS f_hit_run,
+            CASE
+                WHEN at_fault_driver_age BETWEEN 16 AND 21 THEN 1
+                WHEN at_fault_driver_age BETWEEN 22 AND 34 THEN 2
+                WHEN at_fault_driver_age BETWEEN 35 AND 49 THEN 3
+                WHEN at_fault_driver_age BETWEEN 50 AND 64 THEN 4
+                WHEN at_fault_driver_age >= 65 THEN 5
+                ELSE 0
+            END                                           AS age_bracket,
+            day_of_week_num,
+            crash_month,
+            crash_hour,
+            COUNT(*)                                      AS crash_count,
+            COALESCE(SUM(number_killed), 0)               AS total_killed,
+            COALESCE(SUM(number_injured), 0)              AS total_injured
+        FROM crashes
+        WHERE crash_year IS NOT NULL
+        GROUP BY
+            county_code, crash_year, severity, canonical_cause,
+            canonical_weather, canonical_lighting, canonical_collision_type,
+            is_highway, f_alcohol, f_distracted, f_pedestrian, f_cyclist, f_drug,
+            f_hit_run, age_bracket,
+            day_of_week_num, crash_month, crash_hour
+        WITH NO DATA
+    """)
+    op.execute("""
+        CREATE UNIQUE INDEX ix_mv_crashes_wide_pk
+        ON mv_crashes_wide (
+            county_code, crash_year, severity, canonical_cause,
+            canonical_weather, canonical_lighting, canonical_collision_type,
+            is_highway, f_alcohol, f_distracted, f_pedestrian, f_cyclist, f_drug,
+            f_hit_run, age_bracket,
+            day_of_week_num, crash_month, crash_hour
+        )
+    """)

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -83,6 +83,27 @@ def test_stats_rejects_involvement_with_demographics(client):
     assert response.json()["filter"] == "involvement"
 
 
+def test_stats_involvement_false_excludes_unknown_and_matches_crashes(client):
+    """HIGH-1: an involvement `=false` filter must not bucket rows whose
+    underlying flag is NULL (unknown) as 'false'.
+
+    /stats reads mv_crashes_wide; /crashes reads the raw table with
+    `.is_(False)` semantics (NULL excluded). The two must agree.
+
+    Seed alcohol flags: id3=True, id4=False, id5=False, id1/id2 (SWITRS)=NULL.
+    So `alcohol=false` is exactly the 2 real-false crashes — not the 2 NULL
+    SWITRS rows. Before the fix /stats returned 4 (2 false + 2 NULL).
+    """
+    years = "year=2014,2015,2022,2023"
+    stats = client.get(f"/api/stats?alcohol=false&{years}").json()
+    crashes = client.get(
+        f"/api/crashes?alcohol=false&{years}&include_total=true&limit=1"
+    ).json()
+
+    assert stats["total_crashes"] == 2
+    assert stats["total_crashes"] == crashes["total"]
+
+
 # --- group_by=gender / age_bracket (mv_crash_victims_by_demographics) ---
 
 


### PR DESCRIPTION
## HIGH-1 — `/stats` vs `/crashes` disagreed by ~2.7× on involvement `=false`

### Root cause
`mv_crashes_wide` encoded the five involvement flags as **2-valued**:
```sql
CASE WHEN pedestrian_involved THEN 1 ELSE 0 END AS f_pedestrian
```
In SQL a NULL boolean falls through to `ELSE 0`, so the ~6.8M SWITRS rows where involvement is genuinely **unknown** were stamped `0` = "false". An involvement `=false` filter on `/api/stats` (reads the MV) counted those unknowns, while `/api/crashes` (raw table, `column IS FALSE`) excluded them.

### Fix
Recreate the MV with **3-valued** flags (`IS NULL → -1`), exactly matching `is_highway` directly above them. A `f_* = 0`/`= 1` filter now excludes unknowns, lining `/stats` up with the `.is_(False)`/`.is_(True)` semantics on the raw table. No `filters.py`/router changes — the existing `== 0`/`== 1` comparisons already do the right thing once `-1` means "unknown".

### Tests
- New `/stats`-vs-`/crashes` consistency test (`test_stats_involvement_false_excludes_unknown_and_matches_crashes`): seed has alcohol True/False/NULL, asserts `=false` returns exactly the 2 real-false rows (was 4).
- Full backend suite: **622 passed**. Migration down/up roundtrip verified.

### ⚠️ Deploy step
The MV is recreated `WITH NO DATA`, so it is empty between migration and the next refresh. After this deploys, run:
```
docker compose -f docker-compose.prod.yml exec -T backend python -m etl.refresh_materialized_views
```
(`refresh_materialized_views` self-heals the unpopulated case via a non-concurrent REFRESH.)

### User-visible
`involvement=false` filters now return **fewer** crashes — correctly excluding unknowns. `=true` totals unchanged. Worth a methodology note.