### PR TITLE
fix(etl): skip ArcGIS jobs on upstream outage instead of failing the pipeline

### DIFF
--- a/backend/etl/_utils.py
+++ b/backend/etl/_utils.py
@@ -390,6 +390,17 @@ def _check_arcgis_freshness(job: Job, last_run: EtlRun) -> FreshnessResult:
             True, None, count,
             f"row count changed: {prior_count} -> {count}" if prior_count else f"first count: {count}",
         )
+    except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+        # The upstream host is unreachable or erroring (e.g. geo.dot.gov
+        # returning 5xx). This is an outage we can't fix by running the load —
+        # the loader would just hit the same dead host and fail the whole
+        # pipeline. Skip this cycle instead, leaving the last good data in
+        # place; the next run retries automatically once the source recovers.
+        logger.warning("ArcGIS source unreachable for %s: %s — skipping run", job.name, exc)
+        return FreshnessResult(
+            False, None, last_run.source_row_count,
+            f"source unreachable ({exc}); skipping run, will retry next cycle",
+        )
     except Exception as exc:
         logger.warning("ArcGIS freshness check failed for %s: %s", job.name, exc)
         return FreshnessResult(True, None, None, f"freshness check error: {exc}")

--- a/backend/tests/test_etl_utils.py
+++ b/backend/tests/test_etl_utils.py
@@ -10,6 +10,8 @@ Covers:
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import httpx
 import pytest
 
@@ -170,6 +172,67 @@ class TestPostWithRetry:
 
         resp = _utils.post_with_retry("https://example.test", max_retries=2)
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# _check_arcgis_freshness — upstream-outage handling
+# ---------------------------------------------------------------------------
+
+def _arcgis_job(freshness_url: str = "https://geo.dot.gov/query", name: str = "speed_limits"):
+    return SimpleNamespace(name=name, source_type="arcgis", freshness_url=freshness_url)
+
+
+def _last_run(source_row_count: int | None = 100):
+    return SimpleNamespace(source_row_count=source_row_count, finished_at=None)
+
+
+class TestArcgisFreshness:
+    """The freshness probe must not turn a transient upstream outage into a
+    hard job failure. When the ArcGIS host is unreachable or 5xx-ing, the run
+    should be skipped (is_fresh=False) so the loader never runs and the last
+    good data stays in place — instead of fail-opening and crashing the load.
+    """
+
+    def test_5xx_outage_skips_run_instead_of_failing(self, monkeypatch):
+        # geo.dot.gov returning 500s (the real incident): get_with_retry
+        # exhausts retries and raises HTTPStatusError.
+        monkeypatch.setattr(httpx, "get", lambda url, **kw: _make_response(503))
+        monkeypatch.setattr(_utils.time, "sleep", lambda _: None)
+
+        result = _utils._check_arcgis_freshness(_arcgis_job(), _last_run(100))
+
+        assert result.is_fresh is False
+        assert "unreachable" in result.reason.lower()
+
+    def test_connection_error_skips_run(self, monkeypatch):
+        def boom(url, **kw):
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", boom)
+        monkeypatch.setattr(_utils.time, "sleep", lambda _: None)
+
+        result = _utils._check_arcgis_freshness(_arcgis_job(), _last_run(100))
+
+        assert result.is_fresh is False
+        assert "unreachable" in result.reason.lower()
+
+    def test_unchanged_count_still_skips(self, monkeypatch):
+        monkeypatch.setattr(httpx, "get", lambda url, **kw: _make_response(200, b'{"count": 100}'))
+        monkeypatch.setattr(_utils.time, "sleep", lambda _: None)
+
+        result = _utils._check_arcgis_freshness(_arcgis_job(), _last_run(100))
+
+        assert result.is_fresh is False
+        assert "unchanged" in result.reason.lower()
+
+    def test_changed_count_runs(self, monkeypatch):
+        monkeypatch.setattr(httpx, "get", lambda url, **kw: _make_response(200, b'{"count": 250}'))
+        monkeypatch.setattr(_utils.time, "sleep", lambda _: None)
+
+        result = _utils._check_arcgis_freshness(_arcgis_job(), _last_run(100))
+
+        assert result.is_fresh is True
+        assert result.source_row_count == 250
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The 2026-06-28 nightly ETL failed (exit 1) because the `speed_limits` job errored. Root cause was **external**: `geo.dot.gov` (the FHWA HPMS ArcGIS host) was returning 5xx ("Could not access any server machines"). Every other job succeeded.

The failure path: `_check_arcgis_freshness` **fail-opens** on any error (returns `is_fresh=True`), so the job wasn't skipped — the loader then hit the same dead host, exhausted retries, and crashed, failing the whole pipeline for an outage we can't control.

## Fix

In `_check_arcgis_freshness`, catch upstream-outage errors specifically (`httpx.RequestError` / `httpx.HTTPStatusError`, i.e. connectivity + 5xx after retries) and return `is_fresh=False`. The orchestrator then records the run as `skipped_unchanged` with a clear reason (`"source unreachable (…); skipping run, will retry next cycle"`) and **never starts the loader** — leaving last good data in place. Pipeline exits 0; no false-alarm page. The next cycle retries automatically once the source recovers.

Non-outage errors (malformed response, missing `count`) keep the existing fail-open behavior, so genuine problems still surface.

## Why it's safe

- `speed_limits` is static-ish HPMS reference data; a skipped day means nothing.
- The loader already aggregates fully in memory before upserting, so the failed run never touched the table — last good data was already intact.

## Tests

New `TestArcgisFreshness` in `test_etl_utils.py` (TDD, watched fail first):
- 5xx outage → `is_fresh=False` (skip, not crash)
- connection error → `is_fresh=False`
- unchanged count → still skips (regression)
- changed count → runs

`test_etl_utils.py` 28 passed, `test_orchestrator.py` 8 passed.

## Follow-up (not in this PR)
- CKAN (`data.ca.gov`) freshness check has the same fail-open shape; could get the same treatment if it ever flakes.
- A real "source unchanged for N days" staleness alert would catch a *persistent* outage that this fix would otherwise silently skip past.
