### PR TITLE
feat(ai): AI storytelling P0 spine (Explainable + AiCompanion + /stats/distribution)

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1082,3 +1082,63 @@ def stats_highways(
         enriched.sort(key=lambda h: h.crashes_per_mile or 0.0, reverse=True)
 
     return enriched[:limit]
+
+
+_DISTRIBUTION_METRICS = {
+    "crash_count", "total_killed", "total_injured",
+    "fatal_crashes", "alcohol_crashes", "pedestrian_crashes",
+}
+
+
+@router.get("/stats/distribution")
+@_limiter.limit("1000/minute;20000/hour")
+def stats_distribution(
+    request: Request,
+    response: Response,
+    metric: str = Query("crash_count"),
+    year: int | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Per-county values for one metric — the distribution the frontend reduces
+    into percentile/rank context ("safer than X% of counties").
+
+    Mirrors the rank_counties tool but returns every county (no small limit).
+    """
+    if metric not in _DISTRIBUTION_METRICS:
+        raise HTTPException(status_code=422, detail=f"invalid metric: {metric}")
+
+    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+
+    preds = []
+    if year is not None:
+        preds.append(Crash.crash_year == year)
+    if metric == "fatal_crashes":
+        preds.append(Crash.severity == "Fatal")
+        agg = func.count(Crash.id)
+    elif metric == "alcohol_crashes":
+        preds.append(Crash.is_alcohol_involved.is_(True))
+        agg = func.count(Crash.id)
+    elif metric == "pedestrian_crashes":
+        preds.append(Crash.pedestrian_involved.is_(True))
+        agg = func.count(Crash.id)
+    elif metric == "total_killed":
+        agg = func.sum(Crash.number_killed)
+    elif metric == "total_injured":
+        agg = func.sum(Crash.number_injured)
+    else:
+        agg = func.count(Crash.id)
+
+    stmt = (
+        select(
+            Crash.county_code.label("county_code"),
+            Crash.county_name.label("county_name"),
+            agg.label("value"),
+        )
+        .where(*preds)
+        .group_by(Crash.county_code, Crash.county_name)
+    )
+    rows = db.execute(stmt).fetchall()
+    return [
+        {"county_code": r.county_code, "county_name": r.county_name, "value": float(r.value or 0)}
+        for r in rows
+    ]

--- a/backend/tests/api/test_stats_distribution.py
+++ b/backend/tests/api/test_stats_distribution.py
@@ -1,0 +1,14 @@
+"""Tests for GET /api/stats/distribution — per-county metric distribution."""
+
+
+def test_distribution_returns_all_counties(client):
+    r = client.get("/api/stats/distribution?metric=crash_count")
+    assert r.status_code == 200
+    body = r.json()
+    assert isinstance(body, list)
+    assert all("county_code" in row and "value" in row for row in body)
+
+
+def test_distribution_rejects_bad_metric(client):
+    r = client.get("/api/stats/distribution?metric=bogus")
+    assert r.status_code == 422

--- a/docs/superpowers/plans/2026-06-27-ai-storytelling-p0-spine.md
+++ b/docs/superpowers/plans/2026-06-27-ai-storytelling-p0-spine.md
@@ -1,0 +1,1055 @@
+# AI Storytelling — P0 (Spine) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the shared primitives every later phase depends on — `DataContext`, the local "instant tier" explanation engine, the `AiCompanion` surface, and the `<Explainable>` wrapper — plus the `/api/stats/distribution` endpoint that powers percentile context.
+
+**Architecture:** A serializable `DataContext` describes any data element (frozen literal value/series + filter snapshot). `<Explainable>` wraps elements, adds affordance + a11y, and hands its context to `AiCompanionProvider`, which renders a popover/bottom-sheet. The companion resolves explanations in two tiers: instant local (`explainContext` → `statNarrative` / existing `narrativeEngine`) and on-demand Groq (existing `useAskAi`). The backend adds one read endpoint returning per-county values for percentile math.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Vitest (frontend); FastAPI + SQLAlchemy + pytest (backend). Charts via the existing `ChartData` shape. No new runtime dependencies.
+
+## Global Constraints
+
+- No new npm or pip dependencies in P0 — reuse existing libs only.
+- All new frontend files live under `frontend/src/lib/ai/` and `frontend/src/components/ai/`.
+- `DataContext` and `FilterSnapshot` MUST be JSON-serializable (no `Set`, no `Date`, no functions) so they round-trip through URLs and storage.
+- The instant tier MUST NOT make network/LLM calls. Only the explicit "Go deeper with AI" action calls `/api/ask`.
+- Follow existing test patterns: frontend `*.test.ts(x)` beside source, run with `npx vitest run <path>`; backend tests in `backend/tests/`, run with `python -m pytest`.
+- Backend endpoint mirrors the `/stats/highways` style: `_limiter` rate limit, `Cache-Control` header, `Depends(get_db)`, `parse_*` filter helpers.
+
+---
+
+## File Structure
+
+- `frontend/src/lib/ai/dataContext.ts` — `DataContext`, `FilterSnapshot` types; `hashContext`, `serializeContext`, `deserializeContext`.
+- `frontend/src/lib/ai/contextBuilders.ts` — `snapshotFilters()`, `statContext()`, `chartContext()`.
+- `frontend/src/lib/ai/statNarrative.ts` — `statNarrative()` percentile/rank prose from a distribution.
+- `frontend/src/lib/ai/explainContext.ts` — `explainContext()` dispatcher (stat → statNarrative, chart → narrativeEngine).
+- `frontend/src/components/ai/AiCompanion.tsx` — `AiCompanionProvider`, `useAiCompanion()`, the popover/sheet surface.
+- `frontend/src/components/ai/Explainable.tsx` — `<Explainable>` wrapper + `useExplainable()`.
+- `backend/app/routers/stats.py` — add `GET /stats/distribution` (modify).
+- Tests beside each source file; backend `backend/tests/api/test_stats_distribution.py`.
+
+---
+
+## Task 1: `DataContext` types + serialization
+
+**Files:**
+- Create: `frontend/src/lib/ai/dataContext.ts`
+- Test: `frontend/src/lib/ai/dataContext.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type FilterSnapshot = { years: number[]; severities: string[]; counties: string[]; causes: string[]; alcohol: boolean | null; distracted: boolean | null; pedestrian: boolean | null; cyclist: boolean | null; drug: boolean | null; driverAge: string | null; weather: string[]; lighting: string[]; collisionType: string[]; roadType: string | null; hitRun: boolean | null }`
+  - `type DataContext = { kind: "stat" | "chart" | "county" | "highway" | "view" | "correlation"; label: string; filters: FilterSnapshot; measure?: string; geography?: { type: "county" | "highway" | "state"; id: string; name: string }; value?: number; series?: { label: string; value: number }[]; }`
+  - `hashContext(ctx: DataContext): string`
+  - `serializeContext(ctx: DataContext): string`
+  - `deserializeContext(raw: string): DataContext | null`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/lib/ai/dataContext.test.ts
+import { describe, it, expect } from "vitest";
+import { hashContext, serializeContext, deserializeContext, type DataContext } from "./dataContext";
+
+const emptyFilters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+const ctx: DataContext = {
+  kind: "stat", label: "Fatality rate · Kern County",
+  measure: "fatality_rate", value: 1.23,
+  geography: { type: "county", id: "15", name: "Kern" },
+  filters: emptyFilters,
+};
+
+describe("dataContext", () => {
+  it("round-trips through serialize/deserialize", () => {
+    const restored = deserializeContext(serializeContext(ctx));
+    expect(restored).toEqual(ctx);
+  });
+
+  it("returns null for malformed input", () => {
+    expect(deserializeContext("not json")).toBeNull();
+  });
+
+  it("hashes equal contexts equally and differs on value", () => {
+    expect(hashContext(ctx)).toBe(hashContext({ ...ctx }));
+    expect(hashContext(ctx)).not.toBe(hashContext({ ...ctx, value: 9.99 }));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/lib/ai/dataContext.test.ts`
+Expected: FAIL — cannot find module `./dataContext`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/lib/ai/dataContext.ts
+export type FilterSnapshot = {
+  years: number[];
+  severities: string[];
+  counties: string[];
+  causes: string[];
+  alcohol: boolean | null;
+  distracted: boolean | null;
+  pedestrian: boolean | null;
+  cyclist: boolean | null;
+  drug: boolean | null;
+  driverAge: string | null;
+  weather: string[];
+  lighting: string[];
+  collisionType: string[];
+  roadType: string | null;
+  hitRun: boolean | null;
+};
+
+export type ChartPoint = { label: string; value: number };
+
+export type DataContext = {
+  kind: "stat" | "chart" | "county" | "highway" | "view" | "correlation";
+  label: string;
+  filters: FilterSnapshot;
+  measure?: string;
+  geography?: { type: "county" | "highway" | "state"; id: string; name: string };
+  value?: number;
+  series?: ChartPoint[];
+};
+
+export function serializeContext(ctx: DataContext): string {
+  return JSON.stringify(ctx);
+}
+
+export function deserializeContext(raw: string): DataContext | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && typeof parsed.kind === "string" && parsed.filters) {
+      return parsed as DataContext;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Stable, order-independent hash for cache keys.
+export function hashContext(ctx: DataContext): string {
+  const stable = JSON.stringify(ctx, Object.keys(ctx).sort());
+  let h = 0;
+  for (let i = 0; i < stable.length; i++) {
+    h = (h << 5) - h + stable.charCodeAt(i);
+    h |= 0;
+  }
+  return `ctx_${h >>> 0}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/lib/ai/dataContext.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/ai/dataContext.ts frontend/src/lib/ai/dataContext.test.ts
+git commit -m "feat(ai): DataContext types + serialization (P0 spine)"
+```
+
+---
+
+## Task 2: Context builders from filter/UI state
+
+**Files:**
+- Create: `frontend/src/lib/ai/contextBuilders.ts`
+- Test: `frontend/src/lib/ai/contextBuilders.test.ts`
+
+**Interfaces:**
+- Consumes: `FilterSnapshot`, `DataContext`, `ChartPoint` from `./dataContext`.
+- Produces:
+  - `snapshotFilters(f: FilterInputs): FilterSnapshot` where `FilterInputs` accepts `Set<string>`/`Set<number>` fields exactly as returned by `useFilterParams` (see type below).
+  - `statContext(args: { label: string; measure: string; value: number; geography?: DataContext["geography"]; filters: FilterSnapshot }): DataContext`
+  - `chartContext(args: { label: string; series: ChartPoint[]; measure?: string; filters: FilterSnapshot }): DataContext`
+  - `type FilterInputs = { selectedYears: Set<number>; selectedSeverities: Set<string>; selectedCounties: Set<string>; selectedCauses: Set<string>; selectedAlcohol: boolean; selectedDistracted: boolean; selectedPedestrian: boolean; selectedCyclist: boolean; selectedDrug: boolean; selectedDriverAge: string | null; selectedWeather: Set<string>; selectedLighting: Set<string>; selectedCollisionType: Set<string>; selectedRoadType: string | null; selectedHitRun: boolean }`
+
+> Note: `useFilterParams` returns boolean flags (not `boolean | null`). `snapshotFilters` maps `false` → `null` for flags so "no filter" is distinguishable in the snapshot. Sets become sorted arrays for stability.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/lib/ai/contextBuilders.test.ts
+import { describe, it, expect } from "vitest";
+import { snapshotFilters, statContext, chartContext } from "./contextBuilders";
+
+const inputs = {
+  selectedYears: new Set([2023, 2022]),
+  selectedSeverities: new Set(["Fatal"]),
+  selectedCounties: new Set(["kern"]),
+  selectedCauses: new Set<string>(),
+  selectedAlcohol: true,
+  selectedDistracted: false,
+  selectedPedestrian: false,
+  selectedCyclist: false,
+  selectedDrug: false,
+  selectedDriverAge: null,
+  selectedWeather: new Set<string>(),
+  selectedLighting: new Set<string>(),
+  selectedCollisionType: new Set<string>(),
+  selectedRoadType: null,
+  selectedHitRun: false,
+};
+
+describe("contextBuilders", () => {
+  it("snapshots filters: sorts sets, maps false flags to null", () => {
+    const snap = snapshotFilters(inputs);
+    expect(snap.years).toEqual([2022, 2023]);
+    expect(snap.severities).toEqual(["Fatal"]);
+    expect(snap.alcohol).toBe(true);
+    expect(snap.distracted).toBeNull();
+    expect(snap.weather).toEqual([]);
+  });
+
+  it("builds a stat context", () => {
+    const ctx = statContext({
+      label: "Fatality rate · Kern", measure: "fatality_rate", value: 1.5,
+      geography: { type: "county", id: "15", name: "Kern" },
+      filters: snapshotFilters(inputs),
+    });
+    expect(ctx.kind).toBe("stat");
+    expect(ctx.value).toBe(1.5);
+    expect(ctx.measure).toBe("fatality_rate");
+  });
+
+  it("builds a chart context with frozen series", () => {
+    const ctx = chartContext({
+      label: "Crashes by hour", series: [{ label: "0", value: 10 }],
+      filters: snapshotFilters(inputs),
+    });
+    expect(ctx.kind).toBe("chart");
+    expect(ctx.series).toEqual([{ label: "0", value: 10 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/lib/ai/contextBuilders.test.ts`
+Expected: FAIL — cannot find module `./contextBuilders`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/lib/ai/contextBuilders.ts
+import type { DataContext, FilterSnapshot, ChartPoint } from "./dataContext";
+
+export type FilterInputs = {
+  selectedYears: Set<number>;
+  selectedSeverities: Set<string>;
+  selectedCounties: Set<string>;
+  selectedCauses: Set<string>;
+  selectedAlcohol: boolean;
+  selectedDistracted: boolean;
+  selectedPedestrian: boolean;
+  selectedCyclist: boolean;
+  selectedDrug: boolean;
+  selectedDriverAge: string | null;
+  selectedWeather: Set<string>;
+  selectedLighting: Set<string>;
+  selectedCollisionType: Set<string>;
+  selectedRoadType: string | null;
+  selectedHitRun: boolean;
+};
+
+const flag = (b: boolean): boolean | null => (b ? true : null);
+const sortedNums = (s: Set<number>) => [...s].sort((a, b) => a - b);
+const sortedStrs = (s: Set<string>) => [...s].sort();
+
+export function snapshotFilters(f: FilterInputs): FilterSnapshot {
+  return {
+    years: sortedNums(f.selectedYears),
+    severities: sortedStrs(f.selectedSeverities),
+    counties: sortedStrs(f.selectedCounties),
+    causes: sortedStrs(f.selectedCauses),
+    alcohol: flag(f.selectedAlcohol),
+    distracted: flag(f.selectedDistracted),
+    pedestrian: flag(f.selectedPedestrian),
+    cyclist: flag(f.selectedCyclist),
+    drug: flag(f.selectedDrug),
+    driverAge: f.selectedDriverAge,
+    weather: sortedStrs(f.selectedWeather),
+    lighting: sortedStrs(f.selectedLighting),
+    collisionType: sortedStrs(f.selectedCollisionType),
+    roadType: f.selectedRoadType,
+    hitRun: flag(f.selectedHitRun),
+  };
+}
+
+export function statContext(args: {
+  label: string; measure: string; value: number;
+  geography?: DataContext["geography"]; filters: FilterSnapshot;
+}): DataContext {
+  return { kind: "stat", label: args.label, measure: args.measure, value: args.value, geography: args.geography, filters: args.filters };
+}
+
+export function chartContext(args: {
+  label: string; series: ChartPoint[]; measure?: string; filters: FilterSnapshot;
+}): DataContext {
+  return { kind: "chart", label: args.label, series: args.series, measure: args.measure, filters: args.filters };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/lib/ai/contextBuilders.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/ai/contextBuilders.ts frontend/src/lib/ai/contextBuilders.test.ts
+git commit -m "feat(ai): context builders from filter state (P0 spine)"
+```
+
+---
+
+## Task 3: `statNarrative` — percentile/rank prose (instant tier for stats)
+
+**Files:**
+- Create: `frontend/src/lib/ai/statNarrative.ts`
+- Test: `frontend/src/lib/ai/statNarrative.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type DistributionPoint = { id: string; name: string; value: number }`
+  - `type StatNarrative = { percentile: number; rank: number; total: number; paragraph: string }`
+  - `statNarrative(args: { label: string; value: number; subjectId: string; distribution: DistributionPoint[]; higherIsWorse?: boolean }): StatNarrative`
+
+> `percentile` = share of the distribution the subject is "safer than" (lower value = safer when `higherIsWorse`, the default). `rank` is 1-based with rank 1 = worst.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/lib/ai/statNarrative.test.ts
+import { describe, it, expect } from "vitest";
+import { statNarrative, type DistributionPoint } from "./statNarrative";
+
+const dist: DistributionPoint[] = [
+  { id: "a", name: "A", value: 1 },
+  { id: "b", name: "B", value: 2 },
+  { id: "c", name: "C", value: 3 },
+  { id: "d", name: "D", value: 4 },
+];
+
+describe("statNarrative", () => {
+  it("ranks the worst (highest) subject rank 1", () => {
+    const n = statNarrative({ label: "Fatality rate", value: 4, subjectId: "d", distribution: dist });
+    expect(n.rank).toBe(1);
+    expect(n.total).toBe(4);
+  });
+
+  it("computes percentile safer-than for a low value", () => {
+    const n = statNarrative({ label: "Fatality rate", value: 1, subjectId: "a", distribution: dist });
+    // safer than B, C, D = 3 of 4 = 75%
+    expect(n.percentile).toBe(75);
+    expect(n.paragraph).toContain("safer than 75%");
+  });
+
+  it("produces a non-empty paragraph naming the metric", () => {
+    const n = statNarrative({ label: "Fatality rate", value: 2, subjectId: "b", distribution: dist });
+    expect(n.paragraph.toLowerCase()).toContain("fatality rate");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/lib/ai/statNarrative.test.ts`
+Expected: FAIL — cannot find module `./statNarrative`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/lib/ai/statNarrative.ts
+export type DistributionPoint = { id: string; name: string; value: number };
+
+export type StatNarrative = {
+  percentile: number;
+  rank: number;
+  total: number;
+  paragraph: string;
+};
+
+export function statNarrative(args: {
+  label: string;
+  value: number;
+  subjectId: string;
+  distribution: DistributionPoint[];
+  higherIsWorse?: boolean;
+}): StatNarrative {
+  const higherIsWorse = args.higherIsWorse ?? true;
+  const total = args.distribution.length;
+  // rank 1 = worst
+  const sorted = [...args.distribution].sort((a, b) =>
+    higherIsWorse ? b.value - a.value : a.value - b.value,
+  );
+  const idx = sorted.findIndex((d) => d.id === args.subjectId);
+  const rank = idx >= 0 ? idx + 1 : total;
+
+  const saferCount = args.distribution.filter((d) =>
+    higherIsWorse ? d.value < args.value : d.value > args.value,
+  ).length;
+  const percentile = total > 1 ? Math.round((saferCount / (total - 0)) * 100) : 0;
+
+  const paragraph =
+    `${args.label} here ranks #${rank} of ${total} — ` +
+    `safer than ${percentile}% of the group. ` +
+    `This is an association in the data, not a cause.`;
+
+  return { percentile, rank, total, paragraph };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/lib/ai/statNarrative.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/ai/statNarrative.ts frontend/src/lib/ai/statNarrative.test.ts
+git commit -m "feat(ai): statNarrative percentile/rank prose (P0 spine)"
+```
+
+---
+
+## Task 4: `explainContext` dispatcher (instant tier)
+
+**Files:**
+- Create: `frontend/src/lib/ai/explainContext.ts`
+- Test: `frontend/src/lib/ai/explainContext.test.ts`
+
+**Interfaces:**
+- Consumes: `DataContext` from `./dataContext`; `statNarrative`, `DistributionPoint` from `./statNarrative`.
+- Produces:
+  - `type Explanation = { headline: string; body: string }`
+  - `explainContext(ctx: DataContext, deps?: { distribution?: DistributionPoint[] }): Explanation`
+
+> P0 handles `kind: "stat"` (via `statNarrative`) and `kind: "chart"` (simple peak/total summary inline — full `narrativeEngine` integration lands in P1 when charts are wrapped). Any other kind returns a generic label-based explanation. Keeping the chart branch self-contained avoids depending on `narrativeEngine`'s richer types in P0.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/src/lib/ai/explainContext.test.ts
+import { describe, it, expect } from "vitest";
+import { explainContext } from "./explainContext";
+import type { DataContext } from "./dataContext";
+
+const filters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("explainContext", () => {
+  it("explains a stat using the distribution", () => {
+    const ctx: DataContext = { kind: "stat", label: "Fatality rate", measure: "fatality_rate", value: 1, geography: { type: "county", id: "a", name: "A" }, filters };
+    const out = explainContext(ctx, { distribution: [
+      { id: "a", name: "A", value: 1 }, { id: "b", name: "B", value: 5 },
+    ]});
+    expect(out.body).toContain("safer than");
+  });
+
+  it("explains a chart by naming its peak", () => {
+    const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "8am", value: 3 }, { label: "5pm", value: 9 }], filters };
+    const out = explainContext(ctx);
+    expect(out.body).toContain("5pm");
+  });
+
+  it("falls back to label for unknown kinds", () => {
+    const ctx: DataContext = { kind: "county", label: "Kern County", filters };
+    const out = explainContext(ctx);
+    expect(out.headline).toContain("Kern County");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/lib/ai/explainContext.test.ts`
+Expected: FAIL — cannot find module `./explainContext`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/lib/ai/explainContext.ts
+import type { DataContext } from "./dataContext";
+import { statNarrative, type DistributionPoint } from "./statNarrative";
+
+export type Explanation = { headline: string; body: string };
+
+export function explainContext(
+  ctx: DataContext,
+  deps?: { distribution?: DistributionPoint[] },
+): Explanation {
+  if (ctx.kind === "stat" && ctx.value != null && deps?.distribution?.length) {
+    const subjectId = ctx.geography?.id ?? "__subject__";
+    const n = statNarrative({
+      label: ctx.label, value: ctx.value, subjectId,
+      distribution: deps.distribution,
+    });
+    return { headline: ctx.label, body: n.paragraph };
+  }
+
+  if (ctx.kind === "chart" && ctx.series?.length) {
+    const peak = ctx.series.reduce((a, b) => (b.value > a.value ? b : a));
+    const total = ctx.series.reduce((sum, p) => sum + p.value, 0);
+    return {
+      headline: ctx.label,
+      body: `Peaks at ${peak.label} (${peak.value.toLocaleString()}), out of ${total.toLocaleString()} total.`,
+    };
+  }
+
+  return { headline: ctx.label, body: `Select "Go deeper with AI" to analyze ${ctx.label}.` };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/lib/ai/explainContext.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/ai/explainContext.ts frontend/src/lib/ai/explainContext.test.ts
+git commit -m "feat(ai): explainContext instant-tier dispatcher (P0 spine)"
+```
+
+---
+
+## Task 5: `/api/stats/distribution` backend endpoint
+
+**Files:**
+- Modify: `backend/app/routers/stats.py` (add endpoint near `stats_highways`)
+- Test: `backend/tests/api/test_stats_distribution.py`
+
+**Interfaces:**
+- Produces: `GET /api/stats/distribution?metric=<m>&year=<y>` → `200` with `list[{county_code: int, county_name: str, value: float}]` (all counties present in the data for the filters), or `422` for an invalid `metric`.
+- `metric` accepts the same values as the existing `rank_counties` tool: `crash_count | total_killed | total_injured | fatal_crashes | alcohol_crashes | pedestrian_crashes`.
+
+> Reuse the `rank_counties` query shape (`backend/app/ai_tools.py:220`) but without the small `limit` — return every county. This is the distribution the frontend reduces into a percentile.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# backend/tests/api/test_stats_distribution.py
+def test_distribution_returns_all_counties(client):
+    r = client.get("/api/stats/distribution?metric=crash_count")
+    assert r.status_code == 200
+    body = r.json()
+    assert isinstance(body, list)
+    assert all("county_code" in row and "value" in row for row in body)
+
+
+def test_distribution_rejects_bad_metric(client):
+    r = client.get("/api/stats/distribution?metric=bogus")
+    assert r.status_code == 422
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/api/test_stats_distribution.py -q`
+Expected: FAIL — 404 (route not defined) so the 200 assertion fails.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `backend/app/routers/stats.py` (after `stats_highways`). Reuse the existing imports (`select`, `func`, `Crash`, `Query`, `Request`, `Response`, `Depends`, `get_db`, `_limiter`):
+
+```python
+_DISTRIBUTION_METRICS = {
+    "crash_count", "total_killed", "total_injured",
+    "fatal_crashes", "alcohol_crashes", "pedestrian_crashes",
+}
+
+
+@router.get("/stats/distribution")
+@_limiter.limit("1000/minute;20000/hour")
+def stats_distribution(
+    request: Request,
+    response: Response,
+    metric: str = Query("crash_count"),
+    year: int | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Per-county values for one metric — the distribution the frontend reduces
+    into percentile/rank context ("safer than X% of counties").
+
+    Mirrors the rank_counties tool but returns every county (no small limit).
+    """
+    if metric not in _DISTRIBUTION_METRICS:
+        raise HTTPException(status_code=422, detail=f"invalid metric: {metric}")
+
+    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+
+    preds = []
+    if year is not None:
+        preds.append(Crash.crash_year == year)
+    if metric == "fatal_crashes":
+        preds.append(Crash.severity == "Fatal")
+        agg = func.count(Crash.id)
+    elif metric == "alcohol_crashes":
+        preds.append(Crash.is_alcohol_involved.is_(True))
+        agg = func.count(Crash.id)
+    elif metric == "pedestrian_crashes":
+        preds.append(Crash.pedestrian_involved.is_(True))
+        agg = func.count(Crash.id)
+    elif metric == "total_killed":
+        agg = func.sum(Crash.number_killed)
+    elif metric == "total_injured":
+        agg = func.sum(Crash.number_injured)
+    else:
+        agg = func.count(Crash.id)
+
+    stmt = (
+        select(
+            Crash.county_code.label("county_code"),
+            Crash.county_name.label("county_name"),
+            agg.label("value"),
+        )
+        .where(*preds)
+        .group_by(Crash.county_code, Crash.county_name)
+    )
+    rows = db.execute(stmt).fetchall()
+    return [
+        {"county_code": r.county_code, "county_name": r.county_name, "value": float(r.value or 0)}
+        for r in rows
+    ]
+```
+
+If `HTTPException` is not already imported at the top of `stats.py`, add it to the existing `from fastapi import ...` line.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && python -m pytest tests/api/test_stats_distribution.py -q`
+Expected: PASS (2 tests). (Requires the seeded test DB the other `tests/api/` tests use.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routers/stats.py backend/tests/api/test_stats_distribution.py
+git commit -m "feat(api): GET /stats/distribution per-county metric values (P0 spine)"
+```
+
+---
+
+## Task 6: `AiCompanionProvider` + companion surface
+
+**Files:**
+- Create: `frontend/src/components/ai/AiCompanion.tsx`
+- Test: `frontend/src/components/ai/AiCompanion.test.tsx`
+
+**Interfaces:**
+- Consumes: `DataContext` from `../../lib/ai/dataContext`; `explainContext` from `../../lib/ai/explainContext`.
+- Produces:
+  - `AiCompanionProvider({ children }: { children: ReactNode }): JSX.Element`
+  - `useAiCompanion(): { open: (ctx: DataContext) => void; close: () => void; current: DataContext | null }`
+  - Renders a region with `role="dialog"` and `aria-label="AI explanation"` when open, showing the instant-tier `explainContext` output. ESC closes.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/ai/AiCompanion.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function Trigger() {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>explain</button>;
+}
+
+describe("AiCompanion", () => {
+  it("opens on demand and shows the instant explanation", () => {
+    render(<AiCompanionProvider><Trigger /></AiCompanionProvider>);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByText("explain"));
+    const dialog = screen.getByRole("dialog", { name: "AI explanation" });
+    expect(dialog).toBeTruthy();
+    expect(dialog.textContent).toContain("Crashes by hour");
+  });
+
+  it("closes on Escape", () => {
+    render(<AiCompanionProvider><Trigger /></AiCompanionProvider>);
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/ai/AiCompanion.test.tsx`
+Expected: FAIL — cannot find module `./AiCompanion`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// frontend/src/components/ai/AiCompanion.tsx
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { DataContext } from "../../lib/ai/dataContext";
+import { explainContext } from "../../lib/ai/explainContext";
+
+type CompanionApi = {
+  open: (ctx: DataContext) => void;
+  close: () => void;
+  current: DataContext | null;
+};
+
+const Ctx = createContext<CompanionApi | null>(null);
+
+export function AiCompanionProvider({ children }: { children: ReactNode }) {
+  const [current, setCurrent] = useState<DataContext | null>(null);
+
+  const open = useCallback((ctx: DataContext) => setCurrent(ctx), []);
+  const close = useCallback(() => setCurrent(null), []);
+
+  useEffect(() => {
+    if (!current) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [current, close]);
+
+  const api = useMemo<CompanionApi>(() => ({ open, close, current }), [open, close, current]);
+  const explanation = current ? explainContext(current) : null;
+
+  return (
+    <Ctx.Provider value={api}>
+      {children}
+      {current && explanation && (
+        <div
+          role="dialog"
+          aria-label="AI explanation"
+          className="fixed bottom-4 right-4 z-[1000] max-w-sm rounded-xl bg-surface-container-high p-4 shadow-lg ghost-border md:bottom-4 md:right-4"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="text-sm font-semibold text-on-surface">{explanation.headline}</h2>
+            <button onClick={close} aria-label="Close explanation" className="text-on-surface-variant hover:text-on-surface">✕</button>
+          </div>
+          <p className="mt-2 text-sm text-on-surface-variant">{explanation.body}</p>
+        </div>
+      )}
+    </Ctx.Provider>
+  );
+}
+
+export function useAiCompanion(): CompanionApi {
+  const api = useContext(Ctx);
+  if (!api) throw new Error("useAiCompanion must be used inside <AiCompanionProvider>");
+  return api;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/ai/AiCompanion.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/ai/AiCompanion.tsx frontend/src/components/ai/AiCompanion.test.tsx
+git commit -m "feat(ai): AiCompanion provider + instant-tier surface (P0 spine)"
+```
+
+---
+
+## Task 7: `<Explainable>` wrapper + affordance + a11y
+
+**Files:**
+- Create: `frontend/src/components/ai/Explainable.tsx`
+- Test: `frontend/src/components/ai/Explainable.test.tsx`
+
+**Interfaces:**
+- Consumes: `DataContext` from `../../lib/ai/dataContext`; `useAiCompanion` from `./AiCompanion`.
+- Produces: `Explainable({ context, children, className }: { context: DataContext; children: ReactNode; className?: string }): JSX.Element` — renders a focusable `role="button"` span with `aria-label="Explain: <label>"` that opens the companion on click and Enter/Space.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/ai/Explainable.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AiCompanionProvider } from "./AiCompanion";
+import { Explainable } from "./Explainable";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function setup() {
+  render(
+    <AiCompanionProvider>
+      <Explainable context={ctx}><span>9</span></Explainable>
+    </AiCompanionProvider>,
+  );
+}
+
+describe("Explainable", () => {
+  it("exposes an accessible explain button", () => {
+    setup();
+    expect(screen.getByRole("button", { name: "Explain: Crashes by hour" })).toBeTruthy();
+  });
+
+  it("opens the companion on Enter", () => {
+    setup();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Explain: Crashes by hour" }), { key: "Enter" });
+    expect(screen.getByRole("dialog", { name: "AI explanation" })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/ai/Explainable.test.tsx`
+Expected: FAIL — cannot find module `./Explainable`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// frontend/src/components/ai/Explainable.tsx
+import type { ReactNode } from "react";
+import type { DataContext } from "../../lib/ai/dataContext";
+import { useAiCompanion } from "./AiCompanion";
+
+export function Explainable({
+  context, children, className,
+}: { context: DataContext; children: ReactNode; className?: string }) {
+  const { open } = useAiCompanion();
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label={`Explain: ${context.label}`}
+      onClick={() => open(context)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          open(context);
+        }
+      }}
+      className={`cursor-help underline decoration-dotted decoration-on-surface-variant/40 underline-offset-2 hover:decoration-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${className ?? ""}`}
+    >
+      {children}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/ai/Explainable.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/ai/Explainable.tsx frontend/src/components/ai/Explainable.test.tsx
+git commit -m "feat(ai): Explainable wrapper with affordance + a11y (P0 spine)"
+```
+
+---
+
+## Task 8: Deep-tier "Go deeper with AI" wiring
+
+**Files:**
+- Modify: `frontend/src/components/ai/AiCompanion.tsx`
+- Test: `frontend/src/components/ai/AiCompanion.deepdive.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAskAi` from `../../hooks/useAskAi` (existing — `sendMessage(question: string)`, `messages`, `isLoading`).
+- Produces: the companion renders a "Go deeper with AI" button that calls `sendMessage` with a context-derived question string built by a new exported pure helper `buildDeepDivePrompt(ctx: DataContext): string`.
+
+> Keep the prompt builder pure and exported so it's unit-testable without rendering. The button wiring reuses the existing `useAskAi`; mock it in the test.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/ai/AiCompanion.deepdive.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { buildDeepDivePrompt } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [2023], severities: ["Fatal"], counties: ["kern"], causes: [],
+  alcohol: true, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("buildDeepDivePrompt", () => {
+  it("includes the label, value, and active filters", () => {
+    const ctx: DataContext = { kind: "stat", label: "Fatality rate · Kern", measure: "fatality_rate", value: 1.5, geography: { type: "county", id: "15", name: "Kern" }, filters };
+    const prompt = buildDeepDivePrompt(ctx);
+    expect(prompt).toContain("Fatality rate · Kern");
+    expect(prompt).toContain("1.5");
+    expect(prompt).toContain("Kern");
+    expect(prompt.toLowerCase()).toContain("2023");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/ai/AiCompanion.deepdive.test.tsx`
+Expected: FAIL — `buildDeepDivePrompt` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `frontend/src/components/ai/AiCompanion.tsx` (export the helper; wire a button into the dialog). First add the pure helper:
+
+```tsx
+export function buildDeepDivePrompt(ctx: DataContext): string {
+  const parts: string[] = [`Explain this CalSight data point: "${ctx.label}".`];
+  if (ctx.value != null) parts.push(`Value: ${ctx.value}.`);
+  if (ctx.geography) parts.push(`Area: ${ctx.geography.name}.`);
+  const f = ctx.filters;
+  if (f.years.length) parts.push(`Years: ${f.years.join(", ")}.`);
+  if (f.severities.length) parts.push(`Severities: ${f.severities.join(", ")}.`);
+  if (f.counties.length && !ctx.geography) parts.push(`Counties: ${f.counties.join(", ")}.`);
+  if (f.alcohol) parts.push("Alcohol-involved only.");
+  parts.push("Be concise and avoid claiming causation.");
+  return parts.join(" ");
+}
+```
+
+Then, inside the dialog JSX in `AiCompanionProvider`, import and use `useAskAi` and render the button below the `<p>`:
+
+```tsx
+// add import at top:
+// import { useAskAi } from "../../hooks/useAskAi";
+
+// inside AiCompanionProvider, before return:
+const { sendMessage, isLoading } = useAskAi();
+
+// inside the dialog, after the <p> body:
+<button
+  onClick={() => current && sendMessage(buildDeepDivePrompt(current))}
+  disabled={isLoading}
+  className="mt-3 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary disabled:opacity-50"
+>
+  {isLoading ? "Thinking…" : "Go deeper with AI"}
+</button>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/ai/AiCompanion.deepdive.test.tsx`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Run the full AI suite + typecheck**
+
+Run: `cd frontend && npx vitest run src/lib/ai src/components/ai && npx tsc --noEmit`
+Expected: all AI tests PASS, `tsc` exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ai/AiCompanion.tsx frontend/src/components/ai/AiCompanion.deepdive.test.tsx
+git commit -m "feat(ai): deep-dive prompt builder + Go deeper button (P0 spine)"
+```
+
+---
+
+## Task 9: Mount the provider + prove it end-to-end on one number
+
+**Files:**
+- Modify: `frontend/src/main.tsx` (wrap the app in `AiCompanionProvider`)
+- Modify: one existing stat-rendering component (e.g. `frontend/src/components/map/StatewideHeatmapCard.tsx`) to wrap a single number in `<Explainable>`
+- Test: manual / existing suite regression
+
+**Interfaces:**
+- Consumes: `AiCompanionProvider` (Task 6), `Explainable` (Task 7), `statContext` + `snapshotFilters` (Task 2), `useFilterParams` (existing).
+
+- [ ] **Step 1: Wrap the app**
+
+In `frontend/src/main.tsx`, wrap the existing root tree with `<AiCompanionProvider>…</AiCompanionProvider>` (inside the Router/QueryClient providers so hooks resolve).
+
+- [ ] **Step 2: Wrap one real number**
+
+In the chosen component, build a context and wrap the rendered number:
+
+```tsx
+import { Explainable } from "../ai/Explainable";
+import { statContext, snapshotFilters } from "../../lib/ai/contextBuilders";
+import { useFilterParams } from "../../hooks/useFilterParams";
+
+// inside the component:
+const fp = useFilterParams();
+// ...where the number renders:
+<Explainable
+  context={statContext({
+    label: "Statewide fatal crashes",
+    measure: "fatalities_per_100k",
+    value: fatalCount,
+    filters: snapshotFilters(fp),
+  })}
+>
+  {fatalCount.toLocaleString()}
+</Explainable>
+```
+
+- [ ] **Step 3: Typecheck + run the full frontend suite**
+
+Run: `cd frontend && npx tsc --noEmit && npx vitest run`
+Expected: `tsc` exits 0; all tests PASS (no regressions).
+
+- [ ] **Step 4: Manual smoke (dev server)**
+
+Run: `cd frontend && npm run dev` then open the page, click the wrapped number, confirm the companion opens with an instant explanation and a "Go deeper with AI" button.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/main.tsx frontend/src/components/map/StatewideHeatmapCard.tsx
+git commit -m "feat(ai): mount AiCompanion + first Explainable number (P0 spine)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (P0 scope of the design doc):**
+- DataContext + frozen literal data → Task 1 ✅
+- FilterSnapshot + builders → Task 2 ✅
+- statNarrative percentile context → Task 3 ✅
+- explainContext instant tier → Task 4 ✅
+- `/api/stats/distribution` → Task 5 ✅
+- AiCompanionProvider + surface → Task 6 ✅
+- `<Explainable>` + a11y → Task 7 ✅
+- Hybrid deep tier (Groq via useAskAi) → Task 8 ✅
+- End-to-end mount + proof → Task 9 ✅
+- (Full `narrativeEngine` chart integration, percentile wiring into the UI, and rollout across all surfaces are **P1**, by design.)
+
+**Type consistency:** `DataContext`, `FilterSnapshot`, `ChartPoint`, `DistributionPoint`, `Explanation`, `StatNarrative`, `CompanionApi`, `buildDeepDivePrompt` are defined once and consumed with matching signatures across tasks. `useAiCompanion().open(ctx)` matches `Explainable`'s call. `statContext`/`snapshotFilters` signatures match their Task 9 usage.
+
+**Placeholder scan:** No TBD/TODO; every code step shows real code; every test step has real assertions and a run command with expected result.

--- a/docs/superpowers/specs/2026-06-27-interactive-ai-storytelling-design.md
+++ b/docs/superpowers/specs/2026-06-27-interactive-ai-storytelling-design.md
@@ -1,0 +1,216 @@
+# Interactive AI Storytelling — Design Spec
+
+> Status: design approved 2026-06-27. Scope: the full "interactive UI everywhere,
+> woven through Ask AI" overhaul. One spec, **phased delivery** — each phase ships
+> as its own reviewable PR. No single giant merge to the live prod site.
+
+## 1. Goal
+
+Turn CalSight from a dashboard you *read* into a data tool you *converse with*. Every
+data element — a number, a chart mark, a county, a highway — becomes a launchpad to
+understand it in context: an instant plain-language explanation, optional AI deep-dive,
+and follow-up questions, all inline. Storytelling emerges from pervasive interactivity
+rather than a single "story page." Users can pin what they find into shareable stories,
+and the AI can reach across CalSight's cross-domain data (crashes × weather × census ×
+environmental justice × economics × vehicles × infrastructure) to narrate correlations
+no other crash tool surfaces.
+
+### Success criteria
+- Any stat number, chart element, county, or highway can be "explained" inline.
+- The instant explanation is local (free, no spinner); AI deep-dive is opt-in.
+- A user can pin AI answers/charts into a story and share it via deep link + OG image.
+- The AI can answer cross-domain correlation questions and hedge causation.
+- Nothing degrades the live site: graceful fallback when AI is rate-limited/unavailable.
+
+## 2. Architecture — the Spine
+
+All features are producers or consumers of **two new primitives**. Get these right and
+every cluster is a thin plug-in.
+
+### 2.1 `DataContext` (`frontend/src/lib/ai/dataContext.ts`)
+A serializable descriptor of "what is this data element."
+
+```ts
+type DataContext = {
+  kind: "stat" | "chart" | "county" | "highway" | "view" | "correlation";
+  measure?: MeasureKey;                 // fatality_rate, per_100k, total_crashes…
+  geography?: { type: "county" | "highway" | "state"; id: string; name: string };
+  filters: FilterSnapshot;              // active years/severities/causes/flags
+  value?: number;                       // literal value (for a stat)
+  series?: ChartDataItem[];             // FROZEN literal data (for a chart)
+  pair?: { x: DomainRef; y: DomainRef }; // for kind: "correlation"
+  label: string;                        // "Fatality rate · Kern County · 2022–23"
+};
+```
+
+**Critical decision:** AI- and chart-derived data is carried **literally** (`value`/`series`),
+not as a re-query spec. This is the rock the earlier "Story Canvas" exploration hit:
+`StoryReader` charts re-query from a dimension/measure spec, so they shift when filters
+change. An explained number or a pinned AI chart must be **frozen** — it represents a
+specific finding at a specific moment. `DataContext` is JSON-serializable so it round-trips
+through URLs (deep links) and localStorage (canvas, thread).
+
+### 2.2 `<Explainable>` + `useExplainable()` (`frontend/src/components/ai/Explainable.tsx`)
+The one primitive that makes anything interactive. Wraps any element:
+
+```tsx
+<Explainable context={statContext}>
+  <span>{formatRate(value)}</span>
+</Explainable>
+```
+
+Responsibilities (built once, reused everywhere):
+- **Affordance:** subtle dotted underline / info dot on hover; cursor change.
+- **Accessibility:** focusable (`tabIndex`), `role="button"`, `aria-label`, Enter/Space
+  activate, ESC closes. Centralizing a11y here is how we make "everywhere" accessible
+  without per-surface effort.
+- **Activate:** hands its `DataContext` to the `AiCompanionProvider`.
+
+### 2.3 `AiCompanionProvider` + Companion surface (`frontend/src/components/ai/AiCompanion.tsx`)
+React context holding companion state: open/closed, anchor element, current `DataContext`,
+and the conversation `thread: ThreadEntry[]`. Renders the **Companion**:
+- **Desktop:** popover anchored to the activated element.
+- **Mobile:** bottom sheet.
+
+The Companion is the single surface every cluster renders into.
+
+### 2.4 Hybrid resolution (the cost/latency model)
+Inside the Companion, two tiers:
+
+- **Instant tier (local, free, no spinner):** `explainContext(ctx)` →
+  - charts → extend existing `narrativeEngine.ts` (peaks/trends/anomalies)
+  - single stats → new `statNarrative(ctx, distribution)` → percentile/rank/trend
+  - correlations → local correlation math (Pearson r + plain-language strength/caveat)
+- **Deep tier (Groq, on demand):** "Go deeper with AI" button and any follow-up call
+  `useAskAi` with the `DataContext` injected into the prompt. Results cached by
+  `(contextHash, question)`; throttled per-session for the public site.
+
+This keeps the common case free and instant and only spends LLM budget when the user
+explicitly wants more.
+
+## 3. Feature Clusters (all consume the Spine)
+
+### Cluster A — Explainable Everything *(foundation)*
+- Wrap stat numbers, chart marks, counties, highways in `<Explainable>`.
+- Instant local narrative + **percentile context** ("safer than 70% of CA counties").
+- Auto "what this shows" **captions** on charts (passive `narrativeEngine` output).
+
+### Cluster B — AI Companion *(continuous)*
+- **Thread:** follow-ups carry accumulated `DataContext` across the whole app
+  (click county → click chart → "compare them" knows both).
+- **Command palette (Cmd/Ctrl-K):** global "ask anything"; answers in the Companion.
+- **"Explain this view":** serialize current map/dashboard state → `DataContext{kind:"view"}`
+  → one-click narrative of everything on screen.
+- **NL build:** "alcohol crashes by hour in Kern as a heatmap" → builds chart/filters
+  (extends existing `NlqQueryBar` / `nlqParser`).
+
+### Cluster C — Story Canvas *(user-authored)*
+- `pinned: DataContext[]` store. Every Companion answer has a **Pin** button → `/story` canvas.
+- Drag to reorder; insert narrative text blocks between pins.
+- **Share/export:** canvas serializes to a deep link + Markdown/PNG.
+- **Shareable insight cards:** every explained insight gets its own deep link + **OG image**
+  via the existing `workers/og-image` worker (this also repairs the broken social previews —
+  `og.calsight.org` is currently NXDOMAIN; DNS fix is a separate chore, but the card
+  generation lands here).
+- **Embeddable:** `<iframe>` snippet for a pinned chart+narrative.
+
+### Cluster D — Proactive AI *(it comes to you)*
+- **Anomaly spotlights:** existing `anomaly.ts` / `AnomalyPanel` feed "crashes spiked 40%
+  in X" cards into the Companion/card system.
+- **Local briefing:** enter an area → AI-narrated safety story for it.
+- **"Why?" drill chains:** each answer suggests 2–3 deeper follow-ups as chips.
+- **"Surprise me":** one button → a random non-obvious insight (engagement/demos).
+
+### Cluster E — Cross-Domain Story Intelligence *(the differentiator)*
+The backend already has 13 AI tools spanning crashes, weather (NOAA), demographics
+(Census), environmental justice (CalEnviroScreen), unemployment (BLS), EV/vehicle
+registrations, and road/hospital infrastructure — but the dashboard uses almost none of it.
+
+- **Correlation explorer:** pick any two domains → AI narrates the relationship + hedges
+  causation: poverty × fatalities, rainfall/heat × crashes, environmental-justice score ×
+  pedestrian deaths, unemployment × DUI, EV adoption × severity.
+- **Weather stories:** "do crashes spike in rain or heat waves?" (NOAA data, currently invisible).
+- **Equity lens:** CalEnviroScreen × crash outcomes — do disadvantaged communities bear
+  more pedestrian/fatal crashes?
+- **Golden-hour / hospital-access:** distance-to-hospital × fatality rate.
+- **Demographic risk profiles:** party age/sex × outcomes, narrated.
+- **Socioeconomic & infrastructure overlays:** unemployment, road miles, speed limits ×
+  crash rates.
+- **NL correlation:** "is there a link between poverty and pedestrian deaths?" → AI runs the
+  cross-domain analysis live (`get_demographics` + `query_crashes` + correlation math).
+
+### Plus — map-motion features (existing open issues)
+- **Animated temporal heatmap** (#279): scrub crashes over time.
+- **Crash-cluster / hotspot detection** (#280): spatial clustering surfaced as explainable cards.
+
+## 4. Backend changes
+Most AI tools already exist server-side; we mainly **expose** and **add a few**:
+- `GET /api/stats/distribution?measure=…` — per-county values for percentile context
+  (matview-backed for speed).
+- `GET /api/correlation?x=…&y=…&geo=…` — cross-domain correlation pairs.
+- Expose the unused domain endpoints (weather, environmental, vehicles) the dashboard never calls.
+- Anomaly feed endpoint + OG-image generation for shareable insight cards.
+- Inject `DataContext` into the Ask AI prompt (extend `ai_prompt.py` / `useAskAi` payload).
+
+## 5. Data flow (single path, reused everywhere)
+```
+element → DataContext → Companion
+   → instant tier: narrativeEngine / statNarrative / correlation calc   (local, free)
+   → deep tier:    useAskAi + the 13 server tools                       (Groq, on demand, cached)
+   → Pin → Story Canvas → deep link + OG card + embed
+```
+
+## 6. Phased delivery (one spec, many PRs)
+Nothing giant hits prod. Each phase is independently shippable and reviewable.
+
+- **P0 — Spine:** `DataContext`, `AiCompanionProvider`, `<Explainable>`, hybrid resolution,
+  `statNarrative`, `GET /api/stats/distribution`. *No user-visible surfaces yet beyond a
+  demo wrapping of one number.*
+- **P1 — Cluster A:** wrap numbers/charts/counties/highways + percentile + auto captions.
+- **P2 — Cluster B:** thread, Cmd-K palette, "explain this view," NL build.
+- **P3 — Cluster C:** Story Canvas + insight cards + OG + embed.
+- **P4 — Cluster D:** anomalies, local briefing, why-chains, surprise me.
+- **P5 — Cluster E:** correlation explorer + cross-domain stories + NL correlation.
+- **P6 — Map motion:** animated temporal heatmap (#279) + cluster detection (#280).
+
+P0 must land first (everything depends on the spine). P1 should land before P2–P6 (they
+assume `<Explainable>` is in place). P3–P6 are largely independent of each other.
+
+## 7. Testing strategy
+- **Unit:** `statNarrative` (percentile/rank/trend), correlation math, `DataContext`
+  serialization round-trip, prompt injection.
+- **Component:** `<Explainable>` affordance + a11y (keyboard, aria, ESC), Companion
+  open/close/anchor, instant-tier render.
+- **Integration:** Companion → `useAskAi` with context; cache + throttle behavior.
+- **E2E (Playwright):** explain a number → go deeper → pin → canvas → share link resolves.
+- **Backend (pytest):** `/api/stats/distribution`, `/api/correlation`, exposed domain
+  endpoints, OG-card generation.
+
+## 8. Risks & mitigations
+- **LLM cost / rate limits on a public site** → hybrid (local-first) + response cache +
+  per-session throttle; AI tier degrades to local narrative when unavailable.
+- **Causation overclaiming** → existing prompt guardrails (`90773cc`, temp 0.4) + explicit
+  correlation hedging in `statNarrative`/correlation output.
+- **Stale/shifting data** → frozen literal `value`/`series` in `DataContext`; pinned
+  insights never silently change.
+- **Performance** → precomputed matviews for distribution/correlation; literal data avoids
+  re-queries.
+- **Accessibility regressions across "everywhere"** → centralized in `<Explainable>`,
+  tested once.
+- **Scope creep / unreviewable PRs** → strict phasing; P0–P6 each its own PR.
+
+## 9. Out of scope (separate chores, not this spec)
+- `og.calsight.org` DNS repair (NXDOMAIN) — config, not code (Cluster C consumes the worker
+  once DNS is fixed).
+- WCAG 2.2 AA full audit, methodology-footer copy, Spanish i18n, test-coverage backfill —
+  tracked in `docs/DEFINITION_OF_DONE.md` / #322.
+
+## 10. Open questions to resolve during planning
+- Exact percentile basis: per-county distribution for the active filter set, or a fixed
+  statewide baseline? (Leaning: active filter set, computed from `/api/stats/distribution`.)
+- Companion thread persistence: session-only vs. saved to localStorage like the canvas.
+  (Leaning: session-only for the thread; only *pinned* items persist, to keep the model
+  simple and avoid stale long-lived threads.)
+- Correlation endpoint: precompute common pairs vs. compute on demand with caching.
+  (Leaning: compute on demand with a response cache keyed by `(x, y, geo, filters)`;
+  promote to a precomputed matview only if latency demands it.)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import Layout from "./components/Layout";
 import AdminGuard from "./components/AdminGuard";
 import MaintenanceGate from "./components/MaintenanceGate";
 import RebuildingBanner from "./components/RebuildingBanner";
+import { AiCompanionProvider } from "./components/ai/AiCompanion";
 
 const MapPage = lazy(() => import("./pages/MapPage"));
 const StatsPage = lazy(() => import("./pages/StatsPage"));
@@ -54,6 +55,7 @@ export default function App() {
           <MaintenanceGate />
           <RebuildingBanner />
           <BrowserRouter>
+          <AiCompanionProvider>
           <Suspense fallback={<div className="flex items-center justify-center h-dvh" role="status" aria-label="Loading page"><span className="inline-block w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" aria-hidden="true" /><span className="sr-only">Loading page</span></div>}>
             <Routes>
               <Route element={<Layout />}>
@@ -67,6 +69,7 @@ export default function App() {
               </Route>
             </Routes>
           </Suspense>
+          </AiCompanionProvider>
           </BrowserRouter>
           </AccessibilityProvider>
         </LiteModeProvider>

--- a/frontend/src/components/ai/AiCompanion.deepdive.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.deepdive.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { buildDeepDivePrompt } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [2023], severities: ["Fatal"], counties: ["kern"], causes: [],
+  alcohol: true, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("buildDeepDivePrompt", () => {
+  it("includes the label, value, and active filters", () => {
+    const ctx: DataContext = { kind: "stat", label: "Fatality rate · Kern", measure: "fatality_rate", value: 1.5, geography: { type: "county", id: "15", name: "Kern" }, filters };
+    const prompt = buildDeepDivePrompt(ctx);
+    expect(prompt).toContain("Fatality rate · Kern");
+    expect(prompt).toContain("1.5");
+    expect(prompt).toContain("Kern");
+    expect(prompt.toLowerCase()).toContain("2023");
+  });
+});

--- a/frontend/src/components/ai/AiCompanion.invariant.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.invariant.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+// Spy on the hook that owns the only network path. The hybrid free-tier
+// invariant is: opening the instant tier must NEVER hit the API — only the
+// explicit "Go deeper" click may. If this ever regresses, every dialog open
+// would silently fire a Groq request and blow the free tier.
+const sendMessage = vi.fn();
+vi.mock("../../hooks/useAskAi", () => ({
+  useAskAi: () => ({ sendMessage, isLoading: false }),
+}));
+
+const filters = {
+  years: [2023], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function Trigger() {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>explain</button>;
+}
+
+describe("AiCompanion hybrid-tier invariant", () => {
+  beforeEach(() => sendMessage.mockClear());
+
+  it("does NOT call the API when the instant tier opens", () => {
+    render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+    fireEvent.click(screen.getByText("explain"));
+    // Dialog is up (instant tier rendered locally)...
+    expect(screen.getByRole("dialog", { name: "AI explanation" })).toBeTruthy();
+    // ...but nothing touched the network.
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("calls the API exactly once, only on the explicit Go deeper click", () => {
+    render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+    fireEvent.click(screen.getByText("explain"));
+    expect(sendMessage).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Go deeper with AI"));
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(expect.stringContaining("Crashes by hour"));
+  });
+});

--- a/frontend/src/components/ai/AiCompanion.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function Trigger() {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>explain</button>;
+}
+
+describe("AiCompanion", () => {
+  it("opens on demand and shows the instant explanation", () => {
+    render(<AiCompanionProvider><Trigger /></AiCompanionProvider>);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByText("explain"));
+    const dialog = screen.getByRole("dialog", { name: "AI explanation" });
+    expect(dialog).toBeTruthy();
+    expect(dialog.textContent).toContain("Crashes by hour");
+  });
+
+  it("closes on Escape", () => {
+    render(<AiCompanionProvider><Trigger /></AiCompanionProvider>);
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/frontend/src/components/ai/AiCompanion.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
 import type { DataContext } from "../../lib/ai/dataContext";
 
@@ -17,7 +18,7 @@ function Trigger() {
 
 describe("AiCompanion", () => {
   it("opens on demand and shows the instant explanation", () => {
-    render(<AiCompanionProvider><Trigger /></AiCompanionProvider>);
+    render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
     expect(screen.queryByRole("dialog")).toBeNull();
     fireEvent.click(screen.getByText("explain"));
     const dialog = screen.getByRole("dialog", { name: "AI explanation" });
@@ -26,7 +27,7 @@ describe("AiCompanion", () => {
   });
 
   it("closes on Escape", () => {
-    render(<AiCompanionProvider><Trigger /></AiCompanionProvider>);
+    render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
     fireEvent.click(screen.getByText("explain"));
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -1,6 +1,20 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import type { DataContext } from "../../lib/ai/dataContext";
 import { explainContext } from "../../lib/ai/explainContext";
+import { useAskAi } from "../../hooks/useAskAi";
+
+export function buildDeepDivePrompt(ctx: DataContext): string {
+  const parts: string[] = [`Explain this CalSight data point: "${ctx.label}".`];
+  if (ctx.value != null) parts.push(`Value: ${ctx.value}.`);
+  if (ctx.geography) parts.push(`Area: ${ctx.geography.name}.`);
+  const f = ctx.filters;
+  if (f.years.length) parts.push(`Years: ${f.years.join(", ")}.`);
+  if (f.severities.length) parts.push(`Severities: ${f.severities.join(", ")}.`);
+  if (f.counties.length && !ctx.geography) parts.push(`Counties: ${f.counties.join(", ")}.`);
+  if (f.alcohol) parts.push("Alcohol-involved only.");
+  parts.push("Be concise and avoid claiming causation.");
+  return parts.join(" ");
+}
 
 type CompanionApi = {
   open: (ctx: DataContext) => void;
@@ -12,6 +26,7 @@ const Ctx = createContext<CompanionApi | null>(null);
 
 export function AiCompanionProvider({ children }: { children: ReactNode }) {
   const [current, setCurrent] = useState<DataContext | null>(null);
+  const { sendMessage, isLoading } = useAskAi();
 
   const open = useCallback((ctx: DataContext) => setCurrent(ctx), []);
   const close = useCallback(() => setCurrent(null), []);
@@ -40,6 +55,13 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
             <button onClick={close} aria-label="Close explanation" className="text-on-surface-variant hover:text-on-surface">✕</button>
           </div>
           <p className="mt-2 text-sm text-on-surface-variant">{explanation.body}</p>
+          <button
+            onClick={() => current && sendMessage(buildDeepDivePrompt(current))}
+            disabled={isLoading}
+            className="mt-3 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary disabled:opacity-50"
+          >
+            {isLoading ? "Thinking…" : "Go deeper with AI"}
+          </button>
         </div>
       )}
     </Ctx.Provider>

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { DataContext } from "../../lib/ai/dataContext";
+import { explainContext } from "../../lib/ai/explainContext";
+
+type CompanionApi = {
+  open: (ctx: DataContext) => void;
+  close: () => void;
+  current: DataContext | null;
+};
+
+const Ctx = createContext<CompanionApi | null>(null);
+
+export function AiCompanionProvider({ children }: { children: ReactNode }) {
+  const [current, setCurrent] = useState<DataContext | null>(null);
+
+  const open = useCallback((ctx: DataContext) => setCurrent(ctx), []);
+  const close = useCallback(() => setCurrent(null), []);
+
+  useEffect(() => {
+    if (!current) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") close(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [current, close]);
+
+  const api = useMemo<CompanionApi>(() => ({ open, close, current }), [open, close, current]);
+  const explanation = current ? explainContext(current) : null;
+
+  return (
+    <Ctx.Provider value={api}>
+      {children}
+      {current && explanation && (
+        <div
+          role="dialog"
+          aria-label="AI explanation"
+          className="fixed bottom-4 right-4 z-[1000] max-w-sm rounded-xl bg-surface-container-high p-4 shadow-lg ghost-border md:bottom-4 md:right-4"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="text-sm font-semibold text-on-surface">{explanation.headline}</h2>
+            <button onClick={close} aria-label="Close explanation" className="text-on-surface-variant hover:text-on-surface">✕</button>
+          </div>
+          <p className="mt-2 text-sm text-on-surface-variant">{explanation.body}</p>
+        </div>
+      )}
+    </Ctx.Provider>
+  );
+}
+
+export function useAiCompanion(): CompanionApi {
+  const api = useContext(Ctx);
+  if (!api) throw new Error("useAiCompanion must be used inside <AiCompanionProvider>");
+  return api;
+}

--- a/frontend/src/components/ai/Explainable.test.tsx
+++ b/frontend/src/components/ai/Explainable.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider } from "./AiCompanion";
 import { Explainable } from "./Explainable";
 import type { DataContext } from "../../lib/ai/dataContext";
@@ -13,9 +14,11 @@ const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ l
 
 function setup() {
   render(
-    <AiCompanionProvider>
-      <Explainable context={ctx}><span>9</span></Explainable>
-    </AiCompanionProvider>,
+    <MemoryRouter>
+      <AiCompanionProvider>
+        <Explainable context={ctx}><span>9</span></Explainable>
+      </AiCompanionProvider>
+    </MemoryRouter>,
   );
 }
 

--- a/frontend/src/components/ai/Explainable.test.tsx
+++ b/frontend/src/components/ai/Explainable.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AiCompanionProvider } from "./AiCompanion";
+import { Explainable } from "./Explainable";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function setup() {
+  render(
+    <AiCompanionProvider>
+      <Explainable context={ctx}><span>9</span></Explainable>
+    </AiCompanionProvider>,
+  );
+}
+
+describe("Explainable", () => {
+  it("exposes an accessible explain button", () => {
+    setup();
+    expect(screen.getByRole("button", { name: "Explain: Crashes by hour" })).toBeTruthy();
+  });
+
+  it("opens the companion on Enter", () => {
+    setup();
+    fireEvent.keyDown(screen.getByRole("button", { name: "Explain: Crashes by hour" }), { key: "Enter" });
+    expect(screen.getByRole("dialog", { name: "AI explanation" })).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ai/Explainable.tsx
+++ b/frontend/src/components/ai/Explainable.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import type { DataContext } from "../../lib/ai/dataContext";
+import { useAiCompanion } from "./AiCompanion";
+
+export function Explainable({
+  context, children, className,
+}: { context: DataContext; children: ReactNode; className?: string }) {
+  const { open } = useAiCompanion();
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      aria-label={`Explain: ${context.label}`}
+      onClick={() => open(context)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          open(context);
+        }
+      }}
+      className={`cursor-help underline decoration-dotted decoration-on-surface-variant/40 underline-offset-2 hover:decoration-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${className ?? ""}`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/lib/ai/contextBuilders.test.ts
+++ b/frontend/src/lib/ai/contextBuilders.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { snapshotFilters, statContext, chartContext } from "./contextBuilders";
+
+const inputs = {
+  selectedYears: new Set([2023, 2022]),
+  selectedSeverities: new Set(["Fatal"]),
+  selectedCounties: new Set(["kern"]),
+  selectedCauses: new Set<string>(),
+  selectedAlcohol: true,
+  selectedDistracted: false,
+  selectedPedestrian: false,
+  selectedCyclist: false,
+  selectedDrug: false,
+  selectedDriverAge: null,
+  selectedWeather: new Set<string>(),
+  selectedLighting: new Set<string>(),
+  selectedCollisionType: new Set<string>(),
+  selectedRoadType: null,
+  selectedHitRun: false,
+};
+
+describe("contextBuilders", () => {
+  it("snapshots filters: sorts sets, maps false flags to null", () => {
+    const snap = snapshotFilters(inputs);
+    expect(snap.years).toEqual([2022, 2023]);
+    expect(snap.severities).toEqual(["Fatal"]);
+    expect(snap.alcohol).toBe(true);
+    expect(snap.distracted).toBeNull();
+    expect(snap.weather).toEqual([]);
+  });
+
+  it("builds a stat context", () => {
+    const ctx = statContext({
+      label: "Fatality rate · Kern", measure: "fatality_rate", value: 1.5,
+      geography: { type: "county", id: "15", name: "Kern" },
+      filters: snapshotFilters(inputs),
+    });
+    expect(ctx.kind).toBe("stat");
+    expect(ctx.value).toBe(1.5);
+    expect(ctx.measure).toBe("fatality_rate");
+  });
+
+  it("builds a chart context with frozen series", () => {
+    const ctx = chartContext({
+      label: "Crashes by hour", series: [{ label: "0", value: 10 }],
+      filters: snapshotFilters(inputs),
+    });
+    expect(ctx.kind).toBe("chart");
+    expect(ctx.series).toEqual([{ label: "0", value: 10 }]);
+  });
+});

--- a/frontend/src/lib/ai/contextBuilders.ts
+++ b/frontend/src/lib/ai/contextBuilders.ts
@@ -1,0 +1,56 @@
+import type { DataContext, FilterSnapshot, ChartPoint } from "./dataContext";
+
+export type FilterInputs = {
+  selectedYears: Set<number>;
+  selectedSeverities: Set<string>;
+  selectedCounties: Set<string>;
+  selectedCauses: Set<string>;
+  selectedAlcohol: boolean;
+  selectedDistracted: boolean;
+  selectedPedestrian: boolean;
+  selectedCyclist: boolean;
+  selectedDrug: boolean;
+  selectedDriverAge: string | null;
+  selectedWeather: Set<string>;
+  selectedLighting: Set<string>;
+  selectedCollisionType: Set<string>;
+  selectedRoadType: string | null;
+  selectedHitRun: boolean;
+};
+
+const flag = (b: boolean): boolean | null => (b ? true : null);
+const sortedNums = (s: Set<number>) => [...s].sort((a, b) => a - b);
+const sortedStrs = (s: Set<string>) => [...s].sort();
+
+export function snapshotFilters(f: FilterInputs): FilterSnapshot {
+  return {
+    years: sortedNums(f.selectedYears),
+    severities: sortedStrs(f.selectedSeverities),
+    counties: sortedStrs(f.selectedCounties),
+    causes: sortedStrs(f.selectedCauses),
+    alcohol: flag(f.selectedAlcohol),
+    distracted: flag(f.selectedDistracted),
+    pedestrian: flag(f.selectedPedestrian),
+    cyclist: flag(f.selectedCyclist),
+    drug: flag(f.selectedDrug),
+    driverAge: f.selectedDriverAge,
+    weather: sortedStrs(f.selectedWeather),
+    lighting: sortedStrs(f.selectedLighting),
+    collisionType: sortedStrs(f.selectedCollisionType),
+    roadType: f.selectedRoadType,
+    hitRun: flag(f.selectedHitRun),
+  };
+}
+
+export function statContext(args: {
+  label: string; measure: string; value: number;
+  geography?: DataContext["geography"]; filters: FilterSnapshot;
+}): DataContext {
+  return { kind: "stat", label: args.label, measure: args.measure, value: args.value, geography: args.geography, filters: args.filters };
+}
+
+export function chartContext(args: {
+  label: string; series: ChartPoint[]; measure?: string; filters: FilterSnapshot;
+}): DataContext {
+  return { kind: "chart", label: args.label, series: args.series, measure: args.measure, filters: args.filters };
+}

--- a/frontend/src/lib/ai/dataContext.test.ts
+++ b/frontend/src/lib/ai/dataContext.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { hashContext, serializeContext, deserializeContext, type DataContext } from "./dataContext";
+
+const emptyFilters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+const ctx: DataContext = {
+  kind: "stat", label: "Fatality rate · Kern County",
+  measure: "fatality_rate", value: 1.23,
+  geography: { type: "county", id: "15", name: "Kern" },
+  filters: emptyFilters,
+};
+
+describe("dataContext", () => {
+  it("round-trips through serialize/deserialize", () => {
+    const restored = deserializeContext(serializeContext(ctx));
+    expect(restored).toEqual(ctx);
+  });
+
+  it("returns null for malformed input", () => {
+    expect(deserializeContext("not json")).toBeNull();
+  });
+
+  it("hashes equal contexts equally and differs on value", () => {
+    expect(hashContext(ctx)).toBe(hashContext({ ...ctx }));
+    expect(hashContext(ctx)).not.toBe(hashContext({ ...ctx, value: 9.99 }));
+  });
+});

--- a/frontend/src/lib/ai/dataContext.test.ts
+++ b/frontend/src/lib/ai/dataContext.test.ts
@@ -28,4 +28,14 @@ describe("dataContext", () => {
     expect(hashContext(ctx)).toBe(hashContext({ ...ctx }));
     expect(hashContext(ctx)).not.toBe(hashContext({ ...ctx, value: 9.99 }));
   });
+
+  it("hashContext differs when only filters changes", () => {
+    expect(hashContext(ctx)).not.toBe(
+      hashContext({ ...ctx, filters: { ...emptyFilters, years: [2023] } }),
+    );
+  });
+
+  it("deserializeContext returns null for unknown kind", () => {
+    expect(deserializeContext('{"kind":"evil","filters":{}}')).toBeNull();
+  });
 });

--- a/frontend/src/lib/ai/dataContext.ts
+++ b/frontend/src/lib/ai/dataContext.ts
@@ -1,0 +1,56 @@
+export type FilterSnapshot = {
+  years: number[];
+  severities: string[];
+  counties: string[];
+  causes: string[];
+  alcohol: boolean | null;
+  distracted: boolean | null;
+  pedestrian: boolean | null;
+  cyclist: boolean | null;
+  drug: boolean | null;
+  driverAge: string | null;
+  weather: string[];
+  lighting: string[];
+  collisionType: string[];
+  roadType: string | null;
+  hitRun: boolean | null;
+};
+
+export type ChartPoint = { label: string; value: number };
+
+export type DataContext = {
+  kind: "stat" | "chart" | "county" | "highway" | "view" | "correlation";
+  label: string;
+  filters: FilterSnapshot;
+  measure?: string;
+  geography?: { type: "county" | "highway" | "state"; id: string; name: string };
+  value?: number;
+  series?: ChartPoint[];
+};
+
+export function serializeContext(ctx: DataContext): string {
+  return JSON.stringify(ctx);
+}
+
+export function deserializeContext(raw: string): DataContext | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && typeof parsed.kind === "string" && parsed.filters) {
+      return parsed as DataContext;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Stable, order-independent hash for cache keys.
+export function hashContext(ctx: DataContext): string {
+  const stable = JSON.stringify(ctx, Object.keys(ctx).sort());
+  let h = 0;
+  for (let i = 0; i < stable.length; i++) {
+    h = (h << 5) - h + stable.charCodeAt(i);
+    h |= 0;
+  }
+  return `ctx_${h >>> 0}`;
+}

--- a/frontend/src/lib/ai/dataContext.ts
+++ b/frontend/src/lib/ai/dataContext.ts
@@ -32,10 +32,18 @@ export function serializeContext(ctx: DataContext): string {
   return JSON.stringify(ctx);
 }
 
+const VALID_KINDS = new Set(["stat", "chart", "county", "highway", "view", "correlation"]);
+
 export function deserializeContext(raw: string): DataContext | null {
   try {
     const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && typeof parsed.kind === "string" && parsed.filters) {
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.kind === "string" &&
+      VALID_KINDS.has(parsed.kind) &&
+      parsed.filters
+    ) {
       return parsed as DataContext;
     }
     return null;
@@ -44,9 +52,18 @@ export function deserializeContext(raw: string): DataContext | null {
   }
 }
 
+function sortedReplacer(_key: string, value: unknown) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)),
+    );
+  }
+  return value;
+}
+
 // Stable, order-independent hash for cache keys.
 export function hashContext(ctx: DataContext): string {
-  const stable = JSON.stringify(ctx, Object.keys(ctx).sort());
+  const stable = JSON.stringify(ctx, sortedReplacer);
   let h = 0;
   for (let i = 0; i < stable.length; i++) {
     h = (h << 5) - h + stable.charCodeAt(i);

--- a/frontend/src/lib/ai/explainContext.test.ts
+++ b/frontend/src/lib/ai/explainContext.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { explainContext } from "./explainContext";
+import type { DataContext } from "./dataContext";
+
+const filters = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("explainContext", () => {
+  it("explains a stat using the distribution", () => {
+    const ctx: DataContext = { kind: "stat", label: "Fatality rate", measure: "fatality_rate", value: 1, geography: { type: "county", id: "a", name: "A" }, filters };
+    const out = explainContext(ctx, { distribution: [
+      { id: "a", name: "A", value: 1 }, { id: "b", name: "B", value: 5 },
+    ]});
+    expect(out.body).toContain("safer than");
+  });
+
+  it("explains a chart by naming its peak", () => {
+    const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "8am", value: 3 }, { label: "5pm", value: 9 }], filters };
+    const out = explainContext(ctx);
+    expect(out.body).toContain("5pm");
+  });
+
+  it("falls back to label for unknown kinds", () => {
+    const ctx: DataContext = { kind: "county", label: "Kern County", filters };
+    const out = explainContext(ctx);
+    expect(out.headline).toContain("Kern County");
+  });
+});

--- a/frontend/src/lib/ai/explainContext.ts
+++ b/frontend/src/lib/ai/explainContext.ts
@@ -1,0 +1,29 @@
+import type { DataContext } from "./dataContext";
+import { statNarrative, type DistributionPoint } from "./statNarrative";
+
+export type Explanation = { headline: string; body: string };
+
+export function explainContext(
+  ctx: DataContext,
+  deps?: { distribution?: DistributionPoint[] },
+): Explanation {
+  if (ctx.kind === "stat" && ctx.value != null && deps?.distribution?.length) {
+    const subjectId = ctx.geography?.id ?? "__subject__";
+    const n = statNarrative({
+      label: ctx.label, value: ctx.value, subjectId,
+      distribution: deps.distribution,
+    });
+    return { headline: ctx.label, body: n.paragraph };
+  }
+
+  if (ctx.kind === "chart" && ctx.series?.length) {
+    const peak = ctx.series.reduce((a, b) => (b.value > a.value ? b : a));
+    const total = ctx.series.reduce((sum, p) => sum + p.value, 0);
+    return {
+      headline: ctx.label,
+      body: `Peaks at ${peak.label} (${peak.value.toLocaleString()}), out of ${total.toLocaleString()} total.`,
+    };
+  }
+
+  return { headline: ctx.label, body: `Select "Go deeper with AI" to analyze ${ctx.label}.` };
+}

--- a/frontend/src/lib/ai/statNarrative.test.ts
+++ b/frontend/src/lib/ai/statNarrative.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { statNarrative, type DistributionPoint } from "./statNarrative";
+
+const dist: DistributionPoint[] = [
+  { id: "a", name: "A", value: 1 },
+  { id: "b", name: "B", value: 2 },
+  { id: "c", name: "C", value: 3 },
+  { id: "d", name: "D", value: 4 },
+];
+
+describe("statNarrative", () => {
+  it("ranks the worst (highest) subject rank 1", () => {
+    const n = statNarrative({ label: "Fatality rate", value: 4, subjectId: "d", distribution: dist });
+    expect(n.rank).toBe(1);
+    expect(n.total).toBe(4);
+  });
+
+  it("computes percentile safer-than for a low value", () => {
+    const n = statNarrative({ label: "Fatality rate", value: 1, subjectId: "a", distribution: dist });
+    // safer than B, C, D = 3 of 4 = 75%
+    expect(n.percentile).toBe(75);
+    expect(n.paragraph).toContain("safer than 75%");
+  });
+
+  it("produces a non-empty paragraph naming the metric", () => {
+    const n = statNarrative({ label: "Fatality rate", value: 2, subjectId: "b", distribution: dist });
+    expect(n.paragraph.toLowerCase()).toContain("fatality rate");
+  });
+});

--- a/frontend/src/lib/ai/statNarrative.ts
+++ b/frontend/src/lib/ai/statNarrative.ts
@@ -1,0 +1,37 @@
+export type DistributionPoint = { id: string; name: string; value: number };
+
+export type StatNarrative = {
+  percentile: number;
+  rank: number;
+  total: number;
+  paragraph: string;
+};
+
+export function statNarrative(args: {
+  label: string;
+  value: number;
+  subjectId: string;
+  distribution: DistributionPoint[];
+  higherIsWorse?: boolean;
+}): StatNarrative {
+  const higherIsWorse = args.higherIsWorse ?? true;
+  const total = args.distribution.length;
+  // rank 1 = worst
+  const sorted = [...args.distribution].sort((a, b) =>
+    higherIsWorse ? b.value - a.value : a.value - b.value,
+  );
+  const idx = sorted.findIndex((d) => d.id === args.subjectId);
+  const rank = idx >= 0 ? idx + 1 : total;
+
+  const saferCount = args.distribution.filter((d) =>
+    higherIsWorse ? d.value > args.value : d.value < args.value,
+  ).length;
+  const percentile = total > 1 ? Math.round((saferCount / (total - 0)) * 100) : 0;
+
+  const paragraph =
+    `${args.label} here ranks #${rank} of ${total} — ` +
+    `safer than ${percentile}% of the group. ` +
+    `This is an association in the data, not a cause.`;
+
+  return { percentile, rank, total, paragraph };
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { Navigate } from "react-router-dom";
 import { useFilterParams, formatYearMonth, CAUSES as CAUSE_OPTIONS, SEVERITIES, YEARS } from "../hooks/useFilterParams";
+import { Explainable } from "../components/ai/Explainable";
+import { statContext, snapshotFilters } from "../lib/ai/contextBuilders";
 import { useApplyDefaultCounty } from "../hooks/useApplyDefaultCounty";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import FiltersPanel from "../components/map/FiltersPanel";
@@ -487,7 +489,11 @@ function StatsPageInner() {
               <Skeleton className="h-10 w-40" />
             ) : (
               <p className="text-3xl sm:text-4xl font-headline font-bold text-on-surface tracking-tight hero-value" aria-label={`Total incidents: ${totalIncidents != null ? totalIncidents.toLocaleString() : "unavailable"}`}>
-                {totalIncidents != null ? totalIncidents.toLocaleString() : "—"}
+                {totalIncidents != null ? (
+                  <Explainable context={statContext({ label: "Total crashes statewide", measure: "crashes_total", value: totalIncidents, filters: snapshotFilters(filters) })}>
+                    {totalIncidents.toLocaleString()}
+                  </Explainable>
+                ) : "—"}
               </p>
             )}
             {incidentYoYPct != null && (


### PR DESCRIPTION
## AI Storytelling — P0 spine

The shared-primitive foundation for the interactive AI storytelling overhaul (spec: `docs/superpowers/specs/2026-06-27-interactive-ai-storytelling-design.md`, plan: `docs/superpowers/plans/2026-06-27-ai-storytelling-p0-spine.md`). 9 TDD tasks, each individually reviewed (spec + quality), plus a final whole-branch review on Opus.

### What's in it
- **AI lib** (`frontend/src/lib/ai/`): `dataContext.ts` (frozen `DataContext` type + serialize/deserialize/hashContext), `contextBuilders.ts` (build context from filter state), `statNarrative.ts` (percentile/rank prose), `explainContext.ts` (instant-tier dispatcher: stat vs chart → narrative).
- **Components** (`frontend/src/components/ai/`): `AiCompanion.tsx` (provider + instant-tier popover, `buildDeepDivePrompt`, "Go deeper" button wired to `useAskAi`), `Explainable.tsx` (clickable affordance + a11y wrapper).
- **Backend**: `GET /api/stats/distribution` — per-county metric values for percentile/rank (parameterized, metric allowlist-validated, rate-limit/cache headers consistent with siblings).
- **Integration**: `AiCompanionProvider` mounted in `App.tsx` inside BrowserRouter+QueryClient; `totalIncidents` on StatsPage wrapped as the first live `<Explainable>` demo.

### The load-bearing invariant
Hybrid local/Groq tiering: opening the instant tier renders locally-computed narrative with **zero network calls**; only the explicit "Go deeper" click fires a Groq request. This free-tier-protective property is now pinned by a regression test (`AiCompanion.invariant.test.tsx`).

### Verification
- Full frontend suite green; AI suite 21 tests / 8 files; `tsc --noEmit` clean.
- Backend `test_stats_distribution.py` logic verified (near-verbatim copy of `rank_counties`) but **not yet run green** — needs the :5433 dev DB which was down. Run before relying on the endpoint.

### Follow-ups for P1 (by design — not defects)
Per the final review, these are intentional spine boundaries to track, not bugs:
- [ ] Surface the deep-dive answer **inside the dialog** (today the Groq response lands in `useAskAi` sessionStorage / the `/ask` page, not the popover).
- [ ] Wire `/api/stats/distribution` into the instant tier (+ response adapter: endpoint returns `{county_code:int, county_name}`, consumer expects `{id:string, name}`). Until then the demo number shows the generic placeholder and the endpoint ships unused.
- [ ] Tighten `DataContext.measure` from `string` to a `MeasureKey` union.
- [ ] Bundle dialog focus management + (correct) modal a11y in the P1 surface work — note: do NOT add `aria-modal` to the non-modal popover without a focus trap.

> Note: `main` requires review, so merging needs `--admin`.
