### PR TITLE
fix(stats): YoY default skips barely-loaded trailing year; cache street-concentration

### DIFF
--- a/backend/app/routers/changes.py
+++ b/backend/app/routers/changes.py
@@ -44,6 +44,30 @@ _MIN_BASELINE: dict[str, int] = {
     "injured": 50,
 }
 
+# A trailing year holding fewer rows than this share of the prior year's is
+# treated as not-yet-loaded (upstream ingest lag), not as a real collapse in
+# crashes. Defaulting the comparison to such a year would rank every county
+# at -100% — the exact small-number noise this endpoint exists to avoid.
+_MIN_COVERAGE_RATIO = 0.2
+
+
+def _default_year(db: Session) -> int:
+    """Latest crash_year with meaningful coverage relative to the year before."""
+    counts = {
+        int(y): int(n)
+        for y, n in db.execute(
+            select(Crash.crash_year, func.count())
+            .where(Crash.crash_year.isnot(None))
+            .group_by(Crash.crash_year)
+        ).all()
+    }
+    if not counts:
+        return datetime.now(timezone.utc).year
+    year = max(counts)
+    while year - 1 in counts and counts[year] < _MIN_COVERAGE_RATIO * counts[year - 1]:
+        year -= 1
+    return year
+
 
 class CountyChange(BaseModel):
     county_code: int
@@ -92,7 +116,7 @@ def compute_yoy_changes(db: Session, metric: str = "crashes", year: int | None =
     function so the API endpoint and the Ask-AI tool share one implementation.
     """
     if year is None:
-        year = db.execute(select(func.max(Crash.crash_year))).scalar() or datetime.now(timezone.utc).year
+        year = _default_year(db)
 
     current_expr, previous_expr = _metric_exprs(metric, year)
 
@@ -147,7 +171,7 @@ def get_yoy_changes(
     request: Request,
     response: Response,
     metric: MetricKey = Query("crashes"),
-    year: int | None = Query(None, ge=2002, le=2100, description="Comparison year; defaults to the latest year with data"),
+    year: int | None = Query(None, ge=2002, le=2100, description="Comparison year; defaults to the latest year with meaningful data coverage"),
     db: Session = Depends(get_db),
 ):
     """Per-county YoY change ranking for a metric — see compute_yoy_changes."""

--- a/backend/app/routers/intersections.py
+++ b/backend/app/routers/intersections.py
@@ -19,6 +19,7 @@ the counts and lets the reader draw conclusions.
 
 from __future__ import annotations
 
+import time
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -211,6 +212,20 @@ def _resolve_county(db: Session, county: str | None) -> int | None:
 # Concentration curve breakpoints: (label, top-percent-of-streets).
 _CONCENTRATION_POINTS = [("Top 1%", 1), ("Top 5%", 5), ("Top 10%", 10), ("Top 25%", 25)]
 
+# The statewide concentration aggregation walks every crash-carrying street
+# (~2.6M units over 11M crashes) and takes ~25s cold, but its result only
+# changes when ETL loads rows. Cache results in-process with a TTL so each
+# backend worker pays the scan at most once per TTL window per argument set,
+# instead of once per visitor.
+_CONCENTRATION_TTL_SECONDS = 6 * 3600
+_CONCENTRATION_CACHE_MAX = 256
+_concentration_cache: dict[tuple, tuple[float, ConcentrationOut]] = {}
+
+
+def clear_concentration_cache() -> None:
+    """Drop all cached concentration results (tests / manual invalidation)."""
+    _concentration_cache.clear()
+
 
 def _concentration(
     db: Session,
@@ -226,8 +241,13 @@ def _concentration(
     Aggregates crashes per street, ranks by severe (fatal+injury) count, and
     reports what share of severe crashes the top 1/5/10/25% of crash-carrying
     streets hold. Computed entirely in SQL (CTE + window functions) so the
-    long tail never has to leave the database.
+    long tail never has to leave the database. Results are cached in-process
+    for _CONCENTRATION_TTL_SECONDS (see note above).
     """
+    cache_key = (by_secondary, county_code, county_name, year_start, year_end)
+    hit = _concentration_cache.get(cache_key)
+    if hit is not None and hit[0] > time.monotonic():
+        return hit[1]
     preds, group_cols = _street_preds_and_groups(
         by_secondary, county_code, year_start, year_end,
     )
@@ -288,7 +308,7 @@ def _concentration(
             )
         )
 
