### PR TITLE
infra: restore SENTRY_DSN in deploy env + add manual ETL workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,7 @@ jobs:
           GEMINI_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           CEREBRAS_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SENTRY: ${{ secrets.SENTRY_DSN }}
         run: |
           : > backend/.env
           printf 'DATABASE_URL=%s\n' "$DB_URL" >> backend/.env
@@ -80,6 +81,12 @@ jobs:
           printf 'LLM_FALLBACK_3_PROVIDER=cerebras\n' >> backend/.env
           printf 'LLM_FALLBACK_3_KEY=%s\n' "$CEREBRAS_KEY" >> backend/.env
           printf 'DEBUG=false\n' >> backend/.env
+          # Sentry error monitoring for the API container. No-op until the
+          # SENTRY_DSN repo secret is set (main.py gates on a non-empty DSN),
+          # so this is safe to ship before the secret exists. Without this line
+          # the deploy's `: > backend/.env` truncation wiped SENTRY_DSN every
+          # deploy, which is why backend error monitoring never activated.
+          printf 'SENTRY_DSN=%s\n' "$SENTRY" >> backend/.env
 
       - name: Stop standalone cloudflared (if still running as systemd)
         run: systemctl disable --now cloudflared 2>/dev/null || true

--- a/.github/workflows/run-etl.yml
+++ b/.github/workflows/run-etl.yml
@@ -1,0 +1,46 @@
+name: Run ETL Job
+
+# Manually run a single ETL job on the prod runner (LXC 100) against the live
+# backend container — without a full redeploy. Used for one-off backfills like
+# route_number, where the data job is registered in the daily pipeline but you
+# don't want to wait for the next nightly cycle.
+#
+# Trigger from the Actions tab ("Run ETL Job" -> Run workflow) or:
+#   gh workflow run run-etl.yml -f job=extract_route_number
+
+on:
+  workflow_dispatch:
+    inputs:
+      job:
+        description: "ETL module to run (etl.<module>), e.g. extract_route_number"
+        required: true
+        default: "extract_route_number"
+      refresh_matviews:
+        description: "Refresh materialized views after the job (needed for backfills that feed mv_crashes_wide)"
+        type: boolean
+        required: false
+        default: true
+
+concurrency:
+  # Don't let two manual ETL runs (or this + a deploy's backfill) clobber each
+  # other on the DB. Same group as nothing else; cancel-in-progress stays off so
+  # a long backfill is never killed mid-run.
+  group: run-etl
+  cancel-in-progress: false
+
+jobs:
+  run-etl:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Run ETL job (${{ inputs.job }})
+        run: docker compose -f docker-compose.prod.yml exec -T backend python -m "etl.${{ inputs.job }}"
+        timeout-minutes: 240
+
+      - name: Refresh materialized views
+        if: ${{ inputs.refresh_matviews }}
+        run: docker compose -f docker-compose.prod.yml exec -T backend python -m etl.refresh_materialized_views
+        timeout-minutes: 60


### PR DESCRIPTION
## Two infra changes

### 1. Restore `SENTRY_DSN` in the deploy env (root-cause fix)

`deploy.yml` rebuilds `backend/.env` from scratch on every deploy (`: > backend/.env`) and writes back only the DB/CORS/LLM keys. **`SENTRY_DSN` was never re-written**, so the API container's error monitoring got wiped on every deploy and never actually activated — `main.py` gates Sentry on a non-empty DSN, so it silently stayed off. This is the real reason "Sentry: code done, prod unverified."

The backend container reads `env_file: ./backend/.env` (confirmed in `docker-compose.prod.yml`), so adding the key there is exactly what's needed. It's a **no-op until the `SENTRY_DSN` repo secret is created**, so it's safe to merge now.

**Action needed from you to actually turn Sentry on:** add a `SENTRY_DSN` repo secret (`gh secret set SENTRY_DSN`). Until then it stays off, harmlessly.

### 2. Add a manual "Run ETL Job" workflow

`workflow_dispatch` that runs a single ETL module against the live prod backend container via the self-hosted runner — without a full redeploy. For one-off backfills (e.g. `extract_route_number`) when you don't want to wait for the nightly pipeline. Optional matview refresh after.

```
gh workflow run run-etl.yml -f job=extract_route_number
```

## Deliberately NOT included

`HEARTBEAT_URL` and the `R2_*` backup creds are **not** added here. They're read by **host-run** ETL/backup processes (there's no scheduler container — compose is just `backend` + `tunnel`), and your daily R2 backup works *without* those being GitHub secrets — implying they live in a separate host `.env` that the deploy doesn't write. Adding empty `printf` lines for them could **overwrite working backup creds with blanks**. That part needs you to confirm the prod env layout (which `.env` the host cron reads vs. the deploy-written one) before it's safe to touch.

## Verification
- Both workflow files parse as valid YAML.
- `deploy.yml` change is purely additive (one env var + one `printf`), no behavior change when the secret is absent.
