### PR TITLE
feat(distribution): filter-aware /stats/distribution so percentile survives filtering

### DIFF
--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1096,22 +1096,65 @@ def stats_distribution(
     request: Request,
     response: Response,
     metric: str = Query("crash_count"),
-    year: int | None = Query(None),
+    year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    pedestrian: str | None = Query(None),
+    cyclist: str | None = Query(None),
+    drug: str | None = Query(None),
+    driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
     db: Session = Depends(get_db),
 ):
     """Per-county values for one metric — the distribution the frontend reduces
     into percentile/rank context ("safer than X% of counties").
 
-    Mirrors the rank_counties tool but returns every county (no small limit).
+    Accepts the same filter set as /api/stats so the per-county distribution
+    reflects the *same population* as the subject being compared. Without this,
+    the percentile is only honest for the unfiltered (year-only) view, which is
+    why the frontend used to suppress it whenever a filter was active. Mirrors
+    the rank_counties tool but returns every county (no small limit).
     """
     if metric not in _DISTRIBUTION_METRICS:
         raise HTTPException(status_code=422, detail=f"invalid metric: {metric}")
 
     response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
 
-    preds = []
-    if year is not None:
-        preds.append(Crash.crash_year == year)
+    date_range = parse_date_range(start, end)
+    years = years_from_date_range(date_range) if date_range is not None else parse_year(year)
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+
+    preds = build_crash_predicates(
+        years=years,
+        date_range=date_range,
+        county_codes=county_codes,
+        severities=severities,
+        causes=causes,
+        alcohol=parse_bool_flag(alcohol, "alcohol"),
+        distracted=parse_bool_flag(distracted, "distracted"),
+        pedestrian=parse_bool_flag(pedestrian, "pedestrian"),
+        cyclist=parse_bool_flag(cyclist, "cyclist"),
+        drug=parse_bool_flag(drug, "drug"),
+        driver_age=parse_driver_age(driver_age),
+        weather=parse_weather(weather),
+        lighting=parse_lighting(lighting),
+        collision_type=parse_collision_type(collision_type),
+        road_type=parse_road_type(road_type),
+        hit_run=parse_hit_run(hit_run),
+    )
+
+    # Metric-specific predicate + aggregate, AND-combined with the filters above.
     if metric == "fatal_crashes":
         preds.append(Crash.severity == "Fatal")
         agg = func.count(Crash.id)

--- a/backend/tests/api/test_stats_distribution.py
+++ b/backend/tests/api/test_stats_distribution.py
@@ -12,3 +12,30 @@ def test_distribution_returns_all_counties(client):
 def test_distribution_rejects_bad_metric(client):
     r = client.get("/api/stats/distribution?metric=bogus")
     assert r.status_code == 422
+
+
+def test_distribution_respects_alcohol_filter(client):
+    # Of the seeded crashes only id=3 (county 19) is alcohol-involved.
+    r = client.get("/api/stats/distribution?metric=crash_count&alcohol=true")
+    assert r.status_code == 200
+    by_county = {row["county_code"]: row["value"] for row in r.json()}
+    assert by_county.get(19) == 1
+    assert by_county.get(30, 0) == 0
+    assert by_county.get(38, 0) == 0
+
+
+def test_distribution_respects_county_filter(client):
+    # County 19 (Los Angeles) has 3 seeded crashes; filtering should drop the rest.
+    r = client.get("/api/stats/distribution?metric=crash_count&county=los-angeles")
+    assert r.status_code == 200
+    by_county = {row["county_code"]: row["value"] for row in r.json()}
+    assert by_county.get(19) == 3
+    assert 30 not in by_county
+    assert 38 not in by_county
+
+
+def test_distribution_unfiltered_still_returns_full_counts(client):
+    # Backward-compat: no filters => county 19 keeps all 3 crashes.
+    r = client.get("/api/stats/distribution?metric=crash_count")
+    by_county = {row["county_code"]: row["value"] for row in r.json()}
+    assert by_county.get(19) == 3

--- a/frontend/src/components/ai/AiCompanion.distribution.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.distribution.test.tsx
@@ -52,14 +52,16 @@ describe("AiCompanion distribution tier", () => {
     expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
   });
 
