### PR TITLE
fix(freshness): base staleness on last upstream sync, not last row-load

### DIFF
--- a/backend/app/freshness_logic.py
+++ b/backend/app/freshness_logic.py
@@ -1,0 +1,52 @@
+"""Pure staleness-decision logic for the freshness API (no DB imports).
+
+A data source is "stale" when the pipeline hasn't *confirmed it is in sync*
+with upstream within the source's threshold — i.e. it hasn't either loaded
+new rows or verified that upstream is unchanged. This is distinct from "the
+data last changed a long time ago": static annual sources (census, hospitals)
+load rarely but the orchestrator checks them every run and records a
+`skipped_unchanged` row, so they stay fresh as long as the pipeline runs.
+
+Keeping this logic free of database/app imports makes it unit-testable
+without a live Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+
+def _hours_between(now: datetime, then: Optional[datetime]) -> Optional[float]:
+    if then is None:
+        return None
+    return round((now - then).total_seconds() / 3600, 1)
+
+
+def compute_staleness(
+    now: datetime,
+    last_load_at: Optional[datetime],
+    last_check_at: Optional[datetime],
+    threshold_hours: int,
+) -> tuple[bool, Optional[float], Optional[float]]:
+    """Decide staleness from the last load and the last upstream-sync check.
+
+    Args:
+        now: current time (naive UTC, matching stored timestamps).
+        last_load_at: most recent successful row-load, or None.
+        last_check_at: most recent time we confirmed sync with upstream
+            (loaded new rows OR verified unchanged), or None.
+        threshold_hours: how long without a confirmed sync before stale.
+
+    Returns:
+        (is_stale, hours_since_load, hours_since_check).
+    """
+    hours_since_load = _hours_between(now, last_load_at)
+    hours_since_check = _hours_between(now, last_check_at)
+
+    if hours_since_check is None:
+        is_stale = True
+    else:
+        is_stale = hours_since_check > threshold_hours
+
+    return is_stale, hours_since_load, hours_since_check

--- a/backend/app/routers/freshness.py
+++ b/backend/app/routers/freshness.py
@@ -25,18 +25,25 @@ from sqlalchemy import desc, func, text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
+from app.freshness_logic import compute_staleness
 from app.models import EtlRun
 
 router = APIRouter(tags=["freshness"])
+
+# Statuses that count as "we confirmed sync with upstream": either we loaded
+# new rows (success) or we verified upstream is unchanged (skipped_unchanged).
+_SYNC_STATUSES = ("success", "skipped_unchanged")
 
 _limiter = Limiter(key_func=get_remote_address)
 
 
 class SourceFreshness(BaseModel):
     source: str
-    last_success_at: Optional[datetime]
+    last_success_at: Optional[datetime]      # last time rows actually loaded
+    last_checked_at: Optional[datetime]      # last time we confirmed sync w/ upstream
     rows_loaded: Optional[int]
-    hours_since_update: Optional[float]
+    hours_since_update: Optional[float]      # since last_success_at (data age)
+    hours_since_check: Optional[float]       # since last_checked_at (drives is_stale)
     is_stale: bool
     staleness_threshold_hours: int
 
@@ -109,31 +116,44 @@ def get_freshness(
         .all()
     )
 
+    # Last time we confirmed sync with upstream per source — a successful load
+    # OR a skipped_unchanged check both count. This is what staleness keys off,
+    # so static annual sources (checked daily, loaded rarely) don't read stale.
+    last_check_by_source = dict(
+        db.query(EtlRun.source, func.max(EtlRun.finished_at))
+        .filter(EtlRun.status.in_(_SYNC_STATUSES))
+        .group_by(EtlRun.source)
+        .all()
+    )
+
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     results = []
 
     for run in rows:
         threshold = _STALENESS_THRESHOLDS.get(run.source, 168)  # default 1 week
-        hours_ago = None
-        is_stale = False
-
-        if run.finished_at:
-            hours_ago = (now - run.finished_at).total_seconds() / 3600
-            is_stale = hours_ago > threshold
+        last_check = last_check_by_source.get(run.source, run.finished_at)
+        is_stale, hours_since_load, hours_since_check = compute_staleness(
+            now=now,
+            last_load_at=run.finished_at,
+            last_check_at=last_check,
+            threshold_hours=threshold,
+        )
 
         results.append(
             SourceFreshness(
                 source=run.source,
                 last_success_at=run.finished_at,
+                last_checked_at=last_check,
                 rows_loaded=run.rows_loaded,
-                hours_since_update=round(hours_ago, 1) if hours_ago is not None else None,
+                hours_since_update=hours_since_load,
+                hours_since_check=hours_since_check,
                 is_stale=is_stale,
                 staleness_threshold_hours=threshold,
             ).model_dump()
         )
 
-    # Sort: stale sources first, then by recency
-    results.sort(key=lambda x: (not x["is_stale"], x["hours_since_update"] or 9999))
+    # Sort: stale sources first, then by recency of last upstream check
+    results.sort(key=lambda x: (not x["is_stale"], x["hours_since_check"] or 9999))
 
     return results
 
@@ -189,15 +209,30 @@ def get_freshness_summary(
         .all()
     )
 
+    # Last confirmed-sync time per source (success OR skipped_unchanged).
+    last_check_by_source = dict(
+        db.query(EtlRun.source, func.max(EtlRun.finished_at))
+        .filter(EtlRun.status.in_(_SYNC_STATUSES))
+        .group_by(EtlRun.source)
+        .all()
+    )
+
     for source, last_at in runs:
         loaded_sources.add(source)
         if source not in _STALENESS_THRESHOLDS:
             continue
         threshold = _STALENESS_THRESHOLDS[source]
-        if last_at and (now - last_at).total_seconds() / 3600 <= threshold:
-            sources_fresh += 1
-        else:
+        last_check = last_check_by_source.get(source, last_at)
+        is_stale, _, _ = compute_staleness(
+            now=now,
+            last_load_at=last_at,
+            last_check_at=last_check,
+            threshold_hours=threshold,
+        )
+        if is_stale:
             sources_stale += 1
+        else:
+            sources_fresh += 1
 
     sources_never = len(all_sources - loaded_sources)
 

--- a/backend/tests/api/test_freshness.py
+++ b/backend/tests/api/test_freshness.py
@@ -1,6 +1,10 @@
 """Integration tests for /api/freshness and /api/meta/data-freshness."""
 
+from datetime import datetime, timedelta
+
 import pytest
+
+from app.models import EtlRun
 
 pytestmark = pytest.mark.integration
 
@@ -36,6 +40,70 @@ def test_freshness_contains_seeded_sources(client):
 def test_freshness_has_cache_control(client):
     response = client.get("/api/freshness")
     assert "max-age" in response.headers.get("Cache-Control", "")
+
+
+# --- staleness keys off last upstream sync, not last row-load ---
+
+
+def _get_source(body, name):
+    return next((e for e in body if e["source"] == name), None)
+
+
+def test_static_source_recently_checked_is_not_stale(client, db_session):
+    """A source loaded long ago but confirmed unchanged recently is fresh."""
+    now = datetime.utcnow()
+    db_session.add_all([
+        EtlRun(source="hospitals", status="success", rows_loaded=500,
+               started_at=now - timedelta(days=50, hours=1),
+               finished_at=now - timedelta(days=50)),
+        EtlRun(source="hospitals", status="skipped_unchanged",
+               started_at=now - timedelta(hours=7),
+               finished_at=now - timedelta(hours=7)),
+    ])
+    db_session.flush()
+
+    body = client.get("/api/freshness").json()
+    entry = _get_source(body, "hospitals")
+    assert entry is not None
+    assert entry["is_stale"] is False
+    assert entry["hours_since_update"] > 1000   # data itself is old
+    assert entry["hours_since_check"] < 24       # but checked recently
+
+
+def test_source_not_checked_past_threshold_is_stale(client, db_session):
+    """A source the pipeline hasn't even checked in weeks is stale."""
+    now = datetime.utcnow()
+    db_session.add_all([
+        EtlRun(source="weather", status="success", rows_loaded=10,
+               started_at=now - timedelta(days=45, hours=1),
+               finished_at=now - timedelta(days=45)),
+        EtlRun(source="weather", status="skipped_unchanged",
+               started_at=now - timedelta(days=40),
+               finished_at=now - timedelta(days=40)),
+    ])
+    db_session.flush()
+
+    body = client.get("/api/freshness").json()
+    entry = _get_source(body, "weather")
+    assert entry is not None
+    assert entry["is_stale"] is True
+
+
+def test_summary_counts_recently_checked_static_source_as_fresh(client, db_session):
+    now = datetime.utcnow()
+    db_session.add_all([
+        EtlRun(source="demographics", status="success", rows_loaded=58,
+               started_at=now - timedelta(days=48, hours=1),
+               finished_at=now - timedelta(days=48)),
+        EtlRun(source="demographics", status="skipped_unchanged",
+               started_at=now - timedelta(hours=8),
+               finished_at=now - timedelta(hours=8)),
+    ])
+    db_session.flush()
+
+    summary = client.get("/api/freshness/summary").json()
+    # demographics (720h threshold) checked 8h ago → must not inflate the count
+    assert summary["sources_stale"] == 0
 
 
 # --- GET /api/freshness/summary ---