-    return ConcentrationOut(
+    out = ConcentrationOut(
         scope="corridors" if not by_secondary else "intersections",
         county_code=county_code,
         county_name=county_name,
@@ -297,6 +317,12 @@ def _concentration(
         total_severe_crashes=total_severe,
         breakpoints=breakpoints,
     )
+    if len(_concentration_cache) >= _CONCENTRATION_CACHE_MAX:
+        _concentration_cache.clear()
+    _concentration_cache[cache_key] = (
+        time.monotonic() + _CONCENTRATION_TTL_SECONDS, out,
+    )
+    return out
 
 
 @router.get("/intersections", response_model=list[IntersectionOut])

--- a/backend/tests/api/test_intersections.py
+++ b/backend/tests/api/test_intersections.py
@@ -11,8 +11,18 @@ from datetime import datetime
 import pytest
 
 from app.models import Crash
+from app.routers.intersections import clear_concentration_cache
 
 pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _fresh_concentration_cache():
+    """Concentration results are cached in-process; tests seed different data
+    into the same app, so every test starts (and leaves) with a cold cache."""
+    clear_concentration_cache()
+    yield
+    clear_concentration_cache()
 
 
 def _crash(cid, primary, secondary, *, severity="Injury", killed=0, injured=1,
@@ -141,6 +151,25 @@ def test_street_concentration(client, db_session):
     top10 = next(b for b in body["breakpoints"] if b["top_pct"] == 10)
     assert top10["unit_count"] == 1            # ceil(10 * 0.10) = 1
     assert top10["severe_share_pct"] == 100.0  # that 1 street holds all severe
+
+
+def test_street_concentration_cached_until_cleared(client, db_session):
+    """A repeat call within the TTL returns the cached result even after new
+    rows land; clearing the cache picks the new rows up. (The heavy statewide
+    scan must run at most once per TTL window, not once per visitor.)"""
+    cid = 9500
+    db_session.add(_crash(cid, "CACHE ST", "HIT AVE", severity="Injury", injured=1))
+    db_session.flush()
+
+    url = "/api/street-concentration?county=los-angeles&scope=corridors"
+    assert client.get(url).json()["total_units"] == 1
+
+    db_session.add(_crash(cid + 1, "NEW ST", "MISS AVE", severity="Injury", injured=1))
+    db_session.flush()
+    assert client.get(url).json()["total_units"] == 1  # cached
+
+    clear_concentration_cache()
+    assert client.get(url).json()["total_units"] == 2  # recomputed
 
 
 def test_pedestrian_mode_filter(client, db_session):

--- a/backend/tests/api/test_yoy_changes.py
+++ b/backend/tests/api/test_yoy_changes.py
@@ -93,6 +93,27 @@ def test_yoy_solid_baseline_ranks_before_small(client, db_session):
     assert codes.index(38) < codes.index(19)
 
 
+def test_yoy_default_skips_barely_loaded_trailing_year(client, db_session):
+    """A trailing year holding only a sliver of rows (upstream ingest lag) must
+    not be the default comparison year — it would rank every county at -100%."""
+    rows = []
+    cid = 9800
+    for y, n in ((2030, 50), (2031, 2)):
+        for _ in range(n):
+            rows.append(_crash(cid, 19, y))
+            cid += 1
+    db_session.add_all(rows)
+    db_session.flush()
+
+    body = client.get("/api/stats/yoy-changes?metric=crashes").json()
+    assert body["year"] == 2030
+    assert body["partial_year"] is False
+
+    # An explicit request for the sliver year is still honored.
+    body = client.get("/api/stats/yoy-changes?metric=crashes&year=2031").json()
+    assert body["year"] == 2031
+
+
 def test_yoy_ai_tool(db_session, seed_years):
     assert "get_yoy_changes" in TOOL_REGISTRY
     out = get_yoy_changes(db_session, metric="crashes", year=2019, limit=5)


### PR DESCRIPTION
## What does this PR do?

Fixes the two defects found while verifying #349 against prod:

**1. YoY panel led with a wall of −100% rows.** `/api/stats/yoy-changes` defaulted to `max(crash_year)` = 2026, which currently holds only ~487 statewide rows (ingest lag). Every county with zero 2026 rows ranked as a −100% 'biggest change'. The default year now steps back past trailing years holding under 20% of the prior year's row count, so today it compares 2024 → 2025. Explicit `?year=` requests (including 2026) behave exactly as before, with the existing `partial_year` flag.

**2. Statewide street-concentration cost ~25s per cold request.** The Stats page fires it for every visitor and Cloudflare doesn't cache JSON by default. `_concentration` results now sit in a 6h in-process TTL cache (endpoint + AI tool share it), with `clear_concentration_cache()` for invalidation/tests. First request per worker still pays the scan — the durable fix is an ETL-time precompute, noted in the DB-optimization tracker #310.

## How to test
- [x] TDD: new failing tests written first (`test_yoy_default_skips_barely_loaded_trailing_year`, `test_street_concentration_cached_until_cleared`), then the fixes.
- [x] Full backend suite: 725 passed; ruff clean.
- [ ] Post-deploy: `/api/stats/yoy-changes?metric=crashes` should return `year: 2025`, and a second `/api/street-concentration?scope=intersections` request should return in milliseconds.

## Checklist
- [x] Code builds without errors
- [x] Tested locally
- [x] No other PRs need to merge before this one