-  it("does not show percentile when a population-narrowing filter (severity) is active", () => {
+  it("still shows percentile when a population-narrowing filter (severity) is active", () => {
+    // The distribution endpoint now reflects the same filters, so the
+    // percentile stays honest and is shown rather than suppressed.
     const filteredStat: DataContext = {
       ...countyStat,
       filters: { ...baseFilters, severities: ["Fatal"] },
     };
     renderWith(filteredStat);
     fireEvent.click(screen.getByText("open"));
-    expect(screen.getByRole("dialog").textContent).not.toMatch(/ranks #|safer than/i);
+    expect(screen.getByRole("dialog").textContent).toMatch(/ranks #|safer than/i);
   });
 
   it("does not show percentile when two years are selected", () => {

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -6,7 +6,7 @@ import { useAskAi } from "../../hooks/useAskAi";
 import type { ChatMessage } from "../../hooks/useAskAi";
 import InlineChart from "../ask/InlineChart";
 import { useDistribution } from "../../hooks/useDistribution";
-import { measureToMetric, distributionPopulationMatches } from "../../lib/ai/measureMetric";
+import { measureToMetric, filtersToDistributionParams } from "../../lib/ai/measureMetric";
 
 export function buildDeepDivePrompt(ctx: DataContext): string {
   const parts: string[] = [`Explain this CalSight data point: "${ctx.label}".`];
@@ -50,14 +50,24 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
 
   const metric = current?.kind === "stat" ? measureToMetric(current.measure ?? "") : null;
   const years = current?.filters.years ?? [];
+  // Distribution is gated on a single-county, single-year stat. Population-
+  // narrowing filters (severity, cause, alcohol, …) no longer disable it — they
+  // are forwarded so the per-county distribution reflects the same population,
+  // keeping the percentile honest under any filter combination.
   const distEnabled =
     current?.kind === "stat" &&
     current.geography?.type === "county" &&
     metric != null &&
-    years.length <= 1 &&
-    distributionPopulationMatches(current.filters);
+    years.length <= 1;
   const distYear = years.length === 1 ? years[0] : null;
-  const { data: distribution } = useDistribution(metric ?? "crash_count", distYear, { enabled: distEnabled });
+  const distFilterParams = useMemo(
+    () => (current ? filtersToDistributionParams(current.filters) : {}),
+    [current],
+  );
+  const { data: distribution } = useDistribution(metric ?? "crash_count", distYear, {
+    enabled: distEnabled,
+    filterParams: distFilterParams,
+  });
 
   const explanation = current
     ? explainContext(current, distEnabled ? { distribution } : undefined)

--- a/frontend/src/hooks/useDistribution.ts
+++ b/frontend/src/hooks/useDistribution.ts
@@ -6,14 +6,16 @@ import type { DistributionPoint } from "../lib/ai/statNarrative";
 export function useDistribution(
   metric: string,
   year: number | null,
-  options?: { enabled?: boolean },
+  options?: { enabled?: boolean; filterParams?: Record<string, string> },
 ): { data: DistributionPoint[] | undefined; isLoading: boolean } {
+  const filterParams = options?.filterParams ?? {};
   const query = useQuery({
-    queryKey: ["distribution", metric, year],
+    queryKey: ["distribution", metric, year, filterParams],
     enabled: options?.enabled ?? true,
     queryFn: async (): Promise<DistributionPoint[]> => {
       const params = new URLSearchParams({ metric });
       if (year != null) params.set("year", String(year));
+      for (const [k, v] of Object.entries(filterParams)) params.set(k, v);
       const res = await fetch(`${API_BASE}/api/stats/distribution?${params.toString()}`);
       if (!res.ok) throw new Error(`distribution ${res.status}`);
       const data = (await res.json()) as DistributionRow[];

--- a/frontend/src/lib/ai/measureMetric.test.ts
+++ b/frontend/src/lib/ai/measureMetric.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { measureToMetric, normalizeCounty, adaptDistribution, distributionPopulationMatches } from "./measureMetric";
+import { measureToMetric, normalizeCounty, adaptDistribution, filtersToDistributionParams } from "./measureMetric";
 import type { FilterSnapshot } from "./dataContext";
 
 describe("measureToMetric", () => {
@@ -41,17 +41,27 @@ const allEmpty: FilterSnapshot = {
   driverAge: null, weather: [], lighting: [], collisionType: [], roadType: null, hitRun: null,
 };
 
-describe("distributionPopulationMatches", () => {
-  it("returns true when no population-narrowing filter is active", () => {
-    expect(distributionPopulationMatches(allEmpty)).toBe(true);
+describe("filtersToDistributionParams", () => {
+  it("emits no params for an unfiltered snapshot", () => {
+    expect(filtersToDistributionParams(allEmpty)).toEqual({});
   });
-  it("returns false when a severity is present", () => {
-    expect(distributionPopulationMatches({ ...allEmpty, severities: ["Fatal"] })).toBe(false);
+  it("excludes counties and years (distribution must span all counties)", () => {
+    const out = filtersToDistributionParams({ ...allEmpty, counties: ["Kern", "Inyo"], years: [2023] });
+    expect(out.county).toBeUndefined();
+    expect(out.year).toBeUndefined();
   });
-  it("returns false when an involvement flag (alcohol) is set", () => {
-    expect(distributionPopulationMatches({ ...allEmpty, alcohol: true })).toBe(false);
+  it("serializes severities and causes as CSV", () => {
+    const out = filtersToDistributionParams({ ...allEmpty, severities: ["Fatal", "Injury"], causes: ["dui"] });
+    expect(out.severity).toBe("Fatal,Injury");
+    expect(out.cause).toBe("dui");
   });
-  it("returns true for a county + single-year-only snapshot (no other filters)", () => {
-    expect(distributionPopulationMatches({ ...allEmpty, years: [2023], counties: ["Kern"] })).toBe(true);
+  it("serializes boolean involvement flags as 'true'/'false'", () => {
+    expect(filtersToDistributionParams({ ...allEmpty, alcohol: true }).alcohol).toBe("true");
+    expect(filtersToDistributionParams({ ...allEmpty, hitRun: false }).hit_run).toBe("false");
+  });
+  it("passes through driverAge and roadType strings", () => {
+    const out = filtersToDistributionParams({ ...allEmpty, driverAge: "25-34", roadType: "highway" });
+    expect(out.driver_age).toBe("25-34");
+    expect(out.road_type).toBe("highway");
   });
 });

--- a/frontend/src/lib/ai/measureMetric.ts
+++ b/frontend/src/lib/ai/measureMetric.ts
@@ -18,26 +18,27 @@ export function normalizeCounty(name: string): string {
   return name.trim().toLowerCase();
 }
 
-/** True when no population-narrowing filter beyond county + year is active, so
- *  the subject value matches the year-only distribution population and the
- *  percentile is honest. (years and counties are intentionally NOT checked
- *  here — year is gated separately and the single county IS the subject.) */
-export function distributionPopulationMatches(f: FilterSnapshot): boolean {
-  return (
-    f.severities.length === 0 &&
-    f.causes.length === 0 &&
-    f.weather.length === 0 &&
-    f.lighting.length === 0 &&
-    f.collisionType.length === 0 &&
-    f.alcohol == null &&
-    f.distracted == null &&
-    f.pedestrian == null &&
-    f.cyclist == null &&
-    f.drug == null &&
-    f.roadType == null &&
-    f.hitRun == null &&
-    f.driverAge == null
-  );
+/** Serialize the population-narrowing filters into /api/stats/distribution
+ *  query params so the per-county distribution reflects the SAME population as
+ *  the subject. `counties` and `years` are deliberately excluded: the
+ *  distribution must span every county (else the percentile is meaningless),
+ *  and the year is passed separately via the `year` param. */
+export function filtersToDistributionParams(f: FilterSnapshot): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (f.severities.length) out.severity = f.severities.join(",");
+  if (f.causes.length) out.cause = f.causes.join(",");
+  if (f.weather.length) out.weather = f.weather.join(",");
+  if (f.lighting.length) out.lighting = f.lighting.join(",");
+  if (f.collisionType.length) out.collision_type = f.collisionType.join(",");
+  if (f.alcohol != null) out.alcohol = String(f.alcohol);
+  if (f.distracted != null) out.distracted = String(f.distracted);
+  if (f.pedestrian != null) out.pedestrian = String(f.pedestrian);
+  if (f.cyclist != null) out.cyclist = String(f.cyclist);
+  if (f.drug != null) out.drug = String(f.drug);
+  if (f.hitRun != null) out.hit_run = String(f.hitRun);
+  if (f.driverAge != null) out.driver_age = f.driverAge;
+  if (f.roadType != null) out.road_type = f.roadType;
+  return out;
 }
 
 export type DistributionRow = { county_code: number; county_name: string; value: number };


### PR DESCRIPTION
## Problem
The AI companion's percentile context — *"Kern County ranks #N / safer than Y% of counties"* — **vanished the moment any filter was applied** (severity, cause, alcohol, weather, …). That's because `/api/stats/distribution` only accepted `metric` + `year`: comparing a *filtered* subject value against an *unfiltered* year-only distribution would be a dishonest percentile, so the frontend suppressed it entirely (`distributionPopulationMatches` gate).

So the single most useful "is this county unusual?" signal disappeared exactly when a user drilled into a specific crash type.

## Fix
Make the distribution endpoint reflect the **same population** as the subject.

**Backend** — `/stats/distribution` now accepts the full `/api/stats` filter set (county, severity, cause, involvement flags, weather, lighting, collision_type, road_type, hit_run, driver_age, date range), reusing `build_crash_predicates` exactly like `/stats/highways`. AND-combined with the existing metric predicate. **Additive** — unfiltered callers are byte-for-byte unchanged.

**Frontend**
- New pure `filtersToDistributionParams()` serializer (unit-tested). It **deliberately excludes `counties` and `years`**: a per-county percentile must span *every* county, and the year is passed separately — otherwise filtering to one county would make the ranking degenerate.
- `useDistribution` threads the params; `AiCompanion` forwards `current.filters` and relaxes the gate to *single-county + single-year* (no longer "no filters active").
- Removed the now-dead `distributionPopulationMatches` (its only job was the gate this PR reverses).

## Behavior change
Before: filter by "Fatal" → percentile disappears.
After: filter by "Fatal" → "ranks #N among counties **for fatal crashes**", honest because the distribution is now also fatal-only.

## Tests
- Backend integration: distribution respects `alcohol` + `county` filters; unfiltered counts unchanged.
- Frontend unit: serializer (CSV, bool flags, driver_age/road_type passthrough, county/year exclusion); updated companion distribution test to assert the percentile now shows under a severity filter.
- Local: 27 frontend tests green + `tsc --noEmit` clean. Backend integration runs in CI (no local test Postgres in dev env).