### PR TITLE
fix(fars): count modern REST_USE code 20 as unrestrained

### DIFF
--- a/backend/etl/nhtsa_fars.py
+++ b/backend/etl/nhtsa_fars.py
@@ -36,8 +36,13 @@ DEFAULT_START_YEAR = 2001
 DEFAULT_END_YEAR = 2025
 CA_STATE_FIPS = "6"
 
-# REST_USE classification (best-effort, FARS codes drift across years).
-UNRESTRAINED_CODES = {"0"}
+# REST_USE classification (FARS codes drift across years). "None used" is code
+# "0" in older FARS and "20" in modern FARS (2010s+; verified against 2022 data,
+# where "20" = "None Used/Not Applicable" and "0" does not appear). Unknown /
+# not-an-occupant codes are excluded from the denominator: 96 = "Not a Motor
+# Vehicle Occupant" (pedestrians/cyclists), 97/98 = not reported, 99 = unknown,
+# and the older single-digit 8/9 unknowns.
+UNRESTRAINED_CODES = {"0", "20"}
 UNKNOWN_RESTRAINT_CODES = {"8", "9", "96", "97", "98", "99", ""}
 
 FARS_ZIP_URL = (

--- a/backend/tests/test_nhtsa_fars.py
+++ b/backend/tests/test_nhtsa_fars.py
@@ -29,9 +29,24 @@ def test_aggregate_counts_fatalities_per_county():
 def test_aggregate_classifies_restraint():
     lookup = {37: 19}
     rows = [
-        _person(rest="0"),   # unrestrained + known
+        _person(rest="0"),   # unrestrained + known (older FARS "None Used")
         _person(rest="3"),   # restrained + known
         _person(rest="99"),  # unknown -> excluded from denominator
+    ]
+    out = aggregate_fars(rows, lookup, 2022)[0]
+    assert out["fatalities"] == 3
+    assert out["unrestrained_killed"] == 1
+    assert out["restraint_known_killed"] == 2
+
+
+def test_aggregate_counts_modern_none_used_code_20():
+    # Modern FARS (2010s+) codes "None Used" as 20, not 0. Code 96 = "Not a
+    # Motor Vehicle Occupant" (pedestrian) -> excluded from the denominator.
+    lookup = {37: 19}
+    rows = [
+        _person(rest="20"),  # unrestrained + known (modern "None Used")
+        _person(rest="3"),   # restrained + known
+        _person(rest="96"),  # non-occupant -> excluded from denominator
     ]
     out = aggregate_fars(rows, lookup, 2022)[0]
     assert out["fatalities"] == 3


### PR DESCRIPTION
Bug found while diagnosing an ETL question: the FARS `pct_unrestrained` metric would always compute **0%** because `UNRESTRAINED_CODES` only contained `"0"`.

Modern FARS (2010s+) codes "None Used" as **`20`**, not `0` (verified against the real 2022 national file — `"20"` = "None Used/Not Applicable"; `"0"` doesn't appear; `"96"` = "Not a Motor Vehicle Occupant"/pedestrians). This is the cross-year REST_USE drift the spec flagged but the original code didn't handle.

**Fix:** `UNRESTRAINED_CODES = {"0", "20"}` (covers both the older and modern "None Used" codes) + a clarifying comment.

**Verified against real 2022 FARS data** (was 0% before):
- LA County: 263/430 known-restraint fatalities unrestrained → **61.2%**
- Orange County: 70/126 → **55.6%**

(Realistic — roughly half of traffic fatalities are unrestrained.)

**Tests:** added `test_aggregate_counts_modern_none_used_code_20` (code 20 counts as unrestrained; code 96 excluded from denominator). Existing restraint test (code 0) still passes. 7/7 backend FARS tests green.

Note: this is a data-quality fix, not the cause of any pipeline crash — FARS loads without error either way. No live load in this PR.