### PR TITLE
Add Census lived-density (population-weighted density) correlation source

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -190,6 +190,7 @@ from app.routers.etl import router as etl_router  # noqa: E402
 from app.routers.stats import router as stats_router  # noqa: E402
 from app.routers.weather import router as weather_router  # noqa: E402
 from app.routers.fars import router as fars_router  # noqa: E402
+from app.routers.tract_density import router as tract_density_router  # noqa: E402
 
 app.include_router(reference_router, prefix="/api")
 app.include_router(demographics_router, prefix="/api")
@@ -207,6 +208,7 @@ app.include_router(etl_router, prefix="/api")
 app.include_router(pipeline_health_router, prefix="/api")
 app.include_router(weather_router, prefix="/api")
 app.include_router(fars_router, prefix="/api")
+app.include_router(tract_density_router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -532,6 +532,33 @@ class FarsCountyYear(Base):
     )
 
 
+class TractDensityCountyYear(Base):
+    """Population-weighted ("lived") density per county per year.
+
+    Computed from ACS tract populations joined to Census Gazetteer tract
+    land areas: weighted_density = sum(pop^2 / area_sqmi) / sum(pop).
+    Distinct from the crude demographics.population_density.
+
+    Source: Census ACS 5-year (tract population) + Census Gazetteer (land area).
+    """
+
+    __tablename__ = "tract_density_county_year"
+
+    id = Column(Integer, primary_key=True)
+    county_code = Column(
+        SmallInteger, ForeignKey("counties.code"), nullable=False
+    )
+    year = Column(SmallInteger, nullable=False)
+    weighted_density = Column(Float)   # persons per square mile (lived density)
+    tract_count = Column(Integer)      # tracts contributing to the calc
+    created_at = Column(DateTime, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("county_code", "year"),
+        Index("ix_tract_density_county_year", "county_code", "year"),
+    )
+
+
 class SpeedLimit(Base):
     """Posted speed limits aggregated per county.
 

--- a/backend/app/routers/tract_density.py
+++ b/backend/app/routers/tract_density.py
@@ -1,0 +1,42 @@
+"""Census population-weighted ("lived") density per county."""
+
+from fastapi import APIRouter, Depends, Query, Request, Response
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import parse_county_codes, parse_year
+from app.models import TractDensityCountyYear
+from app.schemas.tract_density import TractDensityOut
+
+router = APIRouter(tags=["tract_density"])
+
+_limiter = Limiter(key_func=get_remote_address)
+
+_FIVE_MIN = "public, max-age=300"
+
+
+@router.get("/tract-density", response_model=list[TractDensityOut])
+@_limiter.limit("1000/minute;20000/hour")
+def list_tract_density(
+    request: Request,
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Population-weighted ("lived") density per county/year (CA)."""
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(TractDensityCountyYear)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(TractDensityCountyYear.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(TractDensityCountyYear.year.in_(years))
+    rows = q.order_by(TractDensityCountyYear.county_code, TractDensityCountyYear.year).all()
+    return [TractDensityOut.model_validate(r) for r in rows]

--- a/backend/app/schemas/tract_density.py
+++ b/backend/app/schemas/tract_density.py
@@ -1,0 +1,12 @@
+"""Response model for /api/tract-density."""
+
+from pydantic import BaseModel
+
+
+class TractDensityOut(BaseModel):
+    county_code: int
+    year: int
+    weighted_density: float | None = None
+    tract_count: int | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/etl/census_tract_density.py
+++ b/backend/etl/census_tract_density.py
@@ -107,3 +107,133 @@ def aggregate_county_density(
             "weighted_density": wd, "tract_count": tc,
         })
     return out
+
+
+def fetch_gazetteer_land(gaz_year: int) -> dict[str, float]:
+    """Download a Gazetteer tract zip and return {GEOID: ALAND_SQMI} for CA."""
+    url = GAZETTEER_URL.format(gaz_year=gaz_year)
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = httpx.get(url, timeout=120, follow_redirects=True)
+            resp.raise_for_status()
+            break
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            last_error = exc
+            if attempt < MAX_RETRIES - 1:
+                import time
+                time.sleep(BACKOFF_BASE ** (attempt + 1))
+    else:
+        logger.error("All retries failed for Gazetteer %d", gaz_year)
+        raise last_error
+
+    land: dict[str, float] = {}
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        name = next((n for n in zf.namelist() if n.lower().endswith(".txt")), None)
+        if name is None:
+            logger.warning("No .txt in Gazetteer %d zip", gaz_year)
+            return land
+        with zf.open(name) as fh:
+            # Gazetteer files are tab-delimited; headers have trailing spaces.
+            text = io.TextIOWrapper(fh, encoding="latin-1", newline="")
+            reader = csv.DictReader(text, delimiter="\t")
+            reader.fieldnames = [f.strip() for f in (reader.fieldnames or [])]
+            for row in reader:
+                geoid = (row.get("GEOID") or "").strip()
+                if not geoid.startswith(CA_STATE_FIPS):
+                    continue
+                try:
+                    land[geoid] = float((row.get("ALAND_SQMI") or "").strip())
+                except ValueError:
+                    continue
+    return land
+
+
+def fetch_tract_population(year: int, api_key: str) -> list[dict]:
+    """Fetch ACS5 tract population for CA. Returns [{geoid, pop}]."""
+    url = ACS_URL.format(year=year, key=api_key)
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = httpx.get(url, timeout=60)
+            resp.raise_for_status()
+            data = resp.json()
+            break
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            last_error = exc
+            if attempt < MAX_RETRIES - 1:
+                import time
+                time.sleep(BACKOFF_BASE ** (attempt + 1))
+    else:
+        logger.error("All retries failed for ACS tract pop %d", year)
+        raise last_error
+
+    header = data[0]
+    idx = {name: i for i, name in enumerate(header)}
+    rows: list[dict] = []
+    for row in data[1:]:
+        geoid = f"{row[idx['state']]}{row[idx['county']]}{row[idx['tract']]}"
+        raw = row[idx["B01003_001E"]]
+        try:
+            pop = int(raw) if raw not in (None, "") else None
+        except ValueError:
+            pop = None
+        rows.append({"geoid": geoid, "pop": pop})
+    return rows
+
+
+@track_etl_run("tract_density")
+def run(start_year: int = DEFAULT_START_YEAR, end_year: int = DEFAULT_END_YEAR):
+    """Fetch + join + upsert lived-density rows for CA counties."""
+    api_key = settings.census_api_key
+    if not api_key:
+        logger.error("CENSUS_API_KEY is not set. Add it to backend/.env")
+        return
+
+    db = SessionLocal()
+    gaz_cache: dict[int, dict[str, float]] = {}
+    try:
+        counties = db.query(County.code, County.fips).all()
+        lookup = build_county_lookup([(c.code, c.fips) for c in counties])
+        logger.info("Loaded %d counties", len(lookup))
+
+        total = 0
+        for year in range(start_year, end_year + 1):
+            try:
+                gaz_year = gazetteer_year_for(year)
+                if gaz_year not in gaz_cache:
+                    gaz_cache[gaz_year] = fetch_gazetteer_land(gaz_year)
+                land = gaz_cache[gaz_year]
+
+                tract_rows = fetch_tract_population(year, api_key)
+                rows = aggregate_county_density(tract_rows, land, lookup, year)
+                if not rows:
+                    logger.info("Year %d: no rows", year)
+                    continue
+                stmt = pg_insert(TractDensityCountyYear).values(rows)
+                stmt = stmt.on_conflict_do_update(
+                    constraint="tract_density_county_year_county_code_year_key",
+                    set_={
+                        "weighted_density": stmt.excluded.weighted_density,
+                        "tract_count": stmt.excluded.tract_count,
+                    },
+                )
+                db.execute(stmt)
+                db.commit()
+                total += len(rows)
+                logger.info("Year %d: %d county rows upserted", year, len(rows))
+            except Exception as exc:
+                logger.warning("Tract-density year %d failed: %s", year, exc)
+                db.rollback()
+
+        logger.info("Done. %d total lived-density rows upserted.", total)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Load Census lived-density into Postgres")
+    parser.add_argument("--start", type=int, default=DEFAULT_START_YEAR)
+    parser.add_argument("--end", type=int, default=DEFAULT_END_YEAR)
+    args = parser.parse_args()
+    run(start_year=args.start, end_year=args.end)

--- a/backend/etl/census_tract_density.py
+++ b/backend/etl/census_tract_density.py
@@ -17,6 +17,7 @@ import argparse
 import csv
 import io
 import logging
+import time
 import zipfile
 from collections import defaultdict
 
@@ -121,7 +122,6 @@ def fetch_gazetteer_land(gaz_year: int) -> dict[str, float]:
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:
             last_error = exc
             if attempt < MAX_RETRIES - 1:
