### PR TITLE
fix: parties/victims OOM (incremental load) + ZAP PII false-positive writeup

### DIFF
--- a/backend/etl/load_parties_victims.py
+++ b/backend/etl/load_parties_victims.py
@@ -11,9 +11,16 @@ This is the data that powers insights like:
 
 Source: CCRS on data.ca.gov (Parties_YYYY and InjuredWitnessPassengers_YYYY)
 
+By default a run is INCREMENTAL — it only refreshes the current and previous
+year (where new/late records arrive); historical CCRS years are static and
+already loaded, and reloading all of them every daily run is what kept the
+process alive long enough to get OOM-killed (exit 137). Use --force for a
+full reload of the requested range (backfill / history repair).
+
 Usage:
-    python -m etl.load_parties_victims
-    python -m etl.load_parties_victims --start 2020 --end 2024
+    python -m etl.load_parties_victims                      # incremental (recent years)
+    python -m etl.load_parties_victims --force             # full reload, default range
+    python -m etl.load_parties_victims --start 2020 --end 2024 --force
     python -m etl.load_parties_victims --table parties
     python -m etl.load_parties_victims --table victims
 """
@@ -75,6 +82,24 @@ VICTIMS_RESOURCE_IDS = {
     2025: "10184ea3-7411-42d8-87a6-17039b58f04b",
     2026: "bbe0c38e-d0eb-4152-86e2-0b0895e66ba9",
 }
+
+
+def effective_start_year(start_year: int, force: bool, current_year: int) -> int:
+    """Year to start loading from.
+
+    Parties/victims is the largest CCRS load. A full multi-year reload every
+    daily run kept the process alive long enough for the OOM killer to take it
+    (exit 137) on the shared VM — and historical CCRS years are static once
+    published (already in the DB), so reloading them daily is wasted work.
+
+    Default (daily, ``force=False``): only refresh the current and previous
+    year — where new/late-arriving records land — bounding runtime and memory.
+    ``force=True`` reloads the full requested range (use for a backfill or to
+    repair history).
+    """
+    if force:
+        return start_year
+    return max(start_year, current_year - 1)
 
 
 def _safe_int(value):
@@ -277,6 +302,14 @@ def run(
     """Main entry point."""
     source_name = table if table in ("parties", "victims") else "parties_victims"
 
+    eff_start = effective_start_year(start_year, force, datetime.now().year)
+    logger.info(
+        "Loading %s for %d-%d (%s; requested start %d)",
+        source_name, eff_start, end_year,
+        "full reload" if force else "incremental: recent years only",
+        start_year,
+    )
+
     with etl_run(source_name):
         if table is None or table == "parties":
             load_table(
@@ -287,7 +320,7 @@ def run(
                 upsert_cols=_PARTY_UPSERT_COLS,
                 constraint_name="uq_parties_party_source",
                 id_field="party_id",
-                start_year=start_year,
+                start_year=eff_start,
                 end_year=end_year,
                 force=force,
             )
@@ -301,7 +334,7 @@ def run(
                 upsert_cols=_VICTIM_UPSERT_COLS,
                 constraint_name="uq_victims_victim_source",
                 id_field="victim_id",
-                start_year=start_year,
+                start_year=eff_start,
                 end_year=end_year,
                 force=force,
             )
@@ -315,6 +348,8 @@ if __name__ == "__main__":
     parser.add_argument("--end", type=int, default=DEFAULT_END_YEAR)
     parser.add_argument("--table", choices=["parties", "victims"], default=None,
                         help="Load only parties or victims (default: both)")
-    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--force", action="store_true",
+                        help="Full reload of the requested year range "
+                             "(default is incremental: current + previous year only)")
     args = parser.parse_args()
     run(start_year=args.start, end_year=args.end, table=args.table, force=args.force)

--- a/backend/tests/test_load_parties_victims.py
+++ b/backend/tests/test_load_parties_victims.py
@@ -3,11 +3,28 @@
 from etl.load_parties_victims import (
     transform_party,
     transform_victim,
+    effective_start_year,
     _safe_int,
     _safe_bool,
     PARTIES_RESOURCE_IDS,
     VICTIMS_RESOURCE_IDS,
 )
+
+
+class TestEffectiveStartYear:
+    """Incremental default vs --force full reload (OOM-prevention)."""
+
+    def test_incremental_narrows_to_recent_years(self):
+        # Daily run (not force): start from current_year - 1 even though the
+        # requested start is 2016 — historical years are static & already loaded.
+        assert effective_start_year(2016, force=False, current_year=2026) == 2025
+
+    def test_force_uses_full_requested_range(self):
+        assert effective_start_year(2016, force=True, current_year=2026) == 2016
+
+    def test_incremental_respects_a_later_requested_start(self):
+        # Never widen the range: an explicit recent start wins over the window.
+        assert effective_start_year(2026, force=False, current_year=2026) == 2026
 
 
 class TestSafeInt:

--- a/docs/security/zap-pii-false-positive.md
+++ b/docs/security/zap-pii-false-positive.md
@@ -1,0 +1,82 @@
+# ZAP DAST: "PII Disclosure" on `/api/schools` — False Positive
+
+**Status:** Confirmed false positive (2026-06-29). Safe to suppress.
+
+## The finding
+
+The weekly ZAP DAST scan reports a **HIGH "PII Disclosure"** (rule **10062**, CWE-359),
+6 instances, all on:
+
+```
+GET /api/schools?county=&school_type=&limit=1000&offset=0&include_total=false
+```
+
+Evidence values are 14-digit numbers (e.g. `36676456104525`, `50711346119002`).
+
+## Why it's a false positive
+
+`/api/schools` returns only **public California Department of Education
+school-directory data** — no personal information. A sample record:
+
+```json
+{
+  "cds_code": "08-61820-6005417",
+  "school_name": "'O Me-nok Learning Center",
+  "county_code": 8,
+  "city": "Klamath",
+  "latitude": 41.55610509,
+  "longitude": -124.05281397,
+  "school_type": "Elementary",
+  "status": "Active"
+}
+```
+
+ZAP's passive PII scanner flags **14-digit numeric identifiers** as candidate
+credit-card / PII numbers (some CDS codes coincidentally pass the Luhn check).
+The `cds_code` is the public **County-District-School code** published by CDE —
+it identifies a *school*, not a person. There is no name-of-person, contact,
+financial, health, or other personal data in this endpoint (or anywhere in the
+public read API, which serves only aggregate crash and reference data).
+
+Verdict: **no PII is disclosed.** The match is on a public institutional ID.
+
+## Suppression
+
+Add a ZAP **alert filter** so rule 10062 on this URL is marked False Positive
+and the weekly scan stops failing. In the ZAP Automation Framework plan
+(`alertFilter` job) or context file:
+
+```yaml
+- type: alertFilter
+  alertFilters:
+    - ruleId: 10062          # PII Disclosure
+      newRisk: "False Positive"
+      urlRegex: ".*/api/schools.*"
+```
+
+Or, equivalently, via CLI:
+
+```
+-config "alertFilter.filters.filter(0).ruleId=10062" \
+-config "alertFilter.filters.filter(0).url=.*/api/schools.*" \
+-config "alertFilter.filters.filter(0).urlRegex=true" \
+-config "alertFilter.filters.filter(0).newRisk=-1"   # -1 = False Positive
+```
+
+(The ZAP scan config is not in this repo — apply this where the weekly scan is
+configured on the runner.)
+
+## Related ZAP LOW findings (already fixed in the API)
+
+The same scan's LOW findings are **already resolved in the deployed API** (the
+06-29 run hit a pre-deploy instance); verified live on `api.calsight.org`:
+
+- **X-Content-Type-Options / Cross-Origin-Resource-Policy headers** — present on
+  all responses via `SecurityHeadersMiddleware` (`backend/app/main.py`); also
+  sets `X-Frame-Options: DENY` and `Referrer-Policy`.
+- **500 on null-byte input** — `NullByteSanitizationMiddleware` returns **400**
+  for `%00` in the URL/query (no more unhandled 500s).
+- Both are covered by `backend/tests/api/test_middleware.py`.
+
+The **Unix timestamp disclosure** LOW (`/api/speed-limits`) is a legitimate data
+value (a speed-limit effective date), not sensitive — ignorable.


### PR DESCRIPTION
Addresses the two failing weekly reports.

## ETL — `parties` OOM (exit 137)
**Root cause:** the daily pipeline failed because the `parties` job was **OOM-killed** (exit 137 = kernel SIGKILL; a self-timeout would be SIGTERM/143). `crashes_ccrs` and `fars` succeeded; `parties` died, which is why victims/backfill_derived/materialized_views/etc. have been stale since ~May 13.

The loader already does per-batch gc/expunge (see `TestLoadTableMemoryCleanup`), so the issue is the **full 11-year reload every run** keeping the process alive long enough for the OOM killer on the shared VM — and historical CCRS years are static and already loaded, so reloading them daily is wasted work. (`--force` was also a no-op — the param was never used.)

**Fix:** daily (non-`force`) runs are now **incremental** — only refresh the current + previous year (new `effective_start_year()` helper); `--force` does the full requested range (backfill/repair). The daily job runs without `--force`, so it picks this up automatically: ~2 resource-years instead of 11. Unit-tested (`TestEffectiveStartYear`).

## Security (ZAP) — already fixed, plus PII writeup
Verified **live** on `api.calsight.org`: the ZAP LOW findings are **already resolved** (the 06-29 scan hit a pre-deploy instance):
- `X-Content-Type-Options: nosniff` + `Cross-Origin-Resource-Policy: cross-origin` present on all responses (`SecurityHeadersMiddleware`).
- Null-byte input returns **400, not 500** (`NullByteSanitizationMiddleware`).
- Both covered by existing `tests/api/test_middleware.py`. No code change needed.

The **HIGH "PII Disclosure" on `/api/schools` is a false positive** — ZAP flags 14-digit public school **CDS codes** as candidate PII; the endpoint exposes only public CA school-directory data (no personal info). Documented in `docs/security/zap-pii-false-positive.md` with the ZAP alert-filter (rule 10062) to suppress it — apply where the weekly scan is configured (not in this repo).

## Tests
`test_load_parties_victims.py` 24/24 (3 new for the incremental helper). No live ETL load.