### PR TITLE
fix(ci): run-etl.yml — create backend/.env so docker compose exec works

### DIFF
--- a/.github/workflows/run-etl.yml
+++ b/.github/workflows/run-etl.yml
@@ -36,6 +36,43 @@ jobs:
         with:
           persist-credentials: false
 
+      # `docker compose` parses docker-compose.prod.yml (which declares
+      # env_file: backend/.env) for ANY subcommand, including `exec` — so the
+      # file must exist in this fresh checkout or compose aborts with
+      # "env file ... backend/.env not found" before the ETL ever runs. Mirror
+      # deploy.yml's step to materialize it from the same secrets.
+      - name: Create backend .env from secrets
+        env:
+          DB_URL: ${{ secrets.DATABASE_URL }}
+          CORS: ${{ secrets.CORS_ORIGINS }}
+          CENSUS: ${{ secrets.CENSUS_API_KEY }}
+          NOAA: ${{ secrets.NOAA_API_TOKEN }}
+          BLS: ${{ secrets.BLS_API_KEY }}
+          GROQ_KEY: ${{ secrets.GROQ_API_KEY }}
+          GROQ_KEY_2: ${{ secrets.GROQ_API_KEY_2 }}
+          GEMINI_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENROUTER_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          CEREBRAS_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SENTRY: ${{ secrets.SENTRY_DSN }}
+        run: |
+          : > backend/.env
+          printf 'DATABASE_URL=%s\n' "$DB_URL" >> backend/.env
+          printf 'CORS_ORIGINS=%s\n' "$CORS" >> backend/.env
+          printf 'CENSUS_API_KEY=%s\n' "$CENSUS" >> backend/.env
+          printf 'NOAA_API_TOKEN=%s\n' "$NOAA" >> backend/.env
+          printf 'BLS_API_KEY=%s\n' "$BLS" >> backend/.env
+          printf 'LLM_PROVIDER=groq\n' >> backend/.env
+          printf 'LLM_API_KEY=%s\n' "$GROQ_KEY" >> backend/.env
+          printf 'LLM_API_KEY_2=%s\n' "$GROQ_KEY_2" >> backend/.env
+          printf 'LLM_FALLBACK_1_PROVIDER=gemini\n' >> backend/.env
+          printf 'LLM_FALLBACK_1_KEY=%s\n' "$GEMINI_KEY" >> backend/.env
+          printf 'LLM_FALLBACK_2_PROVIDER=openrouter\n' >> backend/.env
+          printf 'LLM_FALLBACK_2_KEY=%s\n' "$OPENROUTER_KEY" >> backend/.env
+          printf 'LLM_FALLBACK_3_PROVIDER=cerebras\n' >> backend/.env
+          printf 'LLM_FALLBACK_3_KEY=%s\n' "$CEREBRAS_KEY" >> backend/.env
+          printf 'DEBUG=false\n' >> backend/.env
+          printf 'SENTRY_DSN=%s\n' "$SENTRY" >> backend/.env
+
       - name: Run ETL job (${{ inputs.job }})
         run: docker compose -f docker-compose.prod.yml exec -T backend python -m "etl.${{ inputs.job }}"
         timeout-minutes: 240


### PR DESCRIPTION
The manual **Run ETL Job** workflow (`run-etl.yml`) has never succeeded — triggering it (e.g. `job=load_parties_victims`) fails immediately with:

```
env file .../CalSight/backend/.env not found
##[error]Process completed with exit code 1
```

**Cause:** `docker compose` parses `docker-compose.prod.yml` (which declares `env_file: backend/.env`) for *any* subcommand — including `exec` — so the file must exist in the fresh Actions checkout. `deploy.yml` materializes `backend/.env` from secrets before its `docker compose exec` backfill step; `run-etl.yml` skipped that step.

**Fix:** add the same "Create backend .env from secrets" step (mirrors `deploy.yml`) before the ETL `exec`. No other change.

This unblocks on-demand ETL runs from the Actions tab — needed to validate the parties OOM fix (PR #341) and to load the new FARS / lived-density datasets without waiting for the nightly cron.

(Workflow-only change; the proof is a successful manual trigger after merge.)