-                import time
                 time.sleep(BACKOFF_BASE ** (attempt + 1))
     else:
         logger.error("All retries failed for Gazetteer %d", gaz_year)
@@ -155,19 +155,21 @@ def fetch_tract_population(year: int, api_key: str) -> list[dict]:
     last_error = None
     for attempt in range(MAX_RETRIES):
         try:
-            resp = httpx.get(url, timeout=60)
+            resp = httpx.get(url, timeout=60, follow_redirects=True)
             resp.raise_for_status()
             data = resp.json()
             break
         except (httpx.HTTPStatusError, httpx.RequestError) as exc:
             last_error = exc
             if attempt < MAX_RETRIES - 1:
-                import time
                 time.sleep(BACKOFF_BASE ** (attempt + 1))
     else:
         logger.error("All retries failed for ACS tract pop %d", year)
         raise last_error
 
+    if not isinstance(data, list) or not data:
+        logger.warning("ACS tract pop %d returned no rows (check CENSUS_API_KEY)", year)
+        return []
     header = data[0]
     idx = {name: i for i, name in enumerate(header)}
     rows: list[dict] = []

--- a/backend/etl/census_tract_density.py
+++ b/backend/etl/census_tract_density.py
@@ -1,0 +1,109 @@
+"""Census lived-density ETL — population-weighted density per CA county/year.
+
+Joins ACS 5-year tract populations to Census Gazetteer tract land areas and
+computes weighted_density = sum(pop^2/area) / sum(pop) per county. Distinct
+from the crude demographics.population_density.
+
+Sources:
+  - ACS5 B01003_001E (tract population), Census API (settings.census_api_key)
+  - Census Gazetteer national tract file (ALAND_SQMI)
+
+Usage:
+    python -m etl.census_tract_density
+    python -m etl.census_tract_density --start 2018 --end 2022
+"""
+
+import argparse
+import csv
+import io
+import logging
+import zipfile
+from collections import defaultdict
+
+import httpx
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.database import EtlSessionLocal as SessionLocal
+from app.models import County, TractDensityCountyYear
+from app.settings import settings
+from etl._utils import track_etl_run
+from etl.nhtsa_fars import build_county_lookup
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_START_YEAR = 2010
+DEFAULT_END_YEAR = 2023
+CA_STATE_FIPS = "06"
+
+GAZETTEER_URL = (
+    "https://www2.census.gov/geo/docs/maps-data/data/gazetteer/"
+    "{gaz_year}_Gazetteer/{gaz_year}_Gaz_tracts_national.zip"
+)
+ACS_URL = (
+    "https://api.census.gov/data/{year}/acs/acs5"
+    "?get=B01003_001E&for=tract:*&in=state:06&in=county:*&key={key}"
+)
+MAX_RETRIES = 3
+BACKOFF_BASE = 2
+
+
+def gazetteer_year_for(acs_year: int) -> int:
+    """Pair an ACS year with a same-tract-vintage Gazetteer year."""
+    return 2019 if acs_year <= 2019 else 2023
+
+
+def compute_weighted_density(tracts: list[dict]) -> tuple[float, int] | None:
+    """Population-weighted density = sum(pop^2/area) / sum(pop).
+
+    Excludes tracts with missing/non-positive pop or area. Returns
+    (weighted_density, tract_count) or None when nothing contributes.
+    """
+    sum_pop = 0.0
+    sum_term = 0.0
+    count = 0
+    for t in tracts:
+        pop = t.get("pop")
+        area = t.get("area_sqmi")
+        if pop is None or area is None or pop <= 0 or area <= 0:
+            continue
+        sum_pop += pop
+        sum_term += (pop * pop) / area
+        count += 1
+    if count == 0 or sum_pop <= 0:
+        return None
+    return (sum_term / sum_pop, count)
+
+
+def aggregate_county_density(
+    tract_rows: list[dict],
+    gaz_land_by_geoid: dict[str, float],
+    county_lookup: dict[int, int],
+    year: int,
+) -> list[dict]:
+    """Join tract pop to gazetteer land by GEOID, group by county, compute."""
+    by_county: dict[int, list[dict]] = defaultdict(list)
+    for r in tract_rows:
+        geoid = r.get("geoid", "")
+        try:
+            county_fips = int(geoid[2:5])
+        except (ValueError, IndexError):
+            continue
+        code = county_lookup.get(county_fips)
+        if code is None:
+            continue
+        area = gaz_land_by_geoid.get(geoid)
+        if area is None:
+            continue
+        by_county[code].append({"pop": r.get("pop"), "area_sqmi": area})
+
+    out: list[dict] = []
+    for code, tracts in sorted(by_county.items()):
+        res = compute_weighted_density(tracts)
+        if res is None:
+            continue
+        wd, tc = res
+        out.append({
+            "county_code": code, "year": year,
+            "weighted_density": wd, "tract_count": tc,
+        })
+    return out

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -75,6 +75,15 @@ def build_default_registry() -> JobRegistry:
         freshness_table="fars_county_year",
     ))
     registry.register(Job(
+        name="tract_density",
+        module="etl.census_tract_density",
+        schedule="monthly",
+        table_name="tract_density_county_year",
+        max_drop_pct=10,
+        source_type="federal",
+        freshness_table="tract_density_county_year",
+    ))
+    registry.register(Job(
         name="hospitals",
         module="etl.load_hospitals",
         schedule="monthly",

--- a/backend/migrations/versions/u9v0w1x2y3z4_add_tract_density.py
+++ b/backend/migrations/versions/u9v0w1x2y3z4_add_tract_density.py
@@ -1,0 +1,39 @@
+"""add tract_density_county_year table
+
+Population-weighted density per county/year. New empty table — plain
+CREATE TABLE.
+
+Revision ID: u9v0w1x2y3z4
+Revises: t8u9v0w1x2y3
+Create Date: 2026-06-29 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "u9v0w1x2y3z4"
+down_revision: Union[str, None] = "t8u9v0w1x2y3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tract_density_county_year",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("county_code", sa.SmallInteger(), nullable=False),
+        sa.Column("year", sa.SmallInteger(), nullable=False),
+        sa.Column("weighted_density", sa.Float(), nullable=True),
+        sa.Column("tract_count", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True),
+        sa.ForeignKeyConstraint(["county_code"], ["counties.code"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("county_code", "year"),
+    )
+    op.create_index("ix_tract_density_county_year", "tract_density_county_year", ["county_code", "year"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tract_density_county_year", table_name="tract_density_county_year")
+    op.drop_table("tract_density_county_year")

--- a/backend/tests/api/test_tract_density.py
+++ b/backend/tests/api/test_tract_density.py
@@ -1,0 +1,40 @@
+"""Integration tests for /api/tract-density."""
+
+import pytest
+
+from app.models import TractDensityCountyYear
+
+pytestmark = pytest.mark.integration
+
+
+def _seed(db_session):
+    db_session.add_all([
+        TractDensityCountyYear(county_code=19, year=2022, weighted_density=8500.0, tract_count=2300),
+        TractDensityCountyYear(county_code=30, year=2022, weighted_density=4200.0, tract_count=580),
+        TractDensityCountyYear(county_code=19, year=2021, weighted_density=8400.0, tract_count=2295),
+    ])
+    db_session.flush()
+
+
+def test_tract_density_returns_rows(client, db_session):
+    _seed(db_session)
+    resp = client.get("/api/tract-density")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 3
+    row = next(r for r in body if r["county_code"] == 19 and r["year"] == 2022)
+    assert row["weighted_density"] == 8500.0
+    assert row["tract_count"] == 2300
+
+
+def test_tract_density_filters_by_year(client, db_session):
+    _seed(db_session)
+    body = client.get("/api/tract-density?year=2022").json()
+    assert {r["year"] for r in body} == {2022}
+    assert len(body) == 2
+
+
+def test_tract_density_filters_by_county(client, db_session):
+    _seed(db_session)
+    body = client.get("/api/tract-density?county=orange").json()
+    assert {r["county_code"] for r in body} == {30}

--- a/backend/tests/test_census_tract_density.py
+++ b/backend/tests/test_census_tract_density.py
@@ -68,3 +68,12 @@ def test_aggregate_joins_groups_and_skips():
     assert out[1]["year"] == 2022
     assert out[19]["weighted_density"] == 250.0
     assert out[19]["tract_count"] == 1
+
+
+def test_tract_density_job_registered():
+    from etl.jobs import build_default_registry
+
+    registry = build_default_registry()
+    job = registry.get("tract_density")
+    assert job.module == "etl.census_tract_density"
+    assert job.table_name == "tract_density_county_year"

--- a/backend/tests/test_census_tract_density.py
+++ b/backend/tests/test_census_tract_density.py
@@ -1,0 +1,70 @@
+"""Unit tests for lived-density helpers (no DB, no network)."""
+
+from etl.census_tract_density import (
+    compute_weighted_density,
+    gazetteer_year_for,
+    aggregate_county_density,
+)
+
+
+def test_weighted_density_two_tracts():
+    # tract A: pop 1000, area 1 -> density 1000
+    # tract B: pop 3000, area 1 -> density 3000
+    # weighted = (1000^2/1 + 3000^2/1) / (1000+3000) = 10_000_000/4000 = 2500
+    out = compute_weighted_density([
+        {"pop": 1000, "area_sqmi": 1.0},
+        {"pop": 3000, "area_sqmi": 1.0},
+    ])
+    assert out == (2500.0, 2)
+
+
+def test_weighted_density_single_tract_equals_its_density():
+    out = compute_weighted_density([{"pop": 500, "area_sqmi": 2.0}])
+    assert out == (250.0, 1)
+
+
+def test_weighted_density_excludes_invalid_tracts():
+    out = compute_weighted_density([
+        {"pop": 1000, "area_sqmi": 1.0},  # valid
+        {"pop": 0, "area_sqmi": 1.0},      # pop 0 -> excluded
+        {"pop": 500, "area_sqmi": 0.0},    # area 0 -> excluded
+        {"pop": None, "area_sqmi": 1.0},   # pop None -> excluded
+    ])
+    assert out == (1000.0, 1)
+
+
+def test_weighted_density_none_when_no_contributing_tracts():
+    assert compute_weighted_density([]) is None
+    assert compute_weighted_density([{"pop": 0, "area_sqmi": 0.0}]) is None
+
+
+def test_gazetteer_year_for_boundary():
+    assert gazetteer_year_for(2015) == 2019
+    assert gazetteer_year_for(2019) == 2019
+    assert gazetteer_year_for(2020) == 2023
+    assert gazetteer_year_for(2022) == 2023
+
+
+def test_aggregate_joins_groups_and_skips():
+    # county 001 -> code 1, county 037 -> code 19
+    lookup = {1: 1, 37: 19}
+    gaz = {
+        "06001400100": 1.0,
+        "06001400200": 1.0,
+        "06037900100": 2.0,
+        # 06037900200 intentionally missing land area -> skipped
+    }
+    rows = [
+        {"geoid": "06001400100", "pop": 1000},
+        {"geoid": "06001400200", "pop": 3000},
+        {"geoid": "06037900100", "pop": 500},
+        {"geoid": "06037900200", "pop": 9999},  # no land area -> skipped
+        {"geoid": "06099000100", "pop": 100},   # county 099 not in lookup -> skipped
+    ]
+    out = {r["county_code"]: r for r in aggregate_county_density(rows, gaz, lookup, 2022)}
+    assert set(out) == {1, 19}
+    assert out[1]["weighted_density"] == 2500.0
+    assert out[1]["tract_count"] == 2
+    assert out[1]["year"] == 2022
+    assert out[19]["weighted_density"] == 250.0
+    assert out[19]["tract_count"] == 1

--- a/backend/tests/test_census_tract_density.py
+++ b/backend/tests/test_census_tract_density.py
@@ -33,6 +33,14 @@ def test_weighted_density_excludes_invalid_tracts():
     assert out == (1000.0, 1)
 
 
+def test_weighted_density_excludes_negative_pop():
+    out = compute_weighted_density([
+        {"pop": 1000, "area_sqmi": 1.0},   # valid
+        {"pop": -50, "area_sqmi": 1.0},    # negative -> excluded
+    ])
+    assert out == (1000.0, 1)
+
+
 def test_weighted_density_none_when_no_contributing_tracts():
     assert compute_weighted_density([]) is None
     assert compute_weighted_density([{"pop": 0, "area_sqmi": 0.0}]) is None

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -74,7 +74,7 @@ def test_resolve_detects_missing_dependency():
 
 def test_default_registry_has_all_jobs():
     registry = build_default_registry()
-    assert len(registry.jobs) == 24  # +1: fars (NHTSA FARS correlation source)
+    assert len(registry.jobs) == 25  # +1: tract_density (Census lived-density source)
 
 
 def test_default_registry_resolves_without_error():

--- a/docs/superpowers/plans/2026-06-29-lived-density.md
+++ b/docs/superpowers/plans/2026-06-29-lived-density.md
@@ -1,0 +1,860 @@
+# Census Lived-Density Correlation Source — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add population-weighted density ("lived density") as a county-level field (`weighted_density`) in the Stats-page correlation matrix, computed from ACS tract populations joined to Census Gazetteer tract land areas.
+
+**Architecture:** New `tract_density_county_year` table + Alembic migration; `etl/census_tract_density.py` (pure metric/aggregation helpers + httpx/zip + ACS I/O + `run()`) registered in `jobs.py`; `/api/tract-density` read endpoint mirroring `fars.py`; correlation wiring in `useCorrelationData.ts`. Full pipeline + tests; no live data load.
+
+**Tech Stack:** Python 3 / FastAPI / SQLAlchemy / Alembic / pytest (backend); React / TypeScript / vitest / TanStack Query (frontend).
+
+## Global Constraints
+
+- CA only: ACS `in=state:06`; Gazetteer rows filtered to GEOID prefix `06`.
+- Year range default 2010–2023, CLI-overridable (`--start`/`--end`).
+- Metric: `weighted_density = Σ(pop² / area_sqmi) / Σ(pop)` over a county's tracts; exclude tracts with `pop is None`, `pop <= 0`, or `area_sqmi <= 0`; `tract_count` = contributing tracts; `None` if no contributing tracts.
+- Tract-vintage pairing: `gazetteer_year_for(acs_year) = 2019 if acs_year <= 2019 else 2023`.
+- Reuse `build_county_lookup` from `etl.nhtsa_fars` (3-digit FIPS → county_code). Do not reimplement.
+- Census key: `settings.census_api_key` (same as `etl/load_demographics.py`); if unset, `run()` logs and returns.
+- Write DB access via `EtlSessionLocal`; read endpoints via `get_db`.
+- Backend integration tests are marked `pytest.mark.integration` (need Postgres on localhost:5433, provided in CI); pure-function tests need no DB.
+- Spec: `docs/superpowers/specs/2026-06-29-lived-density-design.md`.
+
+---
+
+### Task 1: `TractDensityCountyYear` model + Alembic migration
+
+**Files:**
+- Modify: `backend/app/models.py` (add model after the `FarsCountyYear` class)
+- Create: `backend/migrations/versions/u9v0w1x2y3z4_add_tract_density.py`
+
+**Interfaces:**
+- Produces: `TractDensityCountyYear` ORM model; table `tract_density_county_year`; unique constraint `tract_density_county_year_county_code_year_key` on `(county_code, year)`.
+
+- [ ] **Step 1: Add the model**
+
+In `backend/app/models.py`, immediately after the `FarsCountyYear` class:
+
+```python
+class TractDensityCountyYear(Base):
+    """Population-weighted ("lived") density per county per year.
+
+    Computed from ACS tract populations joined to Census Gazetteer tract
+    land areas: weighted_density = sum(pop^2 / area_sqmi) / sum(pop).
+    Distinct from the crude demographics.population_density.
+
+    Source: Census ACS 5-year (tract population) + Census Gazetteer (land area).
+    """
+
+    __tablename__ = "tract_density_county_year"
+
+    id = Column(Integer, primary_key=True)
+    county_code = Column(
+        SmallInteger, ForeignKey("counties.code"), nullable=False
+    )
+    year = Column(SmallInteger, nullable=False)
+    weighted_density = Column(Float)   # persons per square mile (lived density)
+    tract_count = Column(Integer)      # tracts contributing to the calc
+    created_at = Column(DateTime, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("county_code", "year"),
+        Index("ix_tract_density_county_year", "county_code", "year"),
+    )
+```
+
+- [ ] **Step 2: Verify the model imports cleanly**
+
+Run: `cd backend && python -c "from app.models import TractDensityCountyYear; print(TractDensityCountyYear.__tablename__)"`
+Expected: prints `tract_density_county_year`
+
+- [ ] **Step 3: Write the migration**
+
+Create `backend/migrations/versions/u9v0w1x2y3z4_add_tract_density.py`:
+
+```python
+"""add tract_density_county_year table
+
+Population-weighted density per county/year. New empty table — plain
+CREATE TABLE.
+
+Revision ID: u9v0w1x2y3z4
+Revises: t8u9v0w1x2y3
+Create Date: 2026-06-29 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "u9v0w1x2y3z4"
+down_revision: Union[str, None] = "t8u9v0w1x2y3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tract_density_county_year",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("county_code", sa.SmallInteger(), nullable=False),
+        sa.Column("year", sa.SmallInteger(), nullable=False),
+        sa.Column("weighted_density", sa.Float(), nullable=True),
+        sa.Column("tract_count", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True),
+        sa.ForeignKeyConstraint(["county_code"], ["counties.code"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("county_code", "year"),
+    )
+    op.create_index("ix_tract_density_county_year", "tract_density_county_year", ["county_code", "year"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tract_density_county_year", table_name="tract_density_county_year")
+    op.drop_table("tract_density_county_year")
+```
+
+- [ ] **Step 4: Verify single head**
+
+Run: `cd backend && alembic heads`
+Expected: one head, `u9v0w1x2y3z4 (head)`. (If `alembic` needs a DB and none is available locally, this is verified in CI; at minimum confirm `down_revision` is `t8u9v0w1x2y3`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/models.py backend/migrations/versions/u9v0w1x2y3z4_add_tract_density.py
+git commit -m "feat(density): tract_density_county_year model + migration"
+```
+
+---
+
+### Task 2: Lived-density helpers + unit tests (TDD core)
+
+**Files:**
+- Create: `backend/etl/census_tract_density.py` (pure helpers only in this task)
+- Create: `backend/tests/test_census_tract_density.py`
+
+**Interfaces:**
+- Produces:
+  - `compute_weighted_density(tracts: list[dict]) -> tuple[float, int] | None` — `tracts` are `{"pop": int|None, "area_sqmi": float|None}`; returns `(weighted_density, tract_count)` or `None`.
+  - `gazetteer_year_for(acs_year: int) -> int`.
+  - `aggregate_county_density(tract_rows, gaz_land_by_geoid, county_lookup, year) -> list[dict]` — `tract_rows` are `{"geoid": str, "pop": int|None}`; returns per-county `{county_code, year, weighted_density, tract_count}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/tests/test_census_tract_density.py`:
+
+```python
+"""Unit tests for lived-density helpers (no DB, no network)."""
+
+from etl.census_tract_density import (
+    compute_weighted_density,
+    gazetteer_year_for,
+    aggregate_county_density,
+)
+
+
+def test_weighted_density_two_tracts():
+    # tract A: pop 1000, area 1 -> density 1000
+    # tract B: pop 3000, area 1 -> density 3000
+    # weighted = (1000^2/1 + 3000^2/1) / (1000+3000) = 10_000_000/4000 = 2500
+    out = compute_weighted_density([
+        {"pop": 1000, "area_sqmi": 1.0},
+        {"pop": 3000, "area_sqmi": 1.0},
+    ])
+    assert out == (2500.0, 2)
+
+
+def test_weighted_density_single_tract_equals_its_density():
+    out = compute_weighted_density([{"pop": 500, "area_sqmi": 2.0}])
+    assert out == (250.0, 1)
+
+
+def test_weighted_density_excludes_invalid_tracts():
+    out = compute_weighted_density([
+        {"pop": 1000, "area_sqmi": 1.0},  # valid
+        {"pop": 0, "area_sqmi": 1.0},      # pop 0 -> excluded
+        {"pop": 500, "area_sqmi": 0.0},    # area 0 -> excluded
+        {"pop": None, "area_sqmi": 1.0},   # pop None -> excluded
+    ])
+    assert out == (1000.0, 1)
+
+
+def test_weighted_density_none_when_no_contributing_tracts():
+    assert compute_weighted_density([]) is None
+    assert compute_weighted_density([{"pop": 0, "area_sqmi": 0.0}]) is None
+
+
+def test_gazetteer_year_for_boundary():
+    assert gazetteer_year_for(2015) == 2019
+    assert gazetteer_year_for(2019) == 2019
+    assert gazetteer_year_for(2020) == 2023
+    assert gazetteer_year_for(2022) == 2023
+
+
+def test_aggregate_joins_groups_and_skips():
+    # county 001 -> code 1, county 037 -> code 19
+    lookup = {1: 1, 37: 19}
+    gaz = {
+        "06001400100": 1.0,
+        "06001400200": 1.0,
+        "06037900100": 2.0,
+        # 06037900200 intentionally missing land area -> skipped
+    }
+    rows = [
+        {"geoid": "06001400100", "pop": 1000},
+        {"geoid": "06001400200", "pop": 3000},
+        {"geoid": "06037900100", "pop": 500},
+        {"geoid": "06037900200", "pop": 9999},  # no land area -> skipped
+        {"geoid": "06099000100", "pop": 100},   # county 099 not in lookup -> skipped
+    ]
+    out = {r["county_code"]: r for r in aggregate_county_density(rows, gaz, lookup, 2022)}
+    assert set(out) == {1, 19}
+    assert out[1]["weighted_density"] == 2500.0
+    assert out[1]["tract_count"] == 2
+    assert out[1]["year"] == 2022
+    assert out[19]["weighted_density"] == 250.0
+    assert out[19]["tract_count"] == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_census_tract_density.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'etl.census_tract_density'`
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `backend/etl/census_tract_density.py`:
+
+```python
+"""Census lived-density ETL — population-weighted density per CA county/year.
+
+Joins ACS 5-year tract populations to Census Gazetteer tract land areas and
+computes weighted_density = sum(pop^2/area) / sum(pop) per county. Distinct
+from the crude demographics.population_density.
+
+Sources:
+  - ACS5 B01003_001E (tract population), Census API (settings.census_api_key)
+  - Census Gazetteer national tract file (ALAND_SQMI)
+
+Usage:
+    python -m etl.census_tract_density
+    python -m etl.census_tract_density --start 2018 --end 2022
+"""
+
+import argparse
+import csv
+import io
+import logging
+import zipfile
+from collections import defaultdict
+
+import httpx
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.database import EtlSessionLocal as SessionLocal
+from app.models import County, TractDensityCountyYear
+from app.settings import settings
+from etl._utils import track_etl_run
+from etl.nhtsa_fars import build_county_lookup
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_START_YEAR = 2010
+DEFAULT_END_YEAR = 2023
+CA_STATE_FIPS = "06"
+
+GAZETTEER_URL = (
+    "https://www2.census.gov/geo/docs/maps-data/data/gazetteer/"
+    "{gaz_year}_Gazetteer/{gaz_year}_Gaz_tracts_national.zip"
+)
+ACS_URL = (
+    "https://api.census.gov/data/{year}/acs/acs5"
+    "?get=B01003_001E&for=tract:*&in=state:06&in=county:*&key={key}"
+)
+MAX_RETRIES = 3
+BACKOFF_BASE = 2
+
+
+def gazetteer_year_for(acs_year: int) -> int:
+    """Pair an ACS year with a same-tract-vintage Gazetteer year."""
+    return 2019 if acs_year <= 2019 else 2023
+
+
+def compute_weighted_density(tracts: list[dict]) -> tuple[float, int] | None:
+    """Population-weighted density = sum(pop^2/area) / sum(pop).
+
+    Excludes tracts with missing/non-positive pop or area. Returns
+    (weighted_density, tract_count) or None when nothing contributes.
+    """
+    sum_pop = 0.0
+    sum_term = 0.0
+    count = 0
+    for t in tracts:
+        pop = t.get("pop")
+        area = t.get("area_sqmi")
+        if pop is None or area is None or pop <= 0 or area <= 0:
+            continue
+        sum_pop += pop
+        sum_term += (pop * pop) / area
+        count += 1
+    if count == 0 or sum_pop <= 0:
+        return None
+    return (sum_term / sum_pop, count)
+
+
+def aggregate_county_density(
+    tract_rows: list[dict],
+    gaz_land_by_geoid: dict[str, float],
+    county_lookup: dict[int, int],
+    year: int,
+) -> list[dict]:
+    """Join tract pop to gazetteer land by GEOID, group by county, compute."""
+    by_county: dict[int, list[dict]] = defaultdict(list)
+    for r in tract_rows:
+        geoid = r.get("geoid", "")
+        try:
+            county_fips = int(geoid[2:5])
+        except (ValueError, IndexError):
+            continue
+        code = county_lookup.get(county_fips)
+        if code is None:
+            continue
+        area = gaz_land_by_geoid.get(geoid)
+        if area is None:
+            continue
+        by_county[code].append({"pop": r.get("pop"), "area_sqmi": area})
+
+    out: list[dict] = []
+    for code, tracts in sorted(by_county.items()):
+        res = compute_weighted_density(tracts)
+        if res is None:
+            continue
+        wd, tc = res
+        out.append({
+            "county_code": code, "year": year,
+            "weighted_density": wd, "tract_count": tc,
+        })
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/test_census_tract_density.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/etl/census_tract_density.py backend/tests/test_census_tract_density.py
+git commit -m "feat(density): lived-density helpers + unit tests"
+```
+
+---
+
+### Task 3: Gazetteer/ACS I/O + run() + job registration
+
+**Files:**
+- Modify: `backend/etl/census_tract_density.py` (add `fetch_gazetteer_land`, `fetch_tract_population`, `run`, `__main__`)
+- Modify: `backend/etl/jobs.py` (register `tract_density` job)
+- Modify: `backend/tests/test_census_tract_density.py` (registry test)
+- Modify: `backend/tests/test_orchestrator.py:77` (job-count guard 24 → 25)
+
+**Interfaces:**
+- Consumes: helpers from Task 2; `build_county_lookup` (etl.nhtsa_fars); `Job`/`build_default_registry` (etl.jobs).
+- Produces: `fetch_gazetteer_land(gaz_year) -> dict[str,float]`; `fetch_tract_population(year, api_key) -> list[dict]`; `run(start_year, end_year)`; job `tract_density`.
+
+- [ ] **Step 1: Write the failing registry test**
+
+Append to `backend/tests/test_census_tract_density.py`:
+
+```python
+def test_tract_density_job_registered():
+    from etl.jobs import build_default_registry
+
+    registry = build_default_registry()
+    job = registry.get("tract_density")
+    assert job.module == "etl.census_tract_density"
+    assert job.table_name == "tract_density_county_year"
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_census_tract_density.py::test_tract_density_job_registered -v`
+Expected: FAIL — `KeyError: 'tract_density'` (job not registered).
+
+- [ ] **Step 3: Add I/O + run() to `etl/census_tract_density.py`**
+
+Append to `backend/etl/census_tract_density.py` (before any `if __name__` block):
+
+```python
+def fetch_gazetteer_land(gaz_year: int) -> dict[str, float]:
+    """Download a Gazetteer tract zip and return {GEOID: ALAND_SQMI} for CA."""
+    url = GAZETTEER_URL.format(gaz_year=gaz_year)
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = httpx.get(url, timeout=120, follow_redirects=True)
+            resp.raise_for_status()
+            break
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            last_error = exc
+            if attempt < MAX_RETRIES - 1:
+                import time
+                time.sleep(BACKOFF_BASE ** (attempt + 1))
+    else:
+        logger.error("All retries failed for Gazetteer %d", gaz_year)
+        raise last_error
+
+    land: dict[str, float] = {}
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        name = next((n for n in zf.namelist() if n.lower().endswith(".txt")), None)
+        if name is None:
+            logger.warning("No .txt in Gazetteer %d zip", gaz_year)
+            return land
+        with zf.open(name) as fh:
+            # Gazetteer files are tab-delimited; headers have trailing spaces.
+            text = io.TextIOWrapper(fh, encoding="latin-1", newline="")
+            reader = csv.DictReader(text, delimiter="\t")
+            reader.fieldnames = [f.strip() for f in (reader.fieldnames or [])]
+            for row in reader:
+                geoid = (row.get("GEOID") or "").strip()
+                if not geoid.startswith(CA_STATE_FIPS):
+                    continue
+                try:
+                    land[geoid] = float((row.get("ALAND_SQMI") or "").strip())
+                except ValueError:
+                    continue
+    return land
+
+
+def fetch_tract_population(year: int, api_key: str) -> list[dict]:
+    """Fetch ACS5 tract population for CA. Returns [{geoid, pop}]."""
+    url = ACS_URL.format(year=year, key=api_key)
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = httpx.get(url, timeout=60)
+            resp.raise_for_status()
+            data = resp.json()
+            break
+        except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+            last_error = exc
+            if attempt < MAX_RETRIES - 1:
+                import time
+                time.sleep(BACKOFF_BASE ** (attempt + 1))
+    else:
+        logger.error("All retries failed for ACS tract pop %d", year)
+        raise last_error
+
+    header = data[0]
+    idx = {name: i for i, name in enumerate(header)}
+    rows: list[dict] = []
+    for row in data[1:]:
+        geoid = f"{row[idx['state']]}{row[idx['county']]}{row[idx['tract']]}"
+        raw = row[idx["B01003_001E"]]
+        try:
+            pop = int(raw) if raw not in (None, "") else None
+        except ValueError:
+            pop = None
+        rows.append({"geoid": geoid, "pop": pop})
+    return rows
+
+
+@track_etl_run("tract_density")
+def run(start_year: int = DEFAULT_START_YEAR, end_year: int = DEFAULT_END_YEAR):
+    """Fetch + join + upsert lived-density rows for CA counties."""
+    api_key = settings.census_api_key
+    if not api_key:
+        logger.error("CENSUS_API_KEY is not set. Add it to backend/.env")
+        return
+
+    db = SessionLocal()
+    gaz_cache: dict[int, dict[str, float]] = {}
+    try:
+        counties = db.query(County.code, County.fips).all()
+        lookup = build_county_lookup([(c.code, c.fips) for c in counties])
+        logger.info("Loaded %d counties", len(lookup))
+
+        total = 0
+        for year in range(start_year, end_year + 1):
+            try:
+                gaz_year = gazetteer_year_for(year)
+                if gaz_year not in gaz_cache:
+                    gaz_cache[gaz_year] = fetch_gazetteer_land(gaz_year)
+                land = gaz_cache[gaz_year]
+
+                tract_rows = fetch_tract_population(year, api_key)
+                rows = aggregate_county_density(tract_rows, land, lookup, year)
+                if not rows:
+                    logger.info("Year %d: no rows", year)
+                    continue
+                stmt = pg_insert(TractDensityCountyYear).values(rows)
+                stmt = stmt.on_conflict_do_update(
+                    constraint="tract_density_county_year_county_code_year_key",
+                    set_={
+                        "weighted_density": stmt.excluded.weighted_density,
+                        "tract_count": stmt.excluded.tract_count,
+                    },
+                )
+                db.execute(stmt)
+                db.commit()
+                total += len(rows)
+                logger.info("Year %d: %d county rows upserted", year, len(rows))
+            except Exception as exc:
+                logger.warning("Tract-density year %d failed: %s", year, exc)
+                db.rollback()
+
+        logger.info("Done. %d total lived-density rows upserted.", total)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Load Census lived-density into Postgres")
+    parser.add_argument("--start", type=int, default=DEFAULT_START_YEAR)
+    parser.add_argument("--end", type=int, default=DEFAULT_END_YEAR)
+    args = parser.parse_args()
+    run(start_year=args.start, end_year=args.end)
+```
+
+- [ ] **Step 4: Register the job in `etl/jobs.py`**
+
+After the `fars` job registration block, add:
+
+```python
+    registry.register(Job(
+        name="tract_density",
+        module="etl.census_tract_density",
+        schedule="monthly",
+        table_name="tract_density_county_year",
+        max_drop_pct=10,
+        source_type="federal",
+        freshness_table="tract_density_county_year",
+    ))
+```
+
+- [ ] **Step 5: Bump the orchestrator job-count guard**
+
+In `backend/tests/test_orchestrator.py` line 77, change:
+
+```python
+    assert len(registry.jobs) == 24  # +1: fars (NHTSA FARS correlation source)
+```
+
+to:
+
+```python
+    assert len(registry.jobs) == 25  # +1: tract_density (Census lived-density source)
+```
+
+- [ ] **Step 6: Run the registry + orchestrator tests**
+
+Run: `cd backend && python -m pytest tests/test_census_tract_density.py tests/test_orchestrator.py -v`
+Expected: PASS (7 in census_tract_density + orchestrator suite green)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/etl/census_tract_density.py backend/etl/jobs.py backend/tests/test_census_tract_density.py backend/tests/test_orchestrator.py
+git commit -m "feat(density): gazetteer/ACS I/O + run() + job registration"
+```
+
+---
+
+### Task 4: `/api/tract-density` endpoint + schema
+
+**Files:**
+- Create: `backend/app/schemas/tract_density.py`
+- Create: `backend/app/routers/tract_density.py`
+- Modify: `backend/app/main.py` (import + include, next to `fars`)
+- Create: `backend/tests/api/test_tract_density.py`
+
+**Interfaces:**
+- Consumes: `TractDensityCountyYear` (Task 1).
+- Produces: `GET /api/tract-density` → `list[TractDensityOut]`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `backend/tests/api/test_tract_density.py`:
+
+```python
+"""Integration tests for /api/tract-density."""
+
+import pytest
+
+from app.models import TractDensityCountyYear
+
+pytestmark = pytest.mark.integration
+
+
+def _seed(db_session):
+    db_session.add_all([
+        TractDensityCountyYear(county_code=19, year=2022, weighted_density=8500.0, tract_count=2300),
+        TractDensityCountyYear(county_code=30, year=2022, weighted_density=4200.0, tract_count=580),
+        TractDensityCountyYear(county_code=19, year=2021, weighted_density=8400.0, tract_count=2295),
+    ])
+    db_session.flush()
+
+
+def test_tract_density_returns_rows(client, db_session):
+    _seed(db_session)
+    resp = client.get("/api/tract-density")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 3
+    row = next(r for r in body if r["county_code"] == 19 and r["year"] == 2022)
+    assert row["weighted_density"] == 8500.0
+    assert row["tract_count"] == 2300
+
+
+def test_tract_density_filters_by_year(client, db_session):
+    _seed(db_session)
+    body = client.get("/api/tract-density?year=2022").json()
+    assert {r["year"] for r in body} == {2022}
+    assert len(body) == 2
+
+
+def test_tract_density_filters_by_county(client, db_session):
+    _seed(db_session)
+    body = client.get("/api/tract-density?county=orange").json()
+    assert {r["county_code"] for r in body} == {30}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd backend && python -m pytest tests/api/test_tract_density.py -v`
+Expected: FAIL — 404 (route not registered) / import error.
+
+- [ ] **Step 3: Write the schema**
+
+Create `backend/app/schemas/tract_density.py`:
+
+```python
+"""Response model for /api/tract-density."""
+
+from pydantic import BaseModel
+
+
+class TractDensityOut(BaseModel):
+    county_code: int
+    year: int
+    weighted_density: float | None = None
+    tract_count: int | None = None
+
+    model_config = {"from_attributes": True}
+```
+
+- [ ] **Step 4: Write the router**
+
+Create `backend/app/routers/tract_density.py`:
+
+```python
+"""Census population-weighted ("lived") density per county."""
+
+from fastapi import APIRouter, Depends, Query, Request, Response
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import parse_county_codes, parse_year
+from app.models import TractDensityCountyYear
+from app.schemas.tract_density import TractDensityOut
+
+router = APIRouter(tags=["tract_density"])
+
+_limiter = Limiter(key_func=get_remote_address)
+
+_FIVE_MIN = "public, max-age=300"
+
+
+@router.get("/tract-density", response_model=list[TractDensityOut])
+@_limiter.limit("1000/minute;20000/hour")
+def list_tract_density(
+    request: Request,
+    response: Response,
+    county: str | None = Query(None),
+    year: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Population-weighted ("lived") density per county/year (CA)."""
+    response.headers["Cache-Control"] = _FIVE_MIN
+    q = db.query(TractDensityCountyYear)
+    if county:
+        codes = parse_county_codes(county, get_slug_map(db))
+        if codes:
+            q = q.filter(TractDensityCountyYear.county_code.in_(codes))
+    if year:
+        years = parse_year(year)
+        if years:
+            q = q.filter(TractDensityCountyYear.year.in_(years))
+    rows = q.order_by(TractDensityCountyYear.county_code, TractDensityCountyYear.year).all()
+    return [TractDensityOut.model_validate(r) for r in rows]
+```
+
+- [ ] **Step 5: Register the router in `app/main.py`**
+
+With the other router imports (next to `from app.routers.fars import router as fars_router`):
+
+```python
+from app.routers.tract_density import router as tract_density_router  # noqa: E402
+```
+
+With the other `include_router` calls (after the fars include):
+
+```python
+app.include_router(tract_density_router, prefix="/api")
+```
+
+- [ ] **Step 6: Run the integration tests to verify they pass**
+
+Run: `cd backend && python -m pytest tests/api/test_tract_density.py -v`
+Expected: PASS (3 tests). (Requires Postgres on localhost:5433; runs in CI if not available locally.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/schemas/tract_density.py backend/app/routers/tract_density.py backend/app/main.py backend/tests/api/test_tract_density.py
+git commit -m "feat(density): /api/tract-density endpoint + schema + tests"
+```
+
+---
+
+### Task 5: Wire lived-density into the correlation matrix (frontend)
+
+**Files:**
+- Modify: `frontend/src/hooks/useCorrelationData.ts`
+- Create: `frontend/src/hooks/useCorrelationData.density.test.ts`
+
+**Interfaces:**
+- Consumes: `/api/tract-density` returning `{county_code, year, weighted_density, tract_count}[]`.
+- Produces: exported `applyTractDensityAggregation(rows, byCounty)`; `CORRELATION_FIELDS` entry `weighted_density`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/hooks/useCorrelationData.density.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { CORRELATION_FIELDS, applyTractDensityAggregation } from "./useCorrelationData";
+import type { CountyRow } from "./useCorrelationData";
+
+describe("lived-density correlation field", () => {
+  it("registers weighted_density with source census", () => {
+    const f = CORRELATION_FIELDS.find((x) => x.key === "weighted_density");
+    expect(f).toBeDefined();
+    expect(f?.source).toBe("census");
+  });
+
+  it("applies most-recent-year weighted_density per county, skips unknown counties", () => {
+    const byCounty: Record<string, CountyRow> = { "19": { crash_count: 5 } };
+    applyTractDensityAggregation(
+      [
+        { county_code: 19, year: 2021, weighted_density: 8400, tract_count: 1 },
+        { county_code: 19, year: 2022, weighted_density: 8500, tract_count: 1 },
+        { county_code: 30, year: 2022, weighted_density: 4200, tract_count: 1 }, // not in byCounty
+      ] as unknown as Record<string, unknown>[],
+      byCounty,
+    );
+    expect(byCounty["19"].weighted_density).toBe(8500); // latest year wins
+    expect(byCounty["30"]).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd frontend && npx vitest run src/hooks/useCorrelationData.density.test.ts`
+Expected: FAIL — `applyTractDensityAggregation` is not exported / `weighted_density` not found.
+
+- [ ] **Step 3: Add the field**
+
+In `frontend/src/hooks/useCorrelationData.ts`, append to the `CORRELATION_FIELDS` array (after the `pct_unrestrained` entry from the FARS work):
+
+```typescript
+  { key: "weighted_density", label: "Lived Density", source: "census" },
+```
+
+- [ ] **Step 4: Add the aggregation helper + call**
+
+In `useCorrelationData.ts`, add the exported helper (place it next to `applyFarsAggregation`):
+
+```typescript
+export function applyTractDensityAggregation(
+  density: Record<string, unknown>[],
+  byCounty: Record<string, CountyRow>,
+): void {
+  const latest: Record<string, Record<string, unknown>> = {};
+  for (const r of density) {
+    const code = String(r.county_code ?? "");
+    const existing = latest[code];
+    if (!existing || (r.year as number) > (existing.year as number)) {
+      latest[code] = r;
+    }
+  }
+  for (const [code, r] of Object.entries(latest)) {
+    if (!byCounty[code]) continue;
+    const wd = r.weighted_density as number | null;
+    if (wd != null) byCounty[code].weighted_density = wd;
+  }
+}
+```
+
+Add `/api/tract-density` to the supplemental `Promise.all` (after the `/api/fars` fetch) and include it in the destructuring:
+
+```typescript
+        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/tract-density`),
+```
+
+```typescript
+      const [demographics, calenviro, unemployment, vehicles, weather, fars, density] = await Promise.all([
+```
+
+After the `applyFarsAggregation(fars, byCounty)` call (added in the FARS work), add:
+
+```typescript
+      applyTractDensityAggregation(density, byCounty);
+```
+
+(If the FARS work left the FARS aggregation inline rather than as a call, place `applyTractDensityAggregation(density, byCounty)` immediately after the FARS block. The `CountyRow` type and `safeFetchJson` already exist in this file.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/hooks/useCorrelationData.density.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Typecheck + lint + full FE suite**
+
+Run: `cd frontend && npx tsc --noEmit && npx eslint . && npx vitest run`
+Expected: tsc exit 0; eslint 0 errors; all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/hooks/useCorrelationData.ts frontend/src/hooks/useCorrelationData.density.test.ts
+git commit -m "feat(density): wire lived-density into correlation matrix"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Metric (weighted density formula + exclusions) → Task 2 (`compute_weighted_density`). ✓
+- Tract-vintage pairing → Task 2 (`gazetteer_year_for`). ✓
+- County mapping reuse → Task 2/3 (`build_county_lookup` import). ✓
+- Two sources + join → Task 3 (`fetch_gazetteer_land`, `fetch_tract_population`, `aggregate_county_density`). ✓
+- Gazetteer caching per vintage → Task 3 (`gaz_cache`). ✓
+- Schema/table → Task 1. ✓
+- Job registration + count bump → Task 3. ✓
+- API endpoint + schema → Task 4. ✓
+- Frontend field + aggregation → Task 5. ✓
+- Census key guard → Task 3 (`run`). ✓
+- Tests (unit + router + frontend) → Tasks 2, 3, 4, 5. ✓
+- Out-of-scope respected (no live load, no new chart, CA-only, additive). ✓
+
+**Placeholder scan:** None. Task 5 Step 4 notes the FARS-block placement contingency — that's a concrete conditional instruction (handle inline vs. helper form of the prior FARS work), not an unfilled blank; the code to add is fully shown.
+
+**Type consistency:** `compute_weighted_density`/`aggregate_county_density`/`gazetteer_year_for` signatures match between Task 2 definition and Task 3 usage. `TractDensityCountyYear` columns identical across Tasks 1/3/4. `TractDensityOut` fields match the model and the frontend's consumed keys (`weighted_density`, `tract_count`, `county_code`, `year`). Upsert constraint `tract_density_county_year_county_code_year_key` is the Postgres default for `UniqueConstraint("county_code","year")` on table `tract_density_county_year`, used consistently. `applyTractDensityAggregation(density, byCounty)` signature matches between Task 5 definition and test.

--- a/docs/superpowers/specs/2026-06-29-lived-density-design.md
+++ b/docs/superpowers/specs/2026-06-29-lived-density-design.md
@@ -1,0 +1,119 @@
+# Census "Lived Density" (Population-Weighted Density) — Design Spec
+
+**Date:** 2026-06-29
+**Status:** Approved (design)
+**Sub-project:** 3 of 3 in the "new correlation data sources" effort. (1 = NHTSA FARS, shipped; 2 = DUI arrests, PARKED — no maintainable machine-readable source; 3 = this.) Independent, with its own spec/plan/implementation.
+
+## Goal
+
+Add **population-weighted density** ("lived density") as a new county-level field in the Stats-page correlation matrix. This is the density experienced by the average resident — `Σ(tract_pop² / tract_land_sqmi) / Σ(tract_pop)` over a county's census tracts. It is meaningfully distinct from the crude `population_density` (county population ÷ county land area) the demographics table already exposes: two counties with identical crude density but different internal concentration (a dense city beside empty land vs. uniform suburbia) get very different lived density — and lived density is far more relevant to crash exposure.
+
+New correlation field: **`weighted_density`** (label "Lived Density", source `census`).
+
+Scope of "done" (per decision): **full pipeline + tests, no live data load.** ETL module, model, migration, endpoint, and correlation wiring with tests using fixtures. The actual load runs later via the ETL. Nothing here writes to prod data.
+
+Year scope (per decision): **full 2010–latest**, handling both census-tract vintages (2010-vintage tracts for ACS5 ≤2019, 2020-vintage for ACS5 ≥2020) by pairing each ACS year with a same-vintage Gazetteer.
+
+## Data sources (two, joined per year by tract GEOID)
+
+1. **Tract population** — ACS 5-year `B01003_001E` at tract level, via the same Census API + key the demographics ETL already uses (`settings` Census key). Query: `https://api.census.gov/data/{year}/acs/acs5?get=B01003_001E&for=tract:*&in=state:06&in=county:*&key=...`. (Verified: the endpoint is valid; keyless requests 302 to `missing_key` — the project key is required and already configured.) The response columns include `state`, `county`, `tract`; the 11-digit GEOID = `06` + 3-digit county + 6-digit tract. If the `in=county:*` wildcard is rejected for tracts in a given year, fall back to looping the 58 counties.
+2. **Tract land area** — Census Gazetteer national tract file: `https://www2.census.gov/geo/docs/maps-data/data/gazetteer/{gaz_year}_Gazetteer/{gaz_year}_Gaz_tracts_national.zip` (verified 200, keyless). Inside is a tab-delimited `.txt` with columns including `GEOID`, `ALAND_SQMI`. Filter to CA (`GEOID` starts with `06`).
+
+### Tract-vintage / year pairing
+
+Census tract boundaries change each decade, and land area must match the tract vintage of that year's ACS data. Rule: **for ACS year Y, use the Gazetteer file whose tract vintage matches** — implemented as a small `gazetteer_year_for(acs_year)` map:
+- ACS 2010–2019 → a 2010-vintage Gazetteer (use `2019` tract gazetteer; for 2010–2011 where no tract gazetteer was published, the 2010-vintage file still applies — same tract boundaries).
+- ACS 2020–latest → a 2020-vintage Gazetteer (use the latest available, e.g. `2023`).
+
+The join is by exact tract GEOID; GEOIDs present in one source but not the other are skipped (logged). A mismatched vintage would simply produce few/no matches for a year — so the pairing map is the safeguard. The two distinct Gazetteer files are downloaded once and cached in-process (keyed by gaz_year) so multi-year runs don't re-fetch.
+
+### County mapping
+
+ACS returns the 3-digit county FIPS. Reuse the existing pure helper **`build_county_lookup`** from `etl.nhtsa_fars` (maps last-3-digits-of-`County.fips` → `county_code`) — already exported and unit-tested; no refactor needed.
+
+## The metric
+
+Per county per year, over that county's tracts with valid population and positive land area:
+
+```
+weighted_density = Σ(pop_t² / area_t) / Σ(pop_t)
+tract_count      = number of contributing tracts
+```
+
+- Equivalent to the population-weighted mean of tract densities (each resident weighted by their tract's density). Standard "lived density."
+- Tracts with `pop_t is None`, `pop_t == 0`, or `area_t <= 0` are excluded (can't contribute / divide-by-zero).
+- If a county has no contributing tracts in a year, it produces no row for that year.
+- `weighted_density` is an inherently derived metric (not re-aggregatable from a single stored scalar), so unlike the FARS raw counts it is **stored computed** (a float). `tract_count` is stored for transparency/QA.
+
+## Schema
+
+New table `tract_density_county_year` (same shape family as `fars_county_year`):
+
+| column            | type        | notes |
+|-------------------|-------------|-------|
+| `id`              | Integer PK  | |
+| `county_code`     | SmallInteger FK→counties.code, not null | |
+| `year`            | SmallInteger not null | |
+| `weighted_density`| Float       | population-weighted density (persons/sq mi) |
+| `tract_count`     | Integer     | tracts contributing to the calc |
+| `created_at`      | DateTime server_default now() | |
+
+- `UniqueConstraint("county_code", "year")` (upsert key) + `Index("ix_tract_density_county_year", "county_code", "year")`.
+- Alembic migration: plain `CREATE TABLE`, `down_revision` = current head at implementation time (chain off whatever FARS's `t8u9v0w1x2y3` led to / the live head), working downgrade.
+
+## ETL module — `etl/census_tract_density.py`
+
+Mirrors `noaa_weather.py`/`nhtsa_fars.py` structure:
+- Pure, unit-testable helpers (no network/db):
+  - `compute_weighted_density(tracts: list[dict]) -> tuple[float, int] | None` — input tract dicts `{pop, area_sqmi}`; returns `(weighted_density, tract_count)` or `None` if no contributing tracts. Implements the formula + guards above.
+  - `aggregate_county_density(tract_rows, gaz_land_by_geoid, county_lookup, year) -> list[dict]` — joins ACS tract rows to gazetteer land by GEOID, groups by county_code, calls `compute_weighted_density`, returns `{county_code, year, weighted_density, tract_count}` per county.
+  - `gazetteer_year_for(acs_year: int) -> int` — the vintage-pairing map above.
+- I/O layer (network, not unit-tested):
+  - `fetch_gazetteer_land(gaz_year) -> dict[str, float]` — httpx download + `zipfile` + parse the tab-delimited tract file → `{GEOID: ALAND_SQMI}` for CA (GEOID prefix `06`). Cached per `gaz_year`.
+  - `fetch_tract_population(year, api_key) -> list[dict]` — ACS5 call(s); returns rows with `state`/`county`/`tract`/`B01003_001E`. Builds GEOID = state+county+tract.
+  - `run(start_year, end_year)` — loads counties, builds lookup, per year: resolve gazetteer vintage → land lookup (cached) → fetch ACS tract pop → `aggregate_county_density` → `pg_insert(...).on_conflict_do_update` on `tract_density_county_year_county_code_year_key`, updating `weighted_density`/`tract_count`; per-year try/except + rollback; commit per year. `@track_etl_run("tract_density")`. Reads the Census key from `settings` like `census_api.py`.
+- `argparse` `--start`/`--end` (defaults 2010–2023); `python -m etl.census_tract_density`.
+
+Registered in `etl/jobs.py`: `Job(name="tract_density", module="etl.census_tract_density", schedule="monthly", table_name="tract_density_county_year", max_drop_pct=10, source_type="federal", freshness_table="tract_density_county_year")`.
+
+## API endpoint — `app/routers/tract_density.py`
+
+Copy of `weather.py`/`fars.py`:
+- `GET /api/tract-density` → `list[TractDensityOut]`, optional `county`/`year` filters, ordered by `(county_code, year)`, `Cache-Control: public, max-age=300`, same rate limit.
+- `app/schemas/tract_density.py`: `TractDensityOut` (county_code, year, weighted_density, tract_count), `model_config = {"from_attributes": True}`.
+- Registered in `app/main.py` next to the `fars`/`weather` includes.
+
+## Frontend wiring — `useCorrelationData.ts`
+
+- Add `/api/tract-density` to the supplemental `Promise.all` (graceful-skip via `safeFetchJson`) + include in the destructuring.
+- Aggregate most-recent-year per county → set `byCounty[code].weighted_density` (extract into a pure `applyTractDensityAggregation(rows, byCounty)` helper, mirroring the FARS `applyFarsAggregation` precedent so it's unit-testable).
+- Add to `CORRELATION_FIELDS`: `{ key: "weighted_density", label: "Lived Density", source: "census" }`.
+- No new component — the matrix renders the new row/column automatically.
+
+## Testing
+
+Backend (pytest, fixtures — no network):
+- `compute_weighted_density`: known multi-tract county yields the exact weighted value; single tract returns that tract's density; excludes pop=0 / area<=0 / pop=None tracts; returns `None` when no contributing tracts.
+- `aggregate_county_density`: joins ACS rows to gazetteer land by GEOID; groups by county; skips GEOIDs missing land area; skips unmapped counties; stamps year.
+- `gazetteer_year_for`: 2015→2010-vintage, 2022→2020-vintage at the boundary.
+- Router test (integration): seed `tract_density_county_year`, assert `GET /api/tract-density` shape + `county`/`year` filters (follow `tests/api/test_fars.py`).
+- Job-registry: `tract_density` registered (and bump the `test_orchestrator.py` job-count guard — it will go from 24 to 25).
+
+Frontend (vitest):
+- `weighted_density` registered in `CORRELATION_FIELDS` with `source: "census"`.
+- `applyTractDensityAggregation`: latest-year-wins per county; value set correctly; county absent from `byCounty` skipped.
+
+## Out of scope (YAGNI)
+
+- No live download/load (decision).
+- No new chart/visual — correlation matrix only.
+- No sub-county/tract-level UI — we surface a single county-level metric.
+- No replacement of the existing crude `population_density` — this is additive.
+- Non-CA excluded.
+
+## Risks / notes
+
+- **Tract-vintage boundary (2020).** Handled by `gazetteer_year_for`; a documented discontinuity exists at 2020 (tract boundaries redrawn). Because the matrix uses most-recent-year per county, the active value is from the 2020 vintage; older years are for completeness. Acceptable and noted.
+- **`in=county:*` wildcard for tracts.** If a given ACS year rejects the statewide tract wildcard, `fetch_tract_population` falls back to per-county loops. Either way machine-readable.
+- **Census key.** Same `settings` key the demographics ETL already requires; if unset, `run()` logs and returns (mirrors `noaa_weather.py`'s token guard).
+- **Gazetteer file availability.** 2023 verified; the vintage map only needs one 2010-era file and one 2020-era file, both long-published and stable.

--- a/frontend/src/hooks/useCorrelationData.density.test.ts
+++ b/frontend/src/hooks/useCorrelationData.density.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { CORRELATION_FIELDS, applyTractDensityAggregation } from "./useCorrelationData";
+import type { CountyRow } from "./useCorrelationData";
+
+describe("lived-density correlation field", () => {
+  it("registers weighted_density with source census", () => {
+    const f = CORRELATION_FIELDS.find((x) => x.key === "weighted_density");
+    expect(f).toBeDefined();
+    expect(f?.source).toBe("census");
+  });
+
+  it("applies most-recent-year weighted_density per county, skips unknown counties", () => {
+    const byCounty: Record<string, CountyRow> = { "19": { crash_count: 5 } };
+    applyTractDensityAggregation(
+      [
+        { county_code: 19, year: 2021, weighted_density: 8400, tract_count: 1 },
+        { county_code: 19, year: 2022, weighted_density: 8500, tract_count: 1 },
+        { county_code: 30, year: 2022, weighted_density: 4200, tract_count: 1 }, // not in byCounty
+      ] as unknown as Record<string, unknown>[],
+      byCounty,
+    );
+    expect(byCounty["19"].weighted_density).toBe(8500); // latest year wins
+    expect(byCounty["30"]).toBeUndefined();
+  });
+});

--- a/frontend/src/hooks/useCorrelationData.ts
+++ b/frontend/src/hooks/useCorrelationData.ts
@@ -47,6 +47,7 @@ export const CORRELATION_FIELDS: CorrelationField[] = [
   { key: "precip", label: "Rainfall", source: "weather" },
   { key: "fars_fatalities", label: "FARS Deaths", source: "fars" },
   { key: "pct_unrestrained", label: "Unrestrained %", source: "fars" },
+  { key: "weighted_density", label: "Lived Density", source: "census" },
 ];
 
 function pearsonR(xs: number[], ys: number[]): number {
@@ -95,6 +96,30 @@ export function applyFarsAggregation(
     if (unrestrained != null && known != null && known > 0) {
       byCounty[code].pct_unrestrained = (unrestrained / known) * 100;
     }
+  }
+}
+
+/**
+ * Pure helper: merge tract density rows into byCounty.
+ * Picks the most-recent year per county, then writes `weighted_density`.
+ * Mutates byCounty in place.
+ */
+export function applyTractDensityAggregation(
+  density: Record<string, unknown>[],
+  byCounty: Record<string, CountyRow>,
+): void {
+  const latest: Record<string, Record<string, unknown>> = {};
+  for (const r of density) {
+    const code = String(r.county_code ?? "");
+    const existing = latest[code];
+    if (!existing || (r.year as number) > (existing.year as number)) {
+      latest[code] = r;
+    }
+  }
+  for (const [code, r] of Object.entries(latest)) {
+    if (!byCounty[code]) continue;
+    const wd = r.weighted_density as number | null;
+    if (wd != null) byCounty[code].weighted_density = wd;
   }
 }
 
@@ -147,13 +172,14 @@ export function useCorrelationData(filters?: CorrelationFilters) {
       const stats = await statsRes.json();
 
       // Supplemental sources — fetch in parallel, gracefully skip failures
-      const [demographics, calenviro, unemployment, vehicles, weather, fars] = await Promise.all([
+      const [demographics, calenviro, unemployment, vehicles, weather, fars, density] = await Promise.all([
         safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/demographics`),
         safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/calenviroscreen`),
         safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/unemployment`),
         safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/vehicles`),
         safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/weather`),
         safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/fars`),
+        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/tract-density`),
       ]);
 
       const countyStats: Record<string, unknown>[] = stats.county ?? [];
@@ -267,6 +293,9 @@ export function useCorrelationData(filters?: CorrelationFilters) {
 
       // FARS — most recent year per county; derive pct_unrestrained
       applyFarsAggregation(fars, byCounty);
+
+      // Tract density — most recent year per county
+      applyTractDensityAggregation(density, byCounty);
 
       const countyNames: Record<string, string> = {};
       for (const r of countyStats) {


### PR DESCRIPTION
Adds **population-weighted density** ("lived density") as a new county-level field in the Stats-page correlation matrix. Sub-project 3 of 3 (FARS shipped; DUI parked — no maintainable machine-readable source).

Built via spec → plan → 5 TDD tasks (subagent-driven, per-task reviews) → opus whole-branch review (verdict: ready to merge) → 3 folded tidies. Spec: `docs/superpowers/specs/2026-06-29-lived-density-design.md`; plan: `docs/superpowers/plans/2026-06-29-lived-density.md`.

## What it adds
- **One correlation field:** `weighted_density` ("Lived Density") — the density experienced by the average resident, `Σ(tract_pop²/tract_land_sqmi) / Σ(tract_pop)` over a county's tracts. Distinct from (and more crash-relevant than) the crude `population_density` already in the matrix: it captures internal concentration, so a dense city beside empty land reads very differently from uniform suburbia.

## Changes
- **Schema:** new `tract_density_county_year` table (county_code, year, weighted_density, tract_count) + migration `u9v0w1x2y3z4`.
- **ETL:** `etl/census_tract_density.py` — pure helpers (`compute_weighted_density`, `gazetteer_year_for`, `aggregate_county_density`, reusing FARS's `build_county_lookup`) + two-source I/O (ACS5 `B01003` tract population + Census Gazetteer `ALAND_SQMI`, joined by tract GEOID) + `run()`; registered as a `monthly` `federal` job. Full 2010–2023 across both tract vintages (gazetteer paired per ACS year, cached per vintage).
- **API:** `GET /api/tract-density` + `TractDensityOut` schema — faithful copy of the `fars.py` router.
- **Frontend:** `/api/tract-density` wired into `useCorrelationData.ts` via an exported pure `applyTractDensityAggregation()` helper (most-recent-year per county), plus the new `CORRELATION_FIELDS` entry.

## Scope
Full pipeline + tests, **no live data load** — `/api/tract-density` returns empty and the matrix gracefully skips the field until the ETL runs. Nothing here writes to prod data.

## Tests
- Backend: 8 pure-helper unit tests (weighted-density math, vintage boundary, join/group/skip, exclusions incl. negative pop) + job-registration + orchestrator count bump (24→25) + 3 `/api/tract-density` integration tests (run in CI).
- Frontend: field registration + aggregation behavior (latest-year-wins, skip-unknown-county).
- Local: backend helpers + orchestrator 16/16, full frontend suite 540/540, tsc clean, eslint 0 errors. Backend integration tests run in CI (no local Postgres).