### PR TITLE
fix(#301): wrap NavBar/BottomTabBar in ErrorBoundary, add retry limit

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -44,7 +44,9 @@ export default function Layout() {
       >
         Skip to main content
       </a>
-      <NavBar />
+      <ErrorBoundary fallback={<header className="bg-surface fixed top-0 z-50 h-12 md:h-16 w-full" aria-hidden="true" />}>
+        <NavBar />
+      </ErrorBoundary>
       <OfflineIndicator />
       <ErrorBoundary>
       {isMapPage ? (
@@ -66,7 +68,9 @@ export default function Layout() {
         </div>
       )}
       </ErrorBoundary>
-      <BottomTabBar />
+      <ErrorBoundary fallback={null}>
+        <BottomTabBar />
+      </ErrorBoundary>
     </>
   );
 }

--- a/frontend/src/components/ui/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+vi.mock("../../lib/queryClient", () => ({
+  queryClient: { clear: vi.fn() },
+}));
+
+// Defined at module level so the reference is stable across rerenders —
+// if defined inside a test, React sees a new component type and unmounts/remounts.
+let throwOnRender = false;
+function Bomb() {
+  if (throwOnRender) throw new Error("test error");
+  return <span>OK</span>;
+}
+
+describe("ErrorBoundary", () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    throwOnRender = false;
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload: reloadSpy },
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when there is no error", () => {
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+    expect(screen.getByText("OK")).toBeInTheDocument();
+  });
+
+  it("shows the default error UI when a child throws", () => {
+    throwOnRender = true;
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("renders a custom fallback instead of the default UI", () => {
+    throwOnRender = true;
+    render(
+      <ErrorBoundary fallback={<div>custom fallback</div>}>
+        <Bomb />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("custom fallback")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders nothing when fallback={null} and child throws", () => {
+    throwOnRender = true;
+    const { container } = render(
+      <ErrorBoundary fallback={null}><Bomb /></ErrorBoundary>
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("escalates 'Try again' to 'Reload page' after 3 retries", () => {
+    throwOnRender = true;
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+
+    const btn = () => screen.getByRole("button");
+    expect(btn()).toHaveTextContent("Try again");
+
+    fireEvent.click(btn()); // retryCount → 1, Bomb re-throws
+    fireEvent.click(btn()); // retryCount → 2
+    fireEvent.click(btn()); // retryCount → 3, exhausted
+
+    expect(btn()).toHaveTextContent("Reload page");
+  });
+
+  it("calls window.location.reload when the exhausted button is clicked", () => {
+    throwOnRender = true;
+    render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+
+    const btn = () => screen.getByRole("button");
+    fireEvent.click(btn()); // 1
+    fireEvent.click(btn()); // 2
+    fireEvent.click(btn()); // 3 — exhausted, button now "Reload page"
+    fireEvent.click(btn()); // triggers reload
+
+    expect(reloadSpy).toHaveBeenCalledOnce();
+  });
+
+  it("resets retry count after a successful recovery", () => {
+    throwOnRender = true;
+    const { rerender } = render(<ErrorBoundary><Bomb /></ErrorBoundary>);
+
+    const btn = () => screen.getByRole("button");
+
+    // Failed retry — retryCount increments to 1 but Bomb re-throws
+    fireEvent.click(btn());
+    expect(btn()).toHaveTextContent("Try again");
+
+    // Successful recovery
+    throwOnRender = false;
+    fireEvent.click(btn());
+    expect(screen.getByText("OK")).toBeInTheDocument();
+
+    // New error episode — retryCount should have reset, not accumulated
+    throwOnRender = true;
+    rerender(<ErrorBoundary><Bomb /></ErrorBoundary>);
+    expect(btn()).toHaveTextContent("Try again");
+  });
+});

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -9,12 +9,13 @@ interface Props {
 
 interface State {
   hasError: boolean;
+  retryCount: number;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false };
+  state: State = { hasError: false, retryCount: 0 };
 
-  static getDerivedStateFromError(): State {
+  static getDerivedStateFromError(): Partial<State> {
     return { hasError: true };
   }
 
@@ -24,16 +25,25 @@ export class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
-      return this.props.fallback ?? (
+      if ('fallback' in this.props) return <>{this.props.fallback}</>;
+      const exhausted = this.state.retryCount >= 3;
+      return (
         <div role="alert" className="flex flex-col items-center justify-center p-8 text-center min-h-[200px]">
           <span className="material-symbols-outlined text-[32px] text-error mb-2" aria-hidden="true">error</span>
           <p className="text-on-surface font-semibold">Something went wrong</p>
           <button
             type="button"
-            onClick={() => { queryClient.clear(); this.setState({ hasError: false }); }}
+            onClick={() => {
+              if (exhausted) {
+                window.location.reload();
+              } else {
+                queryClient.clear();
+                this.setState(s => ({ hasError: false, retryCount: s.retryCount + 1 }));
+              }
+            }}
             className="mt-3 px-4 py-2 bg-primary text-on-primary rounded-full text-sm font-semibold hover:opacity-90 transition-opacity"
           >
-            Try again
+            {exhausted ? "Reload page" : "Try again"}
           </button>
         </div>
       );

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -4,6 +4,11 @@ import { queryClient } from "../../lib/queryClient";
 
 interface Props {
   children: ReactNode;
+  // When provided, rendered instead of the default retry UI on error.
+  // Presence is checked with `'fallback' in props` (not ??), so passing
+  // fallback={null} explicitly opts into "render nothing" rather than
+  // falling through to the default UI. Omitting the prop entirely gives
+  // you the default retry UI.
   fallback?: ReactNode;
 }
 
@@ -21,6 +26,13 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  componentDidUpdate(_prevProps: Props, prevState: State) {
+    // Child rendered successfully after a retry — reset count for the next error episode.
+    if (prevState.hasError && !this.state.hasError) {
+      this.setState({ retryCount: 0 });
+    }
   }
 
   render() {


### PR DESCRIPTION
 What
  - Wrapped NavBar and BottomTabBar in individual ErrorBoundary instances in Layout.tsx. Both components were previously
  unguarded — an uncaught render error in either would propagate to the root boundary and crash the entire app.
    - NavBar fallback: a placeholder <header> that preserves height so layout doesn't jump
    - BottomTabBar fallback: null (mobile-only nav, app remains usable without it)
  - Fixed an infinite retry loop in ErrorBoundary: clicking "Try again" after a persistent error (e.g. a failed lazy
  chunk load) would reset state, re-trigger the same error, and repeat indefinitely. After 3 retries the button now
  becomes "Reload page".
  - Fixed a related null fallback bug: fallback ?? default treated fallback={null} as "no fallback provided" due to
  nullish coalescing. Now uses 'fallback' in this.props to distinguish explicit null from omitted.

  Dependencies
  None

  How to test
  - Temporarily throw inside NavBar or BottomTabBar — the rest of the app should remain functional with the appropriate
  fallback rendered
  - Wrap a broken component in <ErrorBoundary> (no fallback prop) and click "Try again" three times — the button should
  become "Reload page" on the fourth error
  - Pass fallback={null} to ErrorBoundary — nothing should be rendered in the error state

  Checklist
  - [x] TypeScript clean (pre-existing @sentry/react type error unrelated to this change)
  - [x] 611/613 tests pass (2 pre-existing timeouts unrelated to this change)
  - [x] No new dependencies