--- a/backend/tests/test_freshness_logic.py
+++ b/backend/tests/test_freshness_logic.py
@@ -1,0 +1,76 @@
+"""Unit tests for the pure staleness-decision helper.
+
+These run without a database. The core behavior under test: a source is
+"stale" only when we haven't *confirmed sync* with upstream (loaded new
+rows OR verified upstream is unchanged) within its threshold — NOT merely
+because the last row-load is old. Static annual sources (census, hospitals)
+load rarely but are checked daily, so they should read as fresh.
+"""
+
+from datetime import datetime, timedelta
+
+from app.freshness_logic import compute_staleness
+
+
+NOW = datetime(2026, 6, 30, 12, 0, 0)
+
+
+def test_static_source_old_load_recent_check_is_fresh():
+    # Hospitals: data last changed 50 days ago, but pipeline confirmed
+    # "unchanged" upstream 7 hours ago. Not stale.
+    is_stale, hours_since_load, hours_since_check = compute_staleness(
+        now=NOW,
+        last_load_at=NOW - timedelta(days=50),
+        last_check_at=NOW - timedelta(hours=7),
+        threshold_hours=720,
+    )
+    assert is_stale is False
+    assert hours_since_load == 1200.0  # 50 days
+    assert hours_since_check == 7.0
+
+
+def test_no_check_ever_is_stale():
+    is_stale, hours_since_load, hours_since_check = compute_staleness(
+        now=NOW,
+        last_load_at=None,
+        last_check_at=None,
+        threshold_hours=720,
+    )
+    assert is_stale is True
+    assert hours_since_load is None
+    assert hours_since_check is None
+
+
+def test_check_older_than_threshold_is_stale():
+    # Pipeline hasn't even checked this source in 40 days — genuinely stale.
+    is_stale, _, hours_since_check = compute_staleness(
+        now=NOW,
+        last_load_at=NOW - timedelta(days=45),
+        last_check_at=NOW - timedelta(days=40),
+        threshold_hours=720,
+    )
+    assert is_stale is True
+    assert hours_since_check == 960.0
+
+
+def test_recent_load_and_check_is_fresh():
+    is_stale, hours_since_load, hours_since_check = compute_staleness(
+        now=NOW,
+        last_load_at=NOW - timedelta(hours=8),
+        last_check_at=NOW - timedelta(hours=8),
+        threshold_hours=48,
+    )
+    assert is_stale is False
+    assert hours_since_load == 8.0
+    assert hours_since_check == 8.0
+
+
+def test_check_exactly_at_threshold_is_not_stale():
+    # Boundary: equal to threshold is still fresh (strictly-greater is stale).
+    is_stale, _, _ = compute_staleness(
+        now=NOW,
+        last_load_at=NOW - timedelta(hours=48),
+        last_check_at=NOW - timedelta(hours=48),
+        threshold_hours=48,
+    )
+    assert is_stale is False


