### PR TITLE
AI Companion P1: inline deep-dive + county percentile tier

### DIFF
--- a/docs/superpowers/plans/2026-06-28-ai-companion-p1.md
+++ b/docs/superpowers/plans/2026-06-28-ai-companion-p1.md
@@ -1,0 +1,704 @@
+# AI Companion P1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the "Go deeper" AI answer inline in the AI Companion popover, and wire `GET /api/stats/distribution` into the instant tier so a single-county stat shows a "ranks #N of 58 — safer than X%" percentile, with a live demo on StatsPage.
+
+**Architecture:** Pure helpers (`measureToMetric`, `normalizeCounty`, distribution adapter) + a react-query `useDistribution` hook feed `explainContext`'s existing stat path. `AiCompanion` gains an inline answer region driven by its own `useAskAi` instance, plus distribution wiring gated to county + single/all-year contexts. StatsPage builds a county-scoped context when exactly one county is selected.
+
+**Tech Stack:** React + TypeScript, @tanstack/react-query, Vitest + @testing-library/react, `react-markdown` + existing `InlineChart`.
+
+Spec: `docs/superpowers/specs/2026-06-28-ai-companion-p1-design.md`
+
+## Global Constraints
+
+- No new npm dependencies (react-query, react-markdown, InlineChart all already present).
+- Preserve the hybrid-tier invariant: no API call (`sendMessage`) until the explicit "Go deeper" click. The existing test `frontend/src/components/ai/AiCompanion.invariant.test.tsx` must still pass.
+- Distribution percentile tier engages ONLY when: `current` is a `stat`, has a `county` geography, `measureToMetric(measure)` ≠ null, AND `current.filters.years.length <= 1` (empty = all years, or a single year). Multi-year selections fall back to the existing tier.
+- County matching is by NAME via `normalizeCounty` (`s.trim().toLowerCase()`) on both the adapted distribution `id` and the subject `geography.id` — never by county code.
+- Distribution is best-effort enrichment: if it errors/empty, fall back silently to the existing placeholder/chart tier (no error UI for the instant tier).
+- Reuse `DistributionPoint` from `frontend/src/lib/ai/statNarrative.ts` (`{ id: string; name: string; value: number }`) — do not redefine it.
+- Test files alongside source as `*.test.ts(x)`.
+- Run frontend commands from `frontend/`.
+
+---
+
+## File Structure
+
+New:
+- `frontend/src/lib/ai/measureMetric.ts` — `DistributionMetric` type, `measureToMetric`, `normalizeCounty`, `adaptDistribution` (Task 1)
+- `frontend/src/hooks/useDistribution.ts` — react-query hook (Task 2)
+- Test files alongside each.
+
+Modified:
+- `frontend/src/components/ai/AiCompanion.tsx` — inline answer (Task 3) + distribution wiring (Task 4)
+- `frontend/src/components/ai/AiCompanion.invariant.test.tsx` — extend the `useAskAi` mock (Task 3)
+- `frontend/src/lib/ai/contextBuilders.ts` — `buildTotalCrashesContext` helper (Task 5)
+- `frontend/src/pages/StatsPage.tsx` — use the helper for the totalIncidents Explainable (Task 5)
+
+---
+
+## Task 1: Metric mapping + distribution adapter (`measureMetric.ts`)
+
+**Files:**
+- Create: `frontend/src/lib/ai/measureMetric.ts`
+- Test: `frontend/src/lib/ai/measureMetric.test.ts`
+
+**Interfaces:**
+- Consumes: `DistributionPoint` from `./statNarrative`.
+- Produces:
+  - `type DistributionMetric = "crash_count" | "total_killed" | "total_injured" | "fatal_crashes" | "alcohol_crashes" | "pedestrian_crashes"`
+  - `measureToMetric(measure: string): DistributionMetric | null`
+  - `normalizeCounty(name: string): string`
+  - `type DistributionRow = { county_code: number; county_name: string; value: number }`
+  - `adaptDistribution(rows: DistributionRow[]): DistributionPoint[]`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// frontend/src/lib/ai/measureMetric.test.ts
+import { describe, it, expect } from "vitest";
+import { measureToMetric, normalizeCounty, adaptDistribution } from "./measureMetric";
+
+describe("measureToMetric", () => {
+  it("maps known distribution metrics", () => {
+    expect(measureToMetric("crash_count")).toBe("crash_count");
+    expect(measureToMetric("fatal_crashes")).toBe("fatal_crashes");
+    expect(measureToMetric("pedestrian_crashes")).toBe("pedestrian_crashes");
+  });
+  it("returns null for unknown measures", () => {
+    expect(measureToMetric("crashes_total")).toBeNull();
+    expect(measureToMetric("")).toBeNull();
+    expect(measureToMetric("ksi_rate")).toBeNull();
+  });
+});
+
+describe("normalizeCounty", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeCounty("  Kern ")).toBe("kern");
+    expect(normalizeCounty("Los Angeles")).toBe("los angeles");
+  });
+});
+
+describe("adaptDistribution", () => {
+  it("maps endpoint rows to DistributionPoint with normalized id", () => {
+    const out = adaptDistribution([
+      { county_code: 15, county_name: "Kern", value: 100 },
+      { county_code: 19, county_name: "Los Angeles", value: 500 },
+    ]);
+    expect(out).toEqual([
+      { id: "kern", name: "Kern", value: 100 },
+      { id: "los angeles", name: "Los Angeles", value: 500 },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/ai/measureMetric.test.ts`
+Expected: FAIL — cannot resolve `./measureMetric`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/lib/ai/measureMetric.ts
+import type { DistributionPoint } from "./statNarrative";
+
+export type DistributionMetric =
+  | "crash_count" | "total_killed" | "total_injured"
+  | "fatal_crashes" | "alcohol_crashes" | "pedestrian_crashes";
+
+const METRICS: ReadonlySet<string> = new Set<DistributionMetric>([
+  "crash_count", "total_killed", "total_injured",
+  "fatal_crashes", "alcohol_crashes", "pedestrian_crashes",
+]);
+
+export function measureToMetric(measure: string): DistributionMetric | null {
+  return METRICS.has(measure) ? (measure as DistributionMetric) : null;
+}
+
+export function normalizeCounty(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+export type DistributionRow = { county_code: number; county_name: string; value: number };
+
+export function adaptDistribution(rows: DistributionRow[]): DistributionPoint[] {
+  return rows.map((r) => ({ id: normalizeCounty(r.county_name), name: r.county_name, value: r.value }));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/ai/measureMetric.test.ts`
+Expected: PASS (3 describe blocks, 4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/ai/measureMetric.ts frontend/src/lib/ai/measureMetric.test.ts
+git commit -m "feat(ai): measure->metric map + distribution adapter"
+```
+
+---
+
+## Task 2: Distribution fetch hook (`useDistribution.ts`)
+
+**Files:**
+- Create: `frontend/src/hooks/useDistribution.ts`
+- Test: `frontend/src/hooks/useDistribution.test.tsx`
+
+**Interfaces:**
+- Consumes: `adaptDistribution`, `DistributionRow` from `../lib/ai/measureMetric`; `DistributionPoint` from `../lib/ai/statNarrative`; `API_BASE` from `../config`.
+- Produces: `useDistribution(metric: string, year: number | null, options?: { enabled?: boolean }): { data: DistributionPoint[] | undefined; isLoading: boolean }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// frontend/src/hooks/useDistribution.test.tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useDistribution } from "./useDistribution";
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const rows = [{ county_code: 15, county_name: "Kern", value: 100 }];
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => rows })) as unknown as typeof fetch);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useDistribution", () => {
+  it("fetches with metric + year and returns adapted points", async () => {
+    const { result } = renderHook(() => useDistribution("crash_count", 2023, { enabled: true }), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual([{ id: "kern", name: "Kern", value: 100 }]);
+    const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain("metric=crash_count");
+    expect(url).toContain("year=2023");
+  });
+
+  it("omits year from the URL when year is null", async () => {
+    const { result } = renderHook(() => useDistribution("crash_count", null, { enabled: true }), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).not.toContain("year=");
+  });
+
+  it("does not fetch when disabled", () => {
+    renderHook(() => useDistribution("crash_count", null, { enabled: false }), { wrapper: wrapper() });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/hooks/useDistribution.test.tsx`
+Expected: FAIL — cannot resolve `./useDistribution`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// frontend/src/hooks/useDistribution.ts
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+import { adaptDistribution, type DistributionRow } from "../lib/ai/measureMetric";
+import type { DistributionPoint } from "../lib/ai/statNarrative";
+
+export function useDistribution(
+  metric: string,
+  year: number | null,
+  options?: { enabled?: boolean },
+): { data: DistributionPoint[] | undefined; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ["distribution", metric, year],
+    enabled: options?.enabled ?? true,
+    queryFn: async (): Promise<DistributionPoint[]> => {
+      const params = new URLSearchParams({ metric });
+      if (year != null) params.set("year", String(year));
+      const res = await fetch(`${API_BASE}/api/stats/distribution?${params.toString()}`);
+      if (!res.ok) throw new Error(`distribution ${res.status}`);
+      const data = (await res.json()) as DistributionRow[];
+      return adaptDistribution(data);
+    },
+  });
+  return { data: query.data, isLoading: query.isLoading };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/hooks/useDistribution.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/hooks/useDistribution.ts frontend/src/hooks/useDistribution.test.tsx
+git commit -m "feat(ai): useDistribution react-query hook"
+```
+
+---
+
+## Task 3: Inline deep-dive answer in the popover (`AiCompanion.tsx`)
+
+**Files:**
+- Modify: `frontend/src/components/ai/AiCompanion.tsx`
+- Modify: `frontend/src/components/ai/AiCompanion.invariant.test.tsx` (extend mock)
+- Test: `frontend/src/components/ai/AiCompanion.inline.test.tsx`
+
+**Interfaces:**
+- Consumes: `useAskAi()` returning `{ sendMessage, isLoading, error, retry, messages }`; `ChatMessage` type from `../../hooks/useAskAi`; `ReactMarkdown`; `InlineChart` from `../ask/InlineChart`.
+- Produces: no new exports; new inline-answer behavior gated by an internal `askedHere` flag.
+
+- [ ] **Step 1: Update the existing invariant test's mock so it still type-checks/runs**
+
+In `AiCompanion.invariant.test.tsx`, replace the mock factory:
+
+```tsx
+const sendMessage = vi.fn();
+vi.mock("../../hooks/useAskAi", () => ({
+  useAskAi: () => ({ sendMessage, isLoading: false, error: null, retry: vi.fn(), messages: [] }),
+}));
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+// frontend/src/components/ai/AiCompanion.inline.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const hoisted = vi.hoisted(() => ({
+  state: {
+    sendMessage: vi.fn(),
+    retry: vi.fn(),
+    isLoading: false,
+    error: null as string | null,
+    messages: [] as Array<{ role: string; content: string; timestamp: number; chart?: unknown }>,
+  },
+}));
+vi.mock("../../hooks/useAskAi", () => ({ useAskAi: () => hoisted.state }));
+
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [2023], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function Trigger() {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>explain</button>;
+}
+function renderApp() {
+  return render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+}
+
+beforeEach(() => {
+  hoisted.state.sendMessage = vi.fn();
+  hoisted.state.retry = vi.fn();
+  hoisted.state.isLoading = false;
+  hoisted.state.error = null;
+  hoisted.state.messages = [];
+});
+
+describe("AiCompanion inline deep-dive", () => {
+  it("does not show any prior assistant answer before Go deeper is clicked", () => {
+    hoisted.state.messages = [{ role: "assistant", content: "STALE ANSWER", timestamp: 1 }];
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    expect(screen.queryByText("STALE ANSWER")).toBeNull();
+  });
+
+  it("renders the latest assistant answer after Go deeper", () => {
+    hoisted.state.messages = [
+      { role: "user", content: "q", timestamp: 1 },
+      { role: "assistant", content: "Fresh inline answer.", timestamp: 2 },
+    ];
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.click(screen.getByText("Go deeper with AI"));
+    expect(screen.getByText("Fresh inline answer.")).toBeTruthy();
+  });
+
+  it("shows a thinking state while loading after Go deeper", () => {
+    hoisted.state.isLoading = true;
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.click(screen.getByText(/Thinking|Go deeper/));
+    expect(screen.getByText(/Thinking/)).toBeTruthy();
+  });
+
+  it("shows an error with a retry button after Go deeper", () => {
+    hoisted.state.error = "Rate limited.";
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.click(screen.getByText("Go deeper with AI"));
+    expect(screen.getByText("Rate limited.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(hoisted.state.retry).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/components/ai/AiCompanion.inline.test.tsx`
+Expected: FAIL — stale answer assertion or "Fresh inline answer." not found (no inline region yet).
+
+- [ ] **Step 4: Implement the inline answer region**
+
+In `AiCompanion.tsx`:
+
+Add imports at the top:
+```tsx
+import ReactMarkdown from "react-markdown";
+import InlineChart from "../ask/InlineChart";
+import type { ChatMessage } from "../../hooks/useAskAi";
+```
+
+Extend the hook destructure and add state inside `AiCompanionProvider`:
+```tsx
+  const { sendMessage, isLoading, error, retry, messages } = useAskAi();
+  const [askedHere, setAskedHere] = useState(false);
+```
+
+Reset the flag whenever the opened context changes (add near the existing Escape effect):
+```tsx
+  useEffect(() => { setAskedHere(false); }, [current]);
+```
+
+Compute the latest assistant message (place just before the `return`):
+```tsx
+  const lastAnswer: ChatMessage | undefined =
+    [...messages].reverse().find((m) => m.role === "assistant");
+```
+
+Change the "Go deeper" button's onClick to set the flag, and add the answer region directly after the button (inside the dialog `<div>`):
+```tsx
+          <button
+            onClick={() => { if (current) { setAskedHere(true); sendMessage(buildDeepDivePrompt(current)); } }}
+            disabled={isLoading}
+            className="mt-3 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary disabled:opacity-50"
+          >
+            {isLoading ? "Thinking…" : "Go deeper with AI"}
+          </button>
+          {askedHere && (
+            <div aria-live="polite" className="mt-3 max-h-[40vh] overflow-y-auto border-t border-outline-variant pt-3">
+              {isLoading && <p className="text-xs text-on-surface-variant">Thinking…</p>}
+              {error && !isLoading && (
+                <p className="text-xs text-error">
+                  {error}{" "}
+                  <button onClick={retry} className="underline" aria-label="Retry deep dive">Retry</button>
+                </p>
+              )}
+              {!isLoading && !error && lastAnswer && (
+                <div className="prose prose-sm dark:prose-invert max-w-none text-on-surface">
+                  <ReactMarkdown>{lastAnswer.content}</ReactMarkdown>
+                  {lastAnswer.chart && <InlineChart chart={lastAnswer.chart} />}
+                </div>
+              )}
+            </div>
+          )}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/ai/AiCompanion.inline.test.tsx src/components/ai/AiCompanion.invariant.test.tsx`
+Expected: PASS (inline 4 tests + invariant 2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ai/AiCompanion.tsx frontend/src/components/ai/AiCompanion.inline.test.tsx frontend/src/components/ai/AiCompanion.invariant.test.tsx
+git commit -m "feat(ai): render deep-dive answer inline in companion popover"
+```
+
+---
+
+## Task 4: Wire distribution into the instant tier (`AiCompanion.tsx`)
+
+**Files:**
+- Modify: `frontend/src/components/ai/AiCompanion.tsx`
+- Test: `frontend/src/components/ai/AiCompanion.distribution.test.tsx`
+
+**Interfaces:**
+- Consumes: `useDistribution` from `../../hooks/useDistribution`; `measureToMetric` from `../../lib/ai/measureMetric`.
+- Produces: distribution passed into `explainContext(current, { distribution })` under the gate.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/src/components/ai/AiCompanion.distribution.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("../../hooks/useAskAi", () => ({
+  useAskAi: () => ({ sendMessage: vi.fn(), isLoading: false, error: null, retry: vi.fn(), messages: [] }),
+}));
+// Always return a 2-county distribution; the provider's gate decides whether to use it.
+vi.mock("../../hooks/useDistribution", () => ({
+  useDistribution: () => ({
+    data: [{ id: "kern", name: "Kern", value: 100 }, { id: "x", name: "X", value: 500 }],
+    isLoading: false,
+  }),
+}));
+
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const baseFilters = {
+  years: [2023], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+const countyStat: DataContext = {
+  kind: "stat", label: "Total crashes · Kern", measure: "crash_count", value: 100,
+  geography: { type: "county", id: "kern", name: "Kern" }, filters: baseFilters,
+};
+const statewideStat: DataContext = {
+  kind: "stat", label: "Total crashes statewide", measure: "crash_count", value: 100, filters: baseFilters,
+};
+
+function Trigger({ ctx }: { ctx: DataContext }) {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>open</button>;
+}
+function renderWith(ctx: DataContext) {
+  return render(<MemoryRouter><AiCompanionProvider><Trigger ctx={ctx} /></AiCompanionProvider></MemoryRouter>);
+}
+
+describe("AiCompanion distribution tier", () => {
+  it("renders a percentile narrative for a single-county stat", () => {
+    renderWith(countyStat);
+    fireEvent.click(screen.getByText("open"));
+    expect(screen.getByRole("dialog").textContent).toMatch(/ranks #|safer than/i);
+  });
+
+  it("does not use distribution for a statewide stat (no county geography)", () => {
+    renderWith(statewideStat);
+    fireEvent.click(screen.getByText("open"));
+    expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/ai/AiCompanion.distribution.test.tsx`
+Expected: FAIL — the single-county case shows the placeholder, not a percentile (distribution not wired yet).
+
+- [ ] **Step 3: Implement the distribution wiring**
+
+In `AiCompanion.tsx`, add imports:
+```tsx
+import { useDistribution } from "../../hooks/useDistribution";
+import { measureToMetric } from "../../lib/ai/measureMetric";
+```
+
+Inside `AiCompanionProvider`, before computing `explanation`, derive the gate and fetch:
+```tsx
+  const metric = current?.kind === "stat" ? measureToMetric(current.measure) : null;
+  const years = current?.filters.years ?? [];
+  const distEnabled =
+    current?.kind === "stat" &&
+    current.geography?.type === "county" &&
+    metric != null &&
+    years.length <= 1;
+  const distYear = years.length === 1 ? years[0] : null;
+  const { data: distribution } = useDistribution(metric ?? "crash_count", distYear, { enabled: distEnabled });
+```
+
+Change the `explanation` computation to pass distribution only when enabled:
+```tsx
+  const explanation = current
+    ? explainContext(current, distEnabled ? { distribution } : undefined)
+    : null;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/ai/AiCompanion.distribution.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full AI component + lib suite to confirm no regression**
+
+Run: `npx vitest run src/components/ai src/lib/ai src/hooks/useDistribution.test.tsx`
+Expected: PASS (all).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ai/AiCompanion.tsx frontend/src/components/ai/AiCompanion.distribution.test.tsx
+git commit -m "feat(ai): wire /stats/distribution percentile into instant tier (county, single/all-year)"
+```
+
+---
+
+## Task 5: County-scoped totalIncidents context (`contextBuilders.ts` + `StatsPage.tsx`)
+
+**Files:**
+- Modify: `frontend/src/lib/ai/contextBuilders.ts`
+- Test: `frontend/src/lib/ai/contextBuilders.test.ts`
+- Modify: `frontend/src/pages/StatsPage.tsx`
+
+**Interfaces:**
+- Consumes: `statContext`, `FilterSnapshot` (from `./dataContext`), `normalizeCounty` (from `./measureMetric`).
+- Produces: `buildTotalCrashesContext(args: { totalIncidents: number | null; counties: Set<string>; filters: FilterSnapshot }): DataContext | null`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// frontend/src/lib/ai/contextBuilders.test.ts
+import { describe, it, expect } from "vitest";
+import { buildTotalCrashesContext } from "./contextBuilders";
+import type { FilterSnapshot } from "./dataContext";
+
+const filters: FilterSnapshot = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("buildTotalCrashesContext", () => {
+  it("returns null when totalIncidents is null", () => {
+    expect(buildTotalCrashesContext({ totalIncidents: null, counties: new Set(), filters })).toBeNull();
+  });
+
+  it("builds a county-scoped stat when exactly one county is selected", () => {
+    const ctx = buildTotalCrashesContext({ totalIncidents: 1234, counties: new Set(["Kern"]), filters });
+    expect(ctx).not.toBeNull();
+    expect(ctx!.kind).toBe("stat");
+    expect(ctx!.measure).toBe("crash_count");
+    expect(ctx!.geography).toEqual({ type: "county", id: "kern", name: "Kern" });
+    expect(ctx!.label).toBe("Total crashes · Kern");
+  });
+
+  it("builds a statewide stat with no geography for 0 or multiple counties", () => {
+    const zero = buildTotalCrashesContext({ totalIncidents: 5, counties: new Set(), filters });
+    const many = buildTotalCrashesContext({ totalIncidents: 5, counties: new Set(["Kern", "Inyo"]), filters });
+    expect(zero!.geography).toBeUndefined();
+    expect(zero!.label).toBe("Total crashes statewide");
+    expect(zero!.measure).toBe("crash_count");
+    expect(many!.geography).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/ai/contextBuilders.test.ts`
+Expected: FAIL — `buildTotalCrashesContext` is not exported.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `frontend/src/lib/ai/contextBuilders.ts` (and add the import at the top):
+
+```tsx
+import { normalizeCounty } from "./measureMetric";
+```
+
+```tsx
+export function buildTotalCrashesContext(args: {
+  totalIncidents: number | null;
+  counties: Set<string>;
+  filters: FilterSnapshot;
+}): DataContext | null {
+  if (args.totalIncidents == null) return null;
+  const names = [...args.counties];
+  if (names.length === 1) {
+    const name = names[0];
+    return statContext({
+      label: `Total crashes · ${name}`,
+      measure: "crash_count",
+      geography: { type: "county", id: normalizeCounty(name), name },
+      value: args.totalIncidents,
+      filters: args.filters,
+    });
+  }
+  return statContext({
+    label: "Total crashes statewide",
+    measure: "crash_count",
+    value: args.totalIncidents,
+    filters: args.filters,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/ai/contextBuilders.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire the helper into StatsPage**
+
+In `frontend/src/pages/StatsPage.tsx`:
+
+Update the import line that brings in `statContext, snapshotFilters`:
+```tsx
+import { statContext, snapshotFilters, buildTotalCrashesContext } from "../lib/ai/contextBuilders";
+```
+(Keep `statContext` if it is still used elsewhere in the file; if not, drop it from the import.)
+
+Replace the existing totalIncidents `<Explainable>` block (currently uses `statContext({ label: "Total crashes statewide", measure: "crashes_total", ... })`) with the helper-driven version:
+
+```tsx
+              <p className="text-3xl sm:text-4xl font-headline font-bold text-on-surface tracking-tight hero-value" aria-label={`Total incidents: ${totalIncidents != null ? totalIncidents.toLocaleString() : "unavailable"}`}>
+                {(() => {
+                  const totalCtx = buildTotalCrashesContext({ totalIncidents: totalIncidents ?? null, counties, filters: snapshotFilters(filters) });
+                  return totalCtx ? (
+                    <Explainable context={totalCtx}>{totalIncidents!.toLocaleString()}</Explainable>
+                  ) : "—";
+                })()}
+              </p>
+```
+
+(`counties` is the existing `Set<string>` of selected county names already in scope in this component; `filters` is the existing `FilterInputs` passed to `snapshotFilters` elsewhere in the file.)
+
+- [ ] **Step 6: Verify the full suite + typecheck**
+
+Run: `npx vitest run src/components/ai src/lib/ai src/hooks/useDistribution.test.tsx src/pages` (all pass)
+Run: `npx tsc --noEmit` (clean, exit 0)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/lib/ai/contextBuilders.ts frontend/src/lib/ai/contextBuilders.test.ts frontend/src/pages/StatsPage.tsx
+git commit -m "feat(ai): county-scoped totalIncidents context for percentile demo"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Inline deep-dive (askedHere gate, loading/error/answer, markdown+chart, aria-live, no stale history) → Task 3. ✅
+- `useDistribution` hook (enabled, URL with/without year, adapted) → Task 2. ✅
+- `measureToMetric` + name-normalized adapter → Task 1. ✅
+- Provider gate (county + mappable measure + ≤1 year) + pass to explainContext → Task 4. ✅
+- StatsPage one-county demo + statewide fallback + `crashes_total`→`crash_count` → Task 5. ✅
+- Hybrid invariant preserved (mock extended, invariant test still run) → Task 3 Steps 1 & 5. ✅
+- Best-effort fallback (no distribution → existing tier) → Task 4 (explainContext already falls back when `distribution` is empty/undefined). ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `DistributionPoint` reused from `statNarrative` across Tasks 1/2/4. `measureToMetric(measure: string): DistributionMetric | null`, `normalizeCounty`, `adaptDistribution(rows: DistributionRow[])` used identically in Tasks 1/2/5. `useDistribution(metric, year, { enabled })` signature matches Task 4's call. `buildTotalCrashesContext({ totalIncidents, counties, filters })` matches Task 5's StatsPage call. `explainContext(ctx, { distribution })` matches its existing signature. ✅
+
+**Note for implementer:** `current.measure` is a `string` on the `stat` variant of `DataContext`; `measureToMetric` takes a `string`, so no extra guard is needed. If `tsc` flags `current.measure` as possibly-undefined after the `kind === "stat"` narrowing, pass `current.measure ?? ""`.

--- a/docs/superpowers/specs/2026-06-28-ai-companion-p1-design.md
+++ b/docs/superpowers/specs/2026-06-28-ai-companion-p1-design.md
@@ -1,0 +1,110 @@
+# AI Companion P1 — Inline Deep-Dive + County Percentile Tier — Design
+
+**Date:** 2026-06-28
+**Status:** Approved (design); spec pending user review
+**Feature area:** AI Companion (`AiCompanion.tsx`), StatsPage, `/api/stats/distribution`
+
+## Summary
+
+Two P1 follow-ups to the P0 AI storytelling spine, both improving the AI Companion popover:
+
+1. **Inline deep-dive** — after "Go deeper with AI", render the AI answer *inside* the popover instead of silently dropping it into `useAskAi`'s sessionStorage (only viewable on `/ask`).
+2. **County percentile tier** — wire the already-built `GET /api/stats/distribution` endpoint into the instant tier so a county-scoped stat shows "ranks #N of 58 — safer than X%". Includes a live demo on StatsPage when exactly one county is selected.
+
+This closes the two headline gaps the P0 whole-branch review flagged and advances issue #306 (distribution UI wiring) and #305 (analytical credibility).
+
+## Background (current state)
+
+- `AiCompanion.tsx` renders a small bottom-right popover. "Go deeper" calls `sendMessage(buildDeepDivePrompt(current))` on the provider's **own** `useAskAi` instance. The response lands in that instance's `messages` (+ shared sessionStorage) but is **not rendered**.
+- `explainContext(ctx, { distribution })` already has a `kind:"stat"` percentile path (via `statNarrative`), but `distribution` is never supplied, so stats fall through to the placeholder.
+- `GET /api/stats/distribution?metric=&year=` returns `[{ county_code:int, county_name:string, value:number }]`; valid metrics: `crash_count, total_killed, total_injured, fatal_crashes, alcohol_crashes, pedestrian_crashes` (422 otherwise).
+- `statNarrative` matches the subject by `DistributionPoint.id === subjectId` and computes rank/percentile.
+- The StatsPage demo wraps statewide `totalIncidents` with `measure:"crashes_total"` and **no** geography — semantically not a percentile subject.
+
+## Part A — Inline deep-dive answer
+
+### Behavior
+- Add local state `askedHere: boolean`, set `true` on "Go deeper" click; reset to `false` whenever `current` changes (new number opened) or the popover closes. This ensures the popover shows **only the answer from this dialog session**, never stale `/ask` history that shares sessionStorage.
+- Below the "Go deeper" button, when `askedHere`, render an answer region:
+  - `isLoading` → a small "Thinking…" line.
+  - `error` (from `useAskAi`) → the error text + the existing `retry` button.
+  - otherwise → the **latest assistant message** (`messages.filter(m => m.role === "assistant").at(-1)`), rendered with `ReactMarkdown` for `content` and `InlineChart` for `chart` (the same primitives chat uses — no feedback/pin chrome).
+- The region is `max-h-[40vh] overflow-y-auto` and wrapped in `aria-live="polite"` so it scrolls and is announced to AT.
+
+### Source of state
+The provider already calls `useAskAi()`; extend the destructure to `{ sendMessage, isLoading, error, retry, messages }`. No new fetch path; the hybrid-tier invariant (no API call until the button) is preserved — `askedHere` only gates *rendering*, and the existing invariant test continues to assert `sendMessage` fires only on click.
+
+## Part B — County percentile tier
+
+### `useDistribution(metric, year, options)`
+New `frontend/src/hooks/useDistribution.ts` — a react-query hook (matching existing hook/query patterns in the repo) that:
+- Fetches `GET ${API_BASE}/api/stats/distribution?metric={metric}&year={year?}`.
+- Accepts `{ enabled?: boolean }`; when disabled, does not fetch.
+- Returns adapted `DistributionPoint[]` (see adapter).
+- Query key includes `metric` and `year`.
+
+### Adapter — match by name, not code
+The frontend selects counties by **name**, not by `county_code`. So the adapter maps each endpoint row to:
+```ts
+{ id: normalizeCounty(row.county_name), name: row.county_name, value: row.value }
+```
+where `normalizeCounty(s) = s.trim().toLowerCase()`. The subject's `geography.id` is built with the **same** `normalizeCounty`, so `statNarrative`'s `id === subjectId` match works without the client knowing county codes.
+
+### `measureToMetric(measure: string): DistributionMetric | null`
+New `frontend/src/lib/ai/measureMetric.ts`:
+```ts
+type DistributionMetric = "crash_count" | "total_killed" | "total_injured"
+  | "fatal_crashes" | "alcohol_crashes" | "pedestrian_crashes";
+```
+Maps known measure strings to a metric; returns `null` for anything else (e.g. `crashes_total`, rates). `normalizeCounty` also lives here (or a small shared util) so the adapter and the demo share one implementation.
+
+### Provider wiring (`AiCompanion.tsx`)
+- Derive, from `current`:
+  - `metric = current?.kind === "stat" ? measureToMetric(current.measure) : null`
+  - `isCounty = current?.geography?.type === "county"`
+  - `year` = the single selected year if `current.filters.years.length === 1`, else `null` if `current.filters.years.length === 0`, else the tier is disabled (see guard).
+  - `distEnabled = current?.kind === "stat" && isCounty && metric != null && current.filters.years.length <= 1`
+- Call `const { data: distribution } = useDistribution(metric ?? "crash_count", year, { enabled: distEnabled })` (metric falls back to a valid default when disabled so the URL is always well-formed; `enabled` prevents the fetch).
+- Compute `explanation = current ? explainContext(current, { distribution: distEnabled ? distribution : undefined }) : null`.
+
+**Year guard rationale:** the endpoint computes one specific year or all years. A multi-specific-year filter (e.g. 2020+2021) would make the subject value and the distribution disagree, producing a dishonest percentile. So multi-year selections disable the distribution tier and fall back to the existing placeholder/chart tier.
+
+### Live demo (`StatsPage.tsx`)
+When exactly one county is selected (`selectedCounties.size === 1`), build the `totalIncidents` Explainable context as county-scoped:
+- `label: "Total crashes · {CountyName}"`
+- `measure: "crash_count"`
+- `geography: { type: "county", id: normalizeCounty(countyName), name: countyName }`
+- `value: totalIncidents`
+
+Otherwise (statewide / multi-county) keep the current context (`label:"Total crashes statewide"`, `measure:"crash_count"`, no geography). (Change `crashes_total` → `crash_count` so the measure is a real metric; statewide still won't fetch because it has no county geography.)
+
+`countyName` comes from the single entry of `selectedCounties`. The demo uses `normalizeCounty` from `measureMetric.ts` for the id.
+
+## Error Handling
+- Deep-dive: `useAskAi` errors surface inline with `retry` (Part A). A rejected fetch never crashes the popover.
+- Distribution: if `useDistribution` errors or returns empty, `explainContext` receives no usable `distribution` and falls back to the existing tier (placeholder/chart) — no error shown for the instant tier (it's best-effort enrichment).
+
+## Non-Goals (YAGNI)
+- Not tightening `DataContext.measure` from `string` to a union (cross-file churn; `measureToMetric` guards the mapping).
+- No streaming of the deep-dive answer; no chart export from the popover.
+- No new distribution metrics beyond the six the endpoint already supports.
+
+## File Summary
+New:
+- `frontend/src/hooks/useDistribution.ts` (+ test)
+- `frontend/src/lib/ai/measureMetric.ts` (`measureToMetric`, `normalizeCounty`, adapter helper) (+ test)
+
+Modified:
+- `frontend/src/components/ai/AiCompanion.tsx` — inline answer region + distribution wiring
+- `frontend/src/pages/StatsPage.tsx` — county-scoped context when 1 county selected
+
+## Testing (TDD)
+- `measureToMetric`: known measures map; unknown → null. `normalizeCounty`: trim/lowercase. Adapter: endpoint rows → `{id,name,value}` with normalized id.
+- `useDistribution`: builds correct URL with/without year; returns adapted points; does not fetch when `enabled:false` (mock fetch).
+- `AiCompanion` (mock `useAskAi`):
+  - does NOT render an answer before "Go deeper" even if `messages` has stale history;
+  - after clicking, renders the latest assistant message (markdown);
+  - shows "Thinking…" while `isLoading`, and error + retry when `error`;
+  - the existing hybrid-invariant test still passes (no `sendMessage` on open).
+- `AiCompanion` distribution enablement: with a county stat + mappable measure + ≤1 year, `explainContext` gets a distribution and the percentile narrative renders; with multi-year or no geography, it falls back (assert via the rendered body text).
+- `StatsPage`: one county selected → context has county geography + `crash_count`; statewide → no geography.

--- a/frontend/src/components/ai/AiCompanion.distribution.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.distribution.test.tsx
@@ -1,0 +1,54 @@
+// frontend/src/components/ai/AiCompanion.distribution.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("../../hooks/useAskAi", () => ({
+  useAskAi: () => ({ sendMessage: vi.fn(), isLoading: false, error: null, retry: vi.fn(), messages: [] }),
+}));
+// Always return a 2-county distribution; the provider's gate decides whether to use it.
+vi.mock("../../hooks/useDistribution", () => ({
+  useDistribution: () => ({
+    data: [{ id: "kern", name: "Kern", value: 100 }, { id: "x", name: "X", value: 500 }],
+    isLoading: false,
+  }),
+}));
+
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const baseFilters = {
+  years: [2023], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+const countyStat: DataContext = {
+  kind: "stat", label: "Total crashes · Kern", measure: "crash_count", value: 100,
+  geography: { type: "county", id: "kern", name: "Kern" }, filters: baseFilters,
+};
+const statewideStat: DataContext = {
+  kind: "stat", label: "Total crashes statewide", measure: "crash_count", value: 100, filters: baseFilters,
+};
+
+function Trigger({ ctx }: { ctx: DataContext }) {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>open</button>;
+}
+function renderWith(ctx: DataContext) {
+  return render(<MemoryRouter><AiCompanionProvider><Trigger ctx={ctx} /></AiCompanionProvider></MemoryRouter>);
+}
+
+describe("AiCompanion distribution tier", () => {
+  it("renders a percentile narrative for a single-county stat", () => {
+    renderWith(countyStat);
+    fireEvent.click(screen.getByText("open"));
+    expect(screen.getByRole("dialog").textContent).toMatch(/ranks #|safer than/i);
+  });
+
+  it("does not use distribution for a statewide stat (no county geography)", () => {
+    renderWith(statewideStat);
+    fireEvent.click(screen.getByText("open"));
+    expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
+  });
+});

--- a/frontend/src/components/ai/AiCompanion.distribution.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.distribution.test.tsx
@@ -1,5 +1,5 @@
 // frontend/src/components/ai/AiCompanion.distribution.test.tsx
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 

--- a/frontend/src/components/ai/AiCompanion.distribution.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.distribution.test.tsx
@@ -51,4 +51,24 @@ describe("AiCompanion distribution tier", () => {
     fireEvent.click(screen.getByText("open"));
     expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
   });
+
+  it("does not show percentile when a population-narrowing filter (severity) is active", () => {
+    const filteredStat: DataContext = {
+      ...countyStat,
+      filters: { ...baseFilters, severities: ["Fatal"] },
+    };
+    renderWith(filteredStat);
+    fireEvent.click(screen.getByText("open"));
+    expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
+  });
+
+  it("does not show percentile when two years are selected", () => {
+    const multiYearStat: DataContext = {
+      ...countyStat,
+      filters: { ...baseFilters, years: [2022, 2023] },
+    };
+    renderWith(multiYearStat);
+    fireEvent.click(screen.getByText("open"));
+    expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
+  });
 });

--- a/frontend/src/components/ai/AiCompanion.inline.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.inline.test.tsx
@@ -3,6 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
+vi.mock("../../hooks/useDistribution", () => ({
+  useDistribution: () => ({ data: undefined, isLoading: false }),
+}));
+
 const hoisted = vi.hoisted(() => ({
   state: {
     sendMessage: vi.fn(),

--- a/frontend/src/components/ai/AiCompanion.inline.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.inline.test.tsx
@@ -63,12 +63,13 @@ describe("AiCompanion inline deep-dive", () => {
     expect(screen.getByText("Fresh inline answer.")).toBeTruthy();
   });
 
-  it("shows a thinking state while loading after Go deeper", () => {
-    hoisted.state.isLoading = true;
-    renderApp();
+  it("shows a thinking state in the inline region after Go deeper is clicked", () => {
+    const { rerender } = renderApp();
     fireEvent.click(screen.getByText("explain"));
-    fireEvent.click(screen.getByText(/Thinking|Go deeper/));
-    expect(screen.getByText(/Thinking/)).toBeTruthy();
+    fireEvent.click(screen.getByText("Go deeper with AI"));
+    hoisted.state.isLoading = true;
+    rerender(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+    expect(screen.getByText("Generating answer…")).toBeTruthy();
   });
 
   it("shows an error with a retry button after Go deeper", () => {

--- a/frontend/src/components/ai/AiCompanion.inline.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.inline.test.tsx
@@ -1,0 +1,79 @@
+// frontend/src/components/ai/AiCompanion.inline.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+const hoisted = vi.hoisted(() => ({
+  state: {
+    sendMessage: vi.fn(),
+    retry: vi.fn(),
+    isLoading: false,
+    error: null as string | null,
+    messages: [] as Array<{ role: string; content: string; timestamp: number; chart?: unknown }>,
+  },
+}));
+vi.mock("../../hooks/useAskAi", () => ({ useAskAi: () => hoisted.state }));
+
+import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import type { DataContext } from "../../lib/ai/dataContext";
+
+const filters = {
+  years: [2023], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ label: "5pm", value: 9 }], filters };
+
+function Trigger() {
+  const { open } = useAiCompanion();
+  return <button onClick={() => open(ctx)}>explain</button>;
+}
+function renderApp() {
+  return render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+}
+
+beforeEach(() => {
+  hoisted.state.sendMessage = vi.fn();
+  hoisted.state.retry = vi.fn();
+  hoisted.state.isLoading = false;
+  hoisted.state.error = null;
+  hoisted.state.messages = [];
+});
+
+describe("AiCompanion inline deep-dive", () => {
+  it("does not show any prior assistant answer before Go deeper is clicked", () => {
+    hoisted.state.messages = [{ role: "assistant", content: "STALE ANSWER", timestamp: 1 }];
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    expect(screen.queryByText("STALE ANSWER")).toBeNull();
+  });
+
+  it("renders the latest assistant answer after Go deeper", () => {
+    hoisted.state.messages = [
+      { role: "user", content: "q", timestamp: 1 },
+      { role: "assistant", content: "Fresh inline answer.", timestamp: 2 },
+    ];
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.click(screen.getByText("Go deeper with AI"));
+    expect(screen.getByText("Fresh inline answer.")).toBeTruthy();
+  });
+
+  it("shows a thinking state while loading after Go deeper", () => {
+    hoisted.state.isLoading = true;
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.click(screen.getByText(/Thinking|Go deeper/));
+    expect(screen.getByText(/Thinking/)).toBeTruthy();
+  });
+
+  it("shows an error with a retry button after Go deeper", () => {
+    hoisted.state.error = "Rate limited.";
+    renderApp();
+    fireEvent.click(screen.getByText("explain"));
+    fireEvent.click(screen.getByText("Go deeper with AI"));
+    expect(screen.getByText("Rate limited.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(hoisted.state.retry).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/ai/AiCompanion.invariant.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.invariant.test.tsx
@@ -10,7 +10,7 @@ import type { DataContext } from "../../lib/ai/dataContext";
 // would silently fire a Groq request and blow the free tier.
 const sendMessage = vi.fn();
 vi.mock("../../hooks/useAskAi", () => ({
-  useAskAi: () => ({ sendMessage, isLoading: false }),
+  useAskAi: () => ({ sendMessage, isLoading: false, error: null, retry: vi.fn(), messages: [] }),
 }));
 
 const filters = {

--- a/frontend/src/components/ai/AiCompanion.invariant.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.invariant.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+
+vi.mock("../../hooks/useDistribution", () => ({
+  useDistribution: () => ({ data: undefined, isLoading: false }),
+}));
+
 import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
 import type { DataContext } from "../../lib/ai/dataContext";
 

--- a/frontend/src/components/ai/AiCompanion.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.test.tsx
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("../../hooks/useDistribution", () => ({
+  useDistribution: () => ({ data: undefined, isLoading: false }),
+}));
 import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
 import type { DataContext } from "../../lib/ai/dataContext";

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -1,7 +1,10 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import ReactMarkdown from "react-markdown";
 import type { DataContext } from "../../lib/ai/dataContext";
 import { explainContext } from "../../lib/ai/explainContext";
 import { useAskAi } from "../../hooks/useAskAi";
+import type { ChatMessage } from "../../hooks/useAskAi";
+import InlineChart from "../ask/InlineChart";
 
 export function buildDeepDivePrompt(ctx: DataContext): string {
   const parts: string[] = [`Explain this CalSight data point: "${ctx.label}".`];
@@ -26,7 +29,8 @@ const Ctx = createContext<CompanionApi | null>(null);
 
 export function AiCompanionProvider({ children }: { children: ReactNode }) {
   const [current, setCurrent] = useState<DataContext | null>(null);
-  const { sendMessage, isLoading } = useAskAi();
+  const [askedHere, setAskedHere] = useState(false);
+  const { sendMessage, isLoading, error, retry, messages } = useAskAi();
 
   const open = useCallback((ctx: DataContext) => setCurrent(ctx), []);
   const close = useCallback(() => setCurrent(null), []);
@@ -38,8 +42,12 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
     return () => document.removeEventListener("keydown", onKey);
   }, [current, close]);
 
+  useEffect(() => { setAskedHere(false); }, [current]);
+
   const api = useMemo<CompanionApi>(() => ({ open, close, current }), [open, close, current]);
   const explanation = current ? explainContext(current) : null;
+  const lastAnswer: ChatMessage | undefined =
+    [...messages].reverse().find((m) => m.role === "assistant");
 
   return (
     <Ctx.Provider value={api}>
@@ -56,12 +64,29 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
           </div>
           <p className="mt-2 text-sm text-on-surface-variant">{explanation.body}</p>
           <button
-            onClick={() => current && sendMessage(buildDeepDivePrompt(current))}
+            onClick={() => { if (current) { setAskedHere(true); sendMessage(buildDeepDivePrompt(current)); } }}
             disabled={isLoading}
             className="mt-3 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary disabled:opacity-50"
           >
             {isLoading ? "Thinking…" : "Go deeper with AI"}
           </button>
+          {askedHere && (
+            <div aria-live="polite" className="mt-3 max-h-[40vh] overflow-y-auto border-t border-outline-variant pt-3">
+              {isLoading && <p className="text-xs text-on-surface-variant">Thinking…</p>}
+              {error && !isLoading && (
+                <p className="text-xs text-error">
+                  {error}{" "}
+                  <button onClick={retry} className="underline" aria-label="Retry deep dive">Retry</button>
+                </p>
+              )}
+              {!isLoading && !error && lastAnswer && (
+                <div className="prose prose-sm dark:prose-invert max-w-none text-on-surface">
+                  <ReactMarkdown>{lastAnswer.content}</ReactMarkdown>
+                  {lastAnswer.chart && <InlineChart chart={lastAnswer.chart} />}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </Ctx.Provider>

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -5,6 +5,8 @@ import { explainContext } from "../../lib/ai/explainContext";
 import { useAskAi } from "../../hooks/useAskAi";
 import type { ChatMessage } from "../../hooks/useAskAi";
 import InlineChart from "../ask/InlineChart";
+import { useDistribution } from "../../hooks/useDistribution";
+import { measureToMetric } from "../../lib/ai/measureMetric";
 
 export function buildDeepDivePrompt(ctx: DataContext): string {
   const parts: string[] = [`Explain this CalSight data point: "${ctx.label}".`];
@@ -45,7 +47,20 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
   useEffect(() => { setAskedHere(false); }, [current]);
 
   const api = useMemo<CompanionApi>(() => ({ open, close, current }), [open, close, current]);
-  const explanation = current ? explainContext(current) : null;
+
+  const metric = current?.kind === "stat" ? measureToMetric(current.measure) : null;
+  const years = current?.filters.years ?? [];
+  const distEnabled =
+    current?.kind === "stat" &&
+    current.geography?.type === "county" &&
+    metric != null &&
+    years.length <= 1;
+  const distYear = years.length === 1 ? years[0] : null;
+  const { data: distribution } = useDistribution(metric ?? "crash_count", distYear, { enabled: distEnabled });
+
+  const explanation = current
+    ? explainContext(current, distEnabled ? { distribution } : undefined)
+    : null;
   const lastAnswer: ChatMessage | undefined =
     [...messages].reverse().find((m) => m.role === "assistant");
 

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -48,7 +48,7 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
 
   const api = useMemo<CompanionApi>(() => ({ open, close, current }), [open, close, current]);
 
-  const metric = current?.kind === "stat" ? measureToMetric(current.measure) : null;
+  const metric = current?.kind === "stat" ? measureToMetric(current.measure ?? "") : null;
   const years = current?.filters.years ?? [];
   const distEnabled =
     current?.kind === "stat" &&

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -6,7 +6,7 @@ import { useAskAi } from "../../hooks/useAskAi";
 import type { ChatMessage } from "../../hooks/useAskAi";
 import InlineChart from "../ask/InlineChart";
 import { useDistribution } from "../../hooks/useDistribution";
-import { measureToMetric } from "../../lib/ai/measureMetric";
+import { measureToMetric, distributionPopulationMatches } from "../../lib/ai/measureMetric";
 
 export function buildDeepDivePrompt(ctx: DataContext): string {
   const parts: string[] = [`Explain this CalSight data point: "${ctx.label}".`];
@@ -54,7 +54,8 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
     current?.kind === "stat" &&
     current.geography?.type === "county" &&
     metric != null &&
-    years.length <= 1;
+    years.length <= 1 &&
+    distributionPopulationMatches(current.filters);
   const distYear = years.length === 1 ? years[0] : null;
   const { data: distribution } = useDistribution(metric ?? "crash_count", distYear, { enabled: distEnabled });
 
@@ -87,7 +88,7 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
           </button>
           {askedHere && (
             <div aria-live="polite" className="mt-3 max-h-[40vh] overflow-y-auto border-t border-outline-variant pt-3">
-              {isLoading && <p className="text-xs text-on-surface-variant">Thinking…</p>}
+              {isLoading && <p className="text-xs text-on-surface-variant">Generating answer…</p>}
               {error && !isLoading && (
                 <p className="text-xs text-error">
                   {error}{" "}

--- a/frontend/src/components/ai/Explainable.test.tsx
+++ b/frontend/src/components/ai/Explainable.test.tsx
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("../../hooks/useDistribution", () => ({
+  useDistribution: () => ({ data: undefined, isLoading: false }),
+}));
 import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider } from "./AiCompanion";
 import { Explainable } from "./Explainable";

--- a/frontend/src/hooks/useDistribution.test.tsx
+++ b/frontend/src/hooks/useDistribution.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useDistribution } from "./useDistribution";
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const rows = [{ county_code: 15, county_name: "Kern", value: 100 }];
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => rows })) as unknown as typeof fetch);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useDistribution", () => {
+  it("fetches with metric + year and returns adapted points", async () => {
+    const { result } = renderHook(() => useDistribution("crash_count", 2023, { enabled: true }), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data).toEqual([{ id: "kern", name: "Kern", value: 100 }]);
+    const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).toContain("metric=crash_count");
+    expect(url).toContain("year=2023");
+  });
+
+  it("omits year from the URL when year is null", async () => {
+    const { result } = renderHook(() => useDistribution("crash_count", null, { enabled: true }), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    const url = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(url).not.toContain("year=");
+  });
+
+  it("does not fetch when disabled", () => {
+    renderHook(() => useDistribution("crash_count", null, { enabled: false }), { wrapper: wrapper() });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useDistribution.ts
+++ b/frontend/src/hooks/useDistribution.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+import { adaptDistribution, type DistributionRow } from "../lib/ai/measureMetric";
+import type { DistributionPoint } from "../lib/ai/statNarrative";
+
+export function useDistribution(
+  metric: string,
+  year: number | null,
+  options?: { enabled?: boolean },
+): { data: DistributionPoint[] | undefined; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: ["distribution", metric, year],
+    enabled: options?.enabled ?? true,
+    queryFn: async (): Promise<DistributionPoint[]> => {
+      const params = new URLSearchParams({ metric });
+      if (year != null) params.set("year", String(year));
+      const res = await fetch(`${API_BASE}/api/stats/distribution?${params.toString()}`);
+      if (!res.ok) throw new Error(`distribution ${res.status}`);
+      const data = (await res.json()) as DistributionRow[];
+      return adaptDistribution(data);
+    },
+  });
+  return { data: query.data, isLoading: query.isLoading };
+}

--- a/frontend/src/lib/ai/contextBuilders.test.ts
+++ b/frontend/src/lib/ai/contextBuilders.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { snapshotFilters, statContext, chartContext } from "./contextBuilders";
+import { snapshotFilters, statContext, chartContext, buildTotalCrashesContext } from "./contextBuilders";
+import type { FilterSnapshot } from "./dataContext";
 
 const inputs = {
   selectedYears: new Set([2023, 2022]),
@@ -47,5 +48,35 @@ describe("contextBuilders", () => {
     });
     expect(ctx.kind).toBe("chart");
     expect(ctx.series).toEqual([{ label: "0", value: 10 }]);
+  });
+});
+
+const filters: FilterSnapshot = {
+  years: [], severities: [], counties: [], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("buildTotalCrashesContext", () => {
+  it("returns null when totalIncidents is null", () => {
+    expect(buildTotalCrashesContext({ totalIncidents: null, counties: new Set(), filters })).toBeNull();
+  });
+
+  it("builds a county-scoped stat when exactly one county is selected", () => {
+    const ctx = buildTotalCrashesContext({ totalIncidents: 1234, counties: new Set(["Kern"]), filters });
+    expect(ctx).not.toBeNull();
+    expect(ctx!.kind).toBe("stat");
+    expect(ctx!.measure).toBe("crash_count");
+    expect(ctx!.geography).toEqual({ type: "county", id: "kern", name: "Kern" });
+    expect(ctx!.label).toBe("Total crashes · Kern");
+  });
+
+  it("builds a statewide stat with no geography for 0 or multiple counties", () => {
+    const zero = buildTotalCrashesContext({ totalIncidents: 5, counties: new Set(), filters });
+    const many = buildTotalCrashesContext({ totalIncidents: 5, counties: new Set(["Kern", "Inyo"]), filters });
+    expect(zero!.geography).toBeUndefined();
+    expect(zero!.label).toBe("Total crashes statewide");
+    expect(zero!.measure).toBe("crash_count");
+    expect(many!.geography).toBeUndefined();
   });
 });

--- a/frontend/src/lib/ai/contextBuilders.ts
+++ b/frontend/src/lib/ai/contextBuilders.ts
@@ -1,4 +1,5 @@
 import type { DataContext, FilterSnapshot, ChartPoint } from "./dataContext";
+import { normalizeCounty } from "./measureMetric";
 
 export type FilterInputs = {
   selectedYears: Set<number>;
@@ -53,4 +54,29 @@ export function chartContext(args: {
   label: string; series: ChartPoint[]; measure?: string; filters: FilterSnapshot;
 }): DataContext {
   return { kind: "chart", label: args.label, series: args.series, measure: args.measure, filters: args.filters };
+}
+
+export function buildTotalCrashesContext(args: {
+  totalIncidents: number | null;
+  counties: Set<string>;
+  filters: FilterSnapshot;
+}): DataContext | null {
+  if (args.totalIncidents == null) return null;
+  const names = [...args.counties];
+  if (names.length === 1) {
+    const name = names[0];
+    return statContext({
+      label: `Total crashes · ${name}`,
+      measure: "crash_count",
+      geography: { type: "county", id: normalizeCounty(name), name },
+      value: args.totalIncidents,
+      filters: args.filters,
+    });
+  }
+  return statContext({
+    label: "Total crashes statewide",
+    measure: "crash_count",
+    value: args.totalIncidents,
+    filters: args.filters,
+  });
 }

--- a/frontend/src/lib/ai/measureMetric.test.ts
+++ b/frontend/src/lib/ai/measureMetric.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { measureToMetric, normalizeCounty, adaptDistribution } from "./measureMetric";
+import { measureToMetric, normalizeCounty, adaptDistribution, distributionPopulationMatches } from "./measureMetric";
+import type { FilterSnapshot } from "./dataContext";
 
 describe("measureToMetric", () => {
   it("maps known distribution metrics", () => {
@@ -31,5 +32,26 @@ describe("adaptDistribution", () => {
       { id: "kern", name: "Kern", value: 100 },
       { id: "los angeles", name: "Los Angeles", value: 500 },
     ]);
+  });
+});
+
+const allEmpty: FilterSnapshot = {
+  years: [2023], severities: [], counties: ["Kern"], causes: [],
+  alcohol: null, distracted: null, pedestrian: null, cyclist: null, drug: null,
+  driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
+};
+
+describe("distributionPopulationMatches", () => {
+  it("returns true when no population-narrowing filter is active", () => {
+    expect(distributionPopulationMatches(allEmpty)).toBe(true);
+  });
+  it("returns false when a severity is present", () => {
+    expect(distributionPopulationMatches({ ...allEmpty, severities: ["Fatal"] })).toBe(false);
+  });
+  it("returns false when an involvement flag (alcohol) is set", () => {
+    expect(distributionPopulationMatches({ ...allEmpty, alcohol: true })).toBe(false);
+  });
+  it("returns true for a county + single-year-only snapshot (no other filters)", () => {
+    expect(distributionPopulationMatches({ ...allEmpty, years: [2023], counties: ["Kern"] })).toBe(true);
   });
 });

--- a/frontend/src/lib/ai/measureMetric.test.ts
+++ b/frontend/src/lib/ai/measureMetric.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { measureToMetric, normalizeCounty, adaptDistribution } from "./measureMetric";
+
+describe("measureToMetric", () => {
+  it("maps known distribution metrics", () => {
+    expect(measureToMetric("crash_count")).toBe("crash_count");
+    expect(measureToMetric("fatal_crashes")).toBe("fatal_crashes");
+    expect(measureToMetric("pedestrian_crashes")).toBe("pedestrian_crashes");
+  });
+  it("returns null for unknown measures", () => {
+    expect(measureToMetric("crashes_total")).toBeNull();
+    expect(measureToMetric("")).toBeNull();
+    expect(measureToMetric("ksi_rate")).toBeNull();
+  });
+});
+
+describe("normalizeCounty", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeCounty("  Kern ")).toBe("kern");
+    expect(normalizeCounty("Los Angeles")).toBe("los angeles");
+  });
+});
+
+describe("adaptDistribution", () => {
+  it("maps endpoint rows to DistributionPoint with normalized id", () => {
+    const out = adaptDistribution([
+      { county_code: 15, county_name: "Kern", value: 100 },
+      { county_code: 19, county_name: "Los Angeles", value: 500 },
+    ]);
+    expect(out).toEqual([
+      { id: "kern", name: "Kern", value: 100 },
+      { id: "los angeles", name: "Los Angeles", value: 500 },
+    ]);
+  });
+});

--- a/frontend/src/lib/ai/measureMetric.ts
+++ b/frontend/src/lib/ai/measureMetric.ts
@@ -1,0 +1,24 @@
+import type { DistributionPoint } from "./statNarrative";
+
+export type DistributionMetric =
+  | "crash_count" | "total_killed" | "total_injured"
+  | "fatal_crashes" | "alcohol_crashes" | "pedestrian_crashes";
+
+const METRICS: ReadonlySet<string> = new Set<DistributionMetric>([
+  "crash_count", "total_killed", "total_injured",
+  "fatal_crashes", "alcohol_crashes", "pedestrian_crashes",
+]);
+
+export function measureToMetric(measure: string): DistributionMetric | null {
+  return METRICS.has(measure) ? (measure as DistributionMetric) : null;
+}
+
+export function normalizeCounty(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+export type DistributionRow = { county_code: number; county_name: string; value: number };
+
+export function adaptDistribution(rows: DistributionRow[]): DistributionPoint[] {
+  return rows.map((r) => ({ id: normalizeCounty(r.county_name), name: r.county_name, value: r.value }));
+}

--- a/frontend/src/lib/ai/measureMetric.ts
+++ b/frontend/src/lib/ai/measureMetric.ts
@@ -1,4 +1,5 @@
 import type { DistributionPoint } from "./statNarrative";
+import type { FilterSnapshot } from "./dataContext";
 
 export type DistributionMetric =
   | "crash_count" | "total_killed" | "total_injured"
@@ -15,6 +16,28 @@ export function measureToMetric(measure: string): DistributionMetric | null {
 
 export function normalizeCounty(name: string): string {
   return name.trim().toLowerCase();
+}
+
+/** True when no population-narrowing filter beyond county + year is active, so
+ *  the subject value matches the year-only distribution population and the
+ *  percentile is honest. (years and counties are intentionally NOT checked
+ *  here — year is gated separately and the single county IS the subject.) */
+export function distributionPopulationMatches(f: FilterSnapshot): boolean {
+  return (
+    f.severities.length === 0 &&
+    f.causes.length === 0 &&
+    f.weather.length === 0 &&
+    f.lighting.length === 0 &&
+    f.collisionType.length === 0 &&
+    f.alcohol == null &&
+    f.distracted == null &&
+    f.pedestrian == null &&
+    f.cyclist == null &&
+    f.drug == null &&
+    f.roadType == null &&
+    f.hitRun == null &&
+    f.driverAge == null
+  );
 }
 
 export type DistributionRow = { county_code: number; county_name: string; value: number };

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useCallback } from "react";
 import { Navigate } from "react-router-dom";
 import { useFilterParams, formatYearMonth, CAUSES as CAUSE_OPTIONS, SEVERITIES, YEARS } from "../hooks/useFilterParams";
 import { Explainable } from "../components/ai/Explainable";
-import { statContext, snapshotFilters } from "../lib/ai/contextBuilders";
+import { snapshotFilters, buildTotalCrashesContext } from "../lib/ai/contextBuilders";
 import { useApplyDefaultCounty } from "../hooks/useApplyDefaultCounty";
 import MobileFilterSheet from "../components/map/MobileFilterSheet";
 import FiltersPanel from "../components/map/FiltersPanel";
@@ -489,11 +489,12 @@ function StatsPageInner() {
               <Skeleton className="h-10 w-40" />
             ) : (
               <p className="text-3xl sm:text-4xl font-headline font-bold text-on-surface tracking-tight hero-value" aria-label={`Total incidents: ${totalIncidents != null ? totalIncidents.toLocaleString() : "unavailable"}`}>
-                {totalIncidents != null ? (
-                  <Explainable context={statContext({ label: "Total crashes statewide", measure: "crashes_total", value: totalIncidents, filters: snapshotFilters(filters) })}>
-                    {totalIncidents.toLocaleString()}
-                  </Explainable>
-                ) : "—"}
+                {(() => {
+                  const totalCtx = buildTotalCrashesContext({ totalIncidents: totalIncidents ?? null, counties, filters: snapshotFilters(filters) });
+                  return totalCtx ? (
+                    <Explainable context={totalCtx}>{totalIncidents!.toLocaleString()}</Explainable>
+                  ) : "—";
+                })()}
               </p>
             )}
             {incidentYoYPct != null && (


### PR DESCRIPTION
## AI Companion P1 — inline deep-dive + county percentile tier

Closes the two headline gaps the P0 spine review flagged; advances #306 (distribution UI wiring) and #305 (analytical credibility).

### What's in it
- **Inline deep-dive** — "Go deeper with AI" now renders the answer *inside* the companion popover (markdown + chart, scrollable, `aria-live`), gated by an `askedHere` flag so stale `/ask` history never shows. Loading + error/retry states inline.
- **County percentile tier** — `GET /api/stats/distribution` wired into the instant tier: a single-county stat shows "ranks #N of 58 — safer than X%".
  - `measureMetric.ts` (measure→metric map, name-normalizing adapter), `useDistribution.ts` (react-query hook), gate in `AiCompanion.tsx`, `buildTotalCrashesContext` + StatsPage demo (totalIncidents becomes county-scoped when exactly one county is selected).
- **Honesty gate** — the percentile only engages when the population matches: county geography + mappable measure + `years.length <= 1` + **no other population-narrowing filter** (severity/cause/involvement/weather/lighting/collision/road/hit-run/driver-age). Otherwise it falls back silently. (Final-review fix: the subject value reflects all filters but the endpoint filters by year only, so an unguarded percentile would be misleading.)

### Verification
- Frontend: 527 tests / 65 files green, `tsc --noEmit` clean.
- Hybrid-tier invariant preserved (no Groq call until the explicit click).

### Deferred (P2, non-blocking — from reviews)
- Broaden `measureToMetric` positive tests to all 6 metrics; strengthen the disabled-fetch test with a microtask flush.
- Longer term: teach `/api/stats/distribution` to accept the full filter set so the percentile can stay enabled under filters (instead of gating off).
