### PR TITLE
feat(etl): one-click clear_stale_runs for zombie 'running' rows

### DIFF
--- a/backend/etl/clear_stale_runs.py
+++ b/backend/etl/clear_stale_runs.py
@@ -1,0 +1,63 @@
+"""Mark stale 'running' etl_runs rows as errored.
+
+When an ETL job is hard-killed (e.g. OOM / exit 137) it never writes its
+terminal status, so its `etl_runs` row is stuck at status='running' forever.
+Those zombie rows make /api/freshness and the pipeline-health view look like a
+job is perpetually in flight. This resets any 'running' row older than a safety
+threshold (default 6h — longer than any real job, which the workflow caps at
+4h) to 'error', leaving genuinely in-flight jobs untouched.
+
+Usage:
+    python -m etl.clear_stale_runs            # rows running > 6h
+    python -m etl.clear_stale_runs 12         # rows running > 12h
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from sqlalchemy import text
+
+from app.database import etl_engine  # write role
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+_SQL = text(
+    """
+    UPDATE etl_runs
+       SET status = 'error',
+           finished_at = COALESCE(finished_at, now()),
+           error_message = COALESCE(
+               error_message,
+               'cleared: stale running row (process died without terminal status)'
+           )
+     WHERE status = 'running'
+       AND started_at < now() - (:h * interval '1 hour')
+    """
+)
+
+
+def clear_stale_runs(older_than_hours: float = 6.0, *, conn=None) -> int:
+    """Reset 'running' rows older than the threshold to 'error'.
+
+    Returns the number of rows updated. `conn` (a Connection or Session) is
+    injectable for testing and runs inside the caller's transaction; when
+    omitted, a fresh transaction on the ETL write-role engine is used.
+    """
+    if conn is not None:
+        return conn.execute(_SQL, {"h": older_than_hours}).rowcount
+    with etl_engine.begin() as c:
+        return c.execute(_SQL, {"h": older_than_hours}).rowcount
+
+
+if __name__ == "__main__":
+    hours = float(sys.argv[1]) if len(sys.argv) > 1 else 6.0
+    n = clear_stale_runs(hours)
+    logger.info("Cleared %d stale 'running' etl_runs row(s) older than %sh.", n, hours)
+    print(f"Cleared {n} stale running row(s).")

--- a/backend/tests/api/test_clear_stale_runs.py
+++ b/backend/tests/api/test_clear_stale_runs.py
@@ -1,0 +1,36 @@
+"""Integration test for etl.clear_stale_runs."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.models import EtlRun
+from etl.clear_stale_runs import clear_stale_runs
+
+pytestmark = pytest.mark.integration
+
+
+def test_clears_only_stale_running_rows(db_session):
+    now = datetime.utcnow()
+    db_session.add_all([
+        # Zombie: 'running' for 2 days — must be cleared.
+        EtlRun(source="zombie_job", status="running",
+               started_at=now - timedelta(days=2)),
+        # Legitimately in-flight: started 30 min ago — must be left alone.
+        EtlRun(source="live_job", status="running",
+               started_at=now - timedelta(minutes=30)),
+    ])
+    db_session.flush()
+
+    cleared = clear_stale_runs(6.0, conn=db_session)
+    assert cleared == 1
+
+    zombie = (db_session.query(EtlRun)
+              .filter_by(source="zombie_job").order_by(EtlRun.id.desc()).first())
+    live = (db_session.query(EtlRun)
+            .filter_by(source="live_job").order_by(EtlRun.id.desc()).first())
+    db_session.refresh(zombie)
+    db_session.refresh(live)
+    assert zombie.status == "error"
+    assert zombie.finished_at is not None
+    assert live.status == "running"


### PR DESCRIPTION
## Why
When an ETL job is hard-killed (OOM / exit 137) it never writes its terminal status, so its `etl_runs` row is stuck at `status='running'` forever. Those zombie rows make `/api/freshness` and pipeline-health look like a job is perpetually in flight — and clearing them has been a recurring manual `UPDATE` chore in the backlog.

## What
New `etl.clear_stale_runs` module resets any `'running'` row **older than a safety threshold** (default 6h — longer than any real job; the manual-ETL workflow caps at 4h) to `'error'`, leaving genuinely in-flight jobs untouched. Now a one-click job via the existing workflow:

```
gh workflow run run-etl.yml -f job=clear_stale_runs -f refresh_matviews=false
```

The threshold is a CLI arg; the query runs in the caller's transaction when a `conn`/session is injected (used by the test).

## Test
Integration test seeds a 2-day-old `running` row + a 30-min-old `running` row and asserts only the stale one flips to `error`. Runs in CI (no local test Postgres in dev env).