### PR TITLE
fix(map): highways above choropleth + CI eslint fix

### DIFF
--- a/docs/mobile-polish-audit.md
+++ b/docs/mobile-polish-audit.md
@@ -67,6 +67,15 @@ Severity: 🔴 collision/unusable · 🟠 visibly broken/clipped · 🟡 minor (
 2. ✅ **Missing icon glyphs** — fixed (PR #332): added `auto_stories`/`push_pin`/`delete_sweep` to the Google Fonts `icon_names` subset. Verified: all 3 render as glyphs.
 3. ✅ **Highway Danger legibility** — fixed (PR #332 palette + #333 casing): dedicated mono-danger ramp (orange→crimson, independent of choropleth) + white casing. Verified live: 150 lines in the danger palette + 152 white casings; routes now read distinctly (esp. the I-5 corridor). NOTE: dark-crimson high-danger routes are still a bit muted over the blue choropleth — optional future polish = dim the county choropleth opacity when Highway Danger is active (removes the competing blue entirely). PWA note: the update appears on the user's SECOND load (service worker serves cached bundle first).
 
+### 🛣️ Highways — next-up backlog (from 2026-06-28 review w/ Jeff)
+- **Highways now render ABOVE the county choropleth** (dedicated Leaflet pane, z-index 450) + this fixed click-to-select (the choropleth was eating clicks). Shipping now.
+- **Click → highway stats already works** (`HighwaySidePanelContent`): route, miles, crashes, killed, injured, fatality rate, crashes/mile. Verified (SR-1).
+- [ ] **Highway AI cards** — wrap the highway side-panel stats in the `Explainable`/"Go deeper" pattern (like stat numbers) so you can ask AI about a route. Own spec→build.
+- [ ] **"Most dangerous highway" ranking feature** — surface it (insight card / rankings table). Data is there: deadliest by deaths = **I-5** (2,672); by fatality rate = **SR-160** (4.39%) then I-40; by crashes/mile = **I-238** (3,169/mi), I-405. (`HighwayRankingsTable` exists — wire/feature it.)
+- [ ] **Highway geometry fidelity** — `ca-highways.geojson` is simplified → straight/coarse lines when zoomed in. Re-export at higher resolution, but balance against load size (adaptive simplify by zoom). Tradeoff with perf below.
+- [ ] **Performance / bundle audit (#302)** — measure the bundle delta from new features (Story Canvas pulls in `html-to-image` + `jspdf`); lazy-load the export libs so they only load on Export; check overall load times.
+- [ ] **Backend query efficiency (#310)** — verify `/api/stats/highways` (and choropleth/stats) hit aggregate/materialized tables + indexes, not raw 25M-row scans. Audit the SQL.
+
 ### ⏳ REMAINING (open backlog — not yet fixed)
 4. 🔴/🟠 **AI companion popover overlaps mobile bottom nav** (`AiCompanion.tsx` `fixed bottom-4`); filter chips clipped right (/stats).
 5. 🟡 "Ask AI" h1 wraps; map double bottom-bars; about spacing; redundant Filters chip.

--- a/frontend/src/components/ask/StoryCanvasPanel.tsx
+++ b/frontend/src/components/ask/StoryCanvasPanel.tsx
@@ -29,6 +29,16 @@ export default function StoryCanvasPanel({ open, onClose, onExportPng, onExportP
     }
   }, [open]);
 
+  // Escape closes. On the document (not the dialog div) to avoid attaching a
+  // key handler to a non-interactive element (jsx-a11y) and to catch the key
+  // regardless of where focus sits inside the panel.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
   if (!open) return null;
 
   const handleClear = () => {
@@ -44,7 +54,6 @@ export default function StoryCanvasPanel({ open, onClose, onExportPng, onExportP
         aria-modal="true"
         aria-label="Your AI story"
         tabIndex={-1}
-        onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
         className="relative w-full max-w-md h-full bg-surface shadow-xl flex flex-col outline-none"
       >
         {/* Header */}

--- a/frontend/src/components/map/HighwayDangerLayer.tsx
+++ b/frontend/src/components/map/HighwayDangerLayer.tsx
@@ -23,6 +23,9 @@ const HIGHWAY_DANGER_COLORS = ["#fdba74", "#f97316", "#dc2626", "#7f1d1d"] as co
 // makes every route read as a distinct line on any background / theme.
 const CASING_COLOR = "#ffffff";
 
+// Dedicated Leaflet pane so highways draw above the county choropleth.
+const HIGHWAY_PANE = "highwayDangerPane";
+
 interface HighwayDangerLayerProps {
   onSelectHighway: (row: HighwayRow) => void;
 }
@@ -86,6 +89,17 @@ export default memo(function HighwayDangerLayer({ onSelectHighway }: HighwayDang
     }
     if (!enabled || !geo) return;
 
+    // Render highways in a dedicated pane ABOVE the county choropleth. Leaflet's
+    // default overlayPane (z-index 400) holds the choropleth, which is a
+    // semi-transparent fill — when highways shared that pane the blue washed
+    // over them and muddied the danger colors. A pane at 450 keeps highways on
+    // top of the choropleth but still below markers (600) / popups (700).
+    if (!map.getPane(HIGHWAY_PANE)) {
+      map.createPane(HIGHWAY_PANE);
+      const pane = map.getPane(HIGHWAY_PANE);
+      if (pane) pane.style.zIndex = "450";
+    }
+
     const features = buildDangerFeatures(geo, rows ?? [], highwayMetric, HIGHWAY_DANGER_COLORS, NO_DATA_COLOR);
     const fc: GeoJSON.FeatureCollection = {
       type: "FeatureCollection",
@@ -99,11 +113,13 @@ export default memo(function HighwayDangerLayer({ onSelectHighway }: HighwayDang
     try {
       // White casing underneath (non-interactive) so the colored lines pop.
       const casing = L.geoJSON(fc, {
+        pane: HIGHWAY_PANE,
         interactive: false,
         style: () => ({ color: CASING_COLOR, weight: 8, opacity: 0.9 }),
       });
       // Colored danger lines on top; these carry the click handler.
       const lines = L.geoJSON(fc, {
+        pane: HIGHWAY_PANE,
         style: (feature) => ({
           color: (feature?.properties?.color as string) ?? NO_DATA_COLOR,
           weight: 5,


### PR DESCRIPTION
Highways render in a dedicated Leaflet pane above the county choropleth (fixes muddy colors + click-to-select being eaten by the choropleth). Also fixes the eslint error that was failing CI (StoryCanvasPanel dialog onKeyDown → document listener). eslint clean, 528 tests green, tsc clean. Verified locally with real data.