### PR TITLE
fix(deploy): create /opt/calsight/backups before compose up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -170,6 +170,12 @@ jobs:
           CLOUDFLARED_TOKEN: ${{ secrets.CLOUDFLARED_TOKEN }}
         run: docker compose -f docker-compose.prod.yml run --rm -T backend alembic upgrade head
 
+      - name: Ensure host backup directory exists
+        # docker-compose.pipeline.yml bind-mounts /opt/calsight/backups into
+        # the pipeline container; the mount fails at container start if the
+        # host directory is missing (first deploy after the C4 backup fix).
+        run: mkdir -p /opt/calsight/backups 2>/dev/null || sudo -n mkdir -p /opt/calsight/backups
+
       - name: Start backend + tunnel + ETL pipeline
         env:
           CLOUDFLARED_TOKEN: ${{ secrets.CLOUDFLARED_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

First deploy after #348 failed at 'Start backend + tunnel + ETL pipeline': `docker-compose.pipeline.yml` bind-mounts `/opt/calsight/backups` (C4 backup fix), and Docker errors at container start when the host directory doesn't exist. The new rollback path restored the previous image, so prod stayed healthy throughout.

This adds a one-line step that creates the directory before `docker compose up`.

## How to test
- [x] Deploy run 28681436403 shows the exact mount failure; prod verified healthy post-rollback (site 200, /api/health ok).
- [ ] Merge → CI → gated deploy should now complete and put #348's code live.

## Checklist
- [x] Code builds without errors
- [x] No other PRs need to merge before this one