### PR TITLE
perf(ask): lazy-load export libs (~400KB off initial load)

### DIFF
--- a/frontend/src/lib/story/exportCanvas.ts
+++ b/frontend/src/lib/story/exportCanvas.ts
@@ -1,5 +1,7 @@
-import { toPng } from "html-to-image";
-import { jsPDF } from "jspdf";
+// `html-to-image` and `jspdf` are heavy and only needed when the user actually
+// exports a story, so they are dynamically imported inside the functions below.
+// This keeps them out of the main bundle (code-split into their own chunk,
+// fetched on first export) instead of loading on every page visit.
 
 // The export target is rendered off-screen with `position: fixed; left: -9999px`
 // so it never flashes to the user. html-to-image clones that node and KEEPS the
@@ -25,11 +27,13 @@ function triggerDownload(dataUrl: string, filename: string) {
 }
 
 export async function exportPng(node: HTMLElement, filename = defaultFilename()): Promise<void> {
+  const { toPng } = await import("html-to-image");
   const dataUrl = await toPng(node, CAPTURE_OPTIONS);
   triggerDownload(dataUrl, `${filename}.png`);
 }
 
 export async function exportPdf(node: HTMLElement, filename = defaultFilename()): Promise<void> {
+  const [{ toPng }, { jsPDF }] = await Promise.all([import("html-to-image"), import("jspdf")]);
   const rect = node.getBoundingClientRect();
   const dataUrl = await toPng(node, CAPTURE_OPTIONS);
 


### PR DESCRIPTION
Dynamic-import html-to-image + jspdf inside the export fns so they code-split out of the AskAiPage chunk and only load on first Export. Verified: entry chunk no longer contains them; jspdf (386KB) is its own lazy chunk. Tests 4/4, eslint + tsc clean.