### PR DESCRIPTION
## Problem
`/api/freshness` flagged ~10–13 sources as `is_stale` even though prod is healthy and the data is as current as upstream allows. Static annual sources (census, hospitals, schools, `road_miles`, `aadt`, `calenviroscreen`, `demographics`, etc.) were marked stale once 30 days passed since their last **row-load** — but the orchestrator checks them upstream **every run** and correctly skips reloading when nothing has changed (recording a `skipped_unchanged` row). So "stale" really meant "hasn't changed in a while," not "out of sync."

Surfaced while verifying last night's ETL recovery (run `28426902650`, success — `13 succeeded, 0 failed, 0 skipped, 11 unchanged`). The "11 unchanged" are exactly the sources the API was crying wolf about.

## Fix
Staleness now keys off the **last confirmed sync with upstream** — the most recent run that was either `success` (loaded new rows) or `skipped_unchanged` (verified upstream unchanged). Both already live in `etl_runs`, so **no schema change**. A source is stale only if the pipeline hasn't *checked* it within its threshold, which still catches a genuinely broken pipeline.

## Changes
- **`app/freshness_logic.py`** — new pure, DB-free `compute_staleness` helper (unit-testable without Postgres)
- **`app/routers/freshness.py`** — both `/api/freshness` and `/api/freshness/summary` use the helper; queries now also fetch last-check time across `success` + `skipped_unchanged`
- Response is **additive**: gains `last_checked_at` + `hours_since_check`; existing fields keep their meaning (you can now read "data last changed 50 days ago, **confirmed current 7h ago**, not stale")
- **Tests:** 5 pure unit tests + 3 integration tests

## No frontend impact
Nothing in the app consumes `/api/freshness` per-source. The user-facing "Last updated" banner uses `/api/meta/data-freshness` (driven by daily-loading crashes) and is untouched. This is purely the monitoring/data-health signal.

## Verification
- Unit tests (logic): 467 passed locally incl. the 5 new ones (RED→GREEN)
- Integration tests run in CI (no local test Postgres in dev env)