### PR TITLE
fix(etl): single-source EtlRun tracking + loud partial failures + naive UTC (M-B8/B9/B12)

### DIFF
--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -32,7 +32,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.cities_match import normalize_name
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
-from app.models import City, Crash, EtlRun
+from app.models import City, Crash
 
 logging.basicConfig(
     level=logging.INFO,
@@ -270,18 +270,12 @@ def run(
     if loaded:
         logger.info("Years already loaded: %s", {y: f"{c:,}" for y, c in sorted(loaded.items())})
 
-    # Create an EtlRun record to track this run
-    etl_run = EtlRun(
-        source="ccrs",
-        status="running",
-        started_at=datetime.now(timezone.utc).replace(tzinfo=None),
-    )
-    db.add(etl_run)
-    db.commit()
-    logger.info("Created EtlRun id=%d", etl_run.id)
-
+    # No self-tracking EtlRun here: the orchestrator's run_job is the single
+    # source of truth for etl_runs (source = the job name, e.g. crashes_ccrs).
+    # A row created here (source="ccrs") was a phantom /api/freshness source and
+    # double-counted run history (M-B8). Batch failures are surfaced by exiting
+    # non-zero, which run_job records as an error.
     total_rows = 0
-    error_message = None
 
     try:
         # Partition years into SWITRS vs CCRS and drop already-loaded years
@@ -380,23 +374,14 @@ def run(
         # Summary
         logger.info("Done. %d total rows upserted, %d batches failed.", total_rows, failed_batches)
 
-        etl_run.status = "partial_success" if failed_batches > 0 else "success"
-        etl_run.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
-        etl_run.rows_loaded = total_rows
+        # Surface partial failures loudly: exit non-zero so the orchestrator
+        # records the job as errored instead of a silent green run.
         if failed_batches > 0:
-            etl_run.error_message = f"{failed_batches} batch(es) failed during load"
-        db.commit()
+            logger.error("%d batch(es) failed during load", failed_batches)
+            sys.exit(1)
 
     except Exception as exc:
-        error_message = str(exc)
         logger.error("ETL run failed: %s", exc)
-        try:
-            etl_run.status = "error"
-            etl_run.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
-            etl_run.error_message = error_message
-            db.commit()
-        except Exception:
-            db.rollback()
         sys.exit(1)
 
     finally:

--- a/backend/etl/load_parties_victims.py
+++ b/backend/etl/load_parties_victims.py
@@ -28,6 +28,7 @@ Usage:
 import argparse
 import gc
 import logging
+import sys
 import time
 from datetime import datetime
 
@@ -36,7 +37,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import CrashParty, CrashVictim
-from etl._utils import etl_run
 
 logging.basicConfig(
     level=logging.INFO,
@@ -214,11 +214,17 @@ def load_table(
     end_year: int,
     force: bool,
 ):
-    """Generic loader for parties or victims."""
+    """Generic loader for parties or victims.
+
+    Returns True if any page fetch failed (a partial load). Callers must treat
+    this as a failure — otherwise a truncated load records a silent success
+    (M-B9).
+    """
     db = SessionLocal()
 
     try:
         total_rows = 0
+        had_failure = False
 
         for year in range(start_year, end_year + 1):
             if year not in resource_ids:
@@ -235,6 +241,7 @@ def load_table(
                     result = _fetch_page(resource_id, offset)
                 except Exception as exc:
                     logger.error("%s year %d failed at offset %d: %s", table_type, year, offset, exc)
+                    had_failure = True
                     break
 
                 total = result["total"]
@@ -288,6 +295,7 @@ def load_table(
             db.expunge_all()
 
         logger.info("Done. %d total %s records upserted.", total_rows, table_type)
+        return had_failure
 
     finally:
         db.close()
@@ -299,7 +307,13 @@ def run(
     table: str | None = None,
     force: bool = False,
 ):
-    """Main entry point."""
+    """Main entry point.
+
+    No self-tracking EtlRun here: the orchestrator's run_job owns the etl_runs
+    row (source = the job name, "parties" / "victims"). Tracking it again here
+    double-counted run history (M-B8). A partial load exits non-zero so run_job
+    records an error instead of a silent success (M-B9).
+    """
     source_name = table if table in ("parties", "victims") else "parties_victims"
 
     eff_start = effective_start_year(start_year, force, datetime.now().year)
@@ -310,34 +324,38 @@ def run(
         start_year,
     )
 
-    with etl_run(source_name):
-        if table is None or table == "parties":
-            load_table(
-                table_type="parties",
-                resource_ids=PARTIES_RESOURCE_IDS,
-                model_class=CrashParty,
-                transform_fn=transform_party,
-                upsert_cols=_PARTY_UPSERT_COLS,
-                constraint_name="uq_parties_party_source",
-                id_field="party_id",
-                start_year=eff_start,
-                end_year=end_year,
-                force=force,
-            )
+    had_failure = False
+    if table is None or table == "parties":
+        had_failure |= load_table(
+            table_type="parties",
+            resource_ids=PARTIES_RESOURCE_IDS,
+            model_class=CrashParty,
+            transform_fn=transform_party,
+            upsert_cols=_PARTY_UPSERT_COLS,
+            constraint_name="uq_parties_party_source",
+            id_field="party_id",
+            start_year=eff_start,
+            end_year=end_year,
+            force=force,
+        )
 
-        if table is None or table == "victims":
-            load_table(
-                table_type="victims",
-                resource_ids=VICTIMS_RESOURCE_IDS,
-                model_class=CrashVictim,
-                transform_fn=transform_victim,
-                upsert_cols=_VICTIM_UPSERT_COLS,
-                constraint_name="uq_victims_victim_source",
-                id_field="victim_id",
-                start_year=eff_start,
-                end_year=end_year,
-                force=force,
-            )
+    if table is None or table == "victims":
+        had_failure |= load_table(
+            table_type="victims",
+            resource_ids=VICTIMS_RESOURCE_IDS,
+            model_class=CrashVictim,
+            transform_fn=transform_victim,
+            upsert_cols=_VICTIM_UPSERT_COLS,
+            constraint_name="uq_victims_victim_source",
+            id_field="victim_id",
+            start_year=eff_start,
+            end_year=end_year,
+            force=force,
+        )
+
+    if had_failure:
+        logger.error("Partial load: one or more page fetches failed")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 SourceType = Literal["ckan", "arcgis", "federal", "none"]
 
 
+def _utc_now() -> datetime:
+    """Naive UTC 'now'. EtlRun.started_at/finished_at are naive DateTime columns,
+    so writing tz-aware values makes staleness math offset-dependent on non-UTC
+    servers. Match the rest of the ETL code, which stores naive UTC (M-B12)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 @dataclass
 class Job:
     name: str
@@ -165,8 +172,8 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
             record = EtlRun(
                 source=job.name,
                 status="skipped_unchanged",
-                started_at=datetime.now(timezone.utc),
-                finished_at=datetime.now(timezone.utc),
+                started_at=_utc_now(),
+                finished_at=_utc_now(),
                 triggered_by=triggered_by,
                 error_message=freshness.reason,
                 validation_status="skipped",
@@ -185,7 +192,7 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
     record = EtlRun(
         source=job.name,
         status="running",
-        started_at=datetime.now(timezone.utc),
+        started_at=_utc_now(),
         triggered_by=triggered_by,
         rows_before=rows_before,
     )
@@ -227,14 +234,14 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
             record.validation_status = val_status
             record.diff_summary = diff_summary
 
-        record.finished_at = datetime.now(timezone.utc)
+        record.finished_at = _utc_now()
         db.commit()
         logger.info("Job %s finished in %.1fs (status=%s)", job.name, elapsed, record.status)
 
     except subprocess.TimeoutExpired:
         record.status = "error"
         record.error_message = f"Job timed out after {job.timeout}s"
-        record.finished_at = datetime.now(timezone.utc)
+        record.finished_at = _utc_now()
         record.validation_status = "skipped"
         db.commit()
         logger.error("Job %s timed out", job.name)
@@ -242,7 +249,7 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
     except Exception as exc:
         record.status = "error"
         record.error_message = str(exc)[:2000]
-        record.finished_at = datetime.now(timezone.utc)
+        record.finished_at = _utc_now()
         record.validation_status = "skipped"
         db.commit()
         logger.exception("Job %s failed unexpectedly", job.name)
@@ -263,14 +270,14 @@ def _cleanup_zombie_runs() -> int:
             db.query(EtlRun)
             .filter(
                 EtlRun.status == "running",
-                EtlRun.started_at < datetime.now(timezone.utc) - timedelta(hours=1),
+                EtlRun.started_at < _utc_now() - timedelta(hours=1),
             )
             .all()
         )
         for z in zombies:
             z.status = "error"
             z.error_message = "Zombie cleanup: process was killed or never finished"
-            z.finished_at = datetime.now(timezone.utc)
+            z.finished_at = _utc_now()
         db.commit()
         if zombies:
             logger.info("Cleaned up %d zombie etl_runs", len(zombies))
@@ -360,8 +367,8 @@ def _run_pipeline_locked(
             record = EtlRun(
                 source=job.name,
                 status="skipped",
-                started_at=datetime.now(timezone.utc),
-                finished_at=datetime.now(timezone.utc),
+                started_at=_utc_now(),
+                finished_at=_utc_now(),
                 triggered_by=triggered_by,
                 error_message=f"Blocked by failed deps: {', '.join(blocked_by)}",
                 validation_status="skipped",
@@ -386,8 +393,8 @@ def _run_pipeline_locked(
             record = EtlRun(
                 source=job.name,
                 status="skipped_unchanged",
-                started_at=datetime.now(timezone.utc),
-                finished_at=datetime.now(timezone.utc),
+                started_at=_utc_now(),
+                finished_at=_utc_now(),
                 triggered_by=triggered_by,
                 error_message=f"All dependencies unchanged: {', '.join(job.depends_on)}",
                 validation_status="skipped",

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -118,3 +118,28 @@ class TestSelectYearsToLoad:
         )
         assert 2026 in ccrs and 2027 in ccrs
         assert 2025 in skipped
+
+
+class TestNoSelfTracking:
+    """M-B8: load_crashes must not create its own EtlRun row. The orchestrator's
+    run_job is the single tracker; a self-created row (source='ccrs') is a phantom
+    source in /api/freshness and double-counts run history."""
+
+    def test_run_does_not_construct_an_etl_run(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from etl import load_crashes as mod
+
+        etl_run_ctor = MagicMock()
+        # raising=False: the loader no longer imports EtlRun at all, which is
+        # exactly the fix — if it ever references mod.EtlRun again this mock
+        # would catch it.
+        monkeypatch.setattr(mod, "EtlRun", etl_run_ctor, raising=False)
+        monkeypatch.setattr(mod, "SessionLocal", lambda: MagicMock())
+        monkeypatch.setattr(mod, "build_city_lookup", lambda db: {})
+        monkeypatch.setattr(mod, "get_loaded_years", lambda db: {})
+        # No years to load → run() does only bookkeeping, no network.
+        monkeypatch.setattr(mod, "select_years_to_load", lambda *a, **k: ([], [], []))
+
+        mod.run(start_year=2016, end_year=2016, source_filter="ccrs")
+
+        etl_run_ctor.assert_not_called()

--- a/backend/tests/test_load_parties_victims.py
+++ b/backend/tests/test_load_parties_victims.py
@@ -1,5 +1,7 @@
 """Tests for the parties & victims ETL transform functions."""
 
+import pytest
+
 from etl.load_parties_victims import (
     transform_party,
     transform_victim,
@@ -218,3 +220,59 @@ class TestLoadTableMemoryCleanup:
             f"gc.collect() should fire per batch (expected >=2, got {len(gc_calls)})"
         )
         fake_db.expunge_all.assert_called()
+
+
+class TestPartialFailureIsLoud:
+    """M-B9: a page-fetch failure must not be recorded as a silent success."""
+
+    def test_load_table_reports_failure_when_a_page_fetch_raises(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from etl import load_parties_victims as mod
+
+        def boom(_rid, _off):
+            raise RuntimeError("CKAN 500")
+
+        monkeypatch.setattr(mod, "_fetch_page", boom)
+        monkeypatch.setattr(mod, "SessionLocal", lambda: MagicMock())
+
+        had_failure = mod.load_table(
+            table_type="parties",
+            resource_ids={2026: "fake-id"},
+            model_class=MagicMock(),
+            transform_fn=mod.transform_party,
+            upsert_cols=["collision_id"],
+            constraint_name="uq_parties_party_source",
+            id_field="party_id",
+            start_year=2026,
+            end_year=2026,
+            force=False,
+        )
+
+        assert had_failure is True
+
+    def test_run_exits_nonzero_when_a_table_had_a_fetch_failure(self, monkeypatch):
+        from etl import load_parties_victims as mod
+
+        monkeypatch.setattr(mod, "load_table", lambda **kw: True)
+
+        with pytest.raises(SystemExit) as exc:
+            mod.run(table="parties")
+
+        assert exc.value.code != 0
+
+
+class TestNoSelfTracking:
+    """M-B8: the orchestrator owns EtlRun; the loader must not create its own
+    (double-tracking that inflates run history + phantom /api/freshness sources)."""
+
+    def test_run_does_not_open_its_own_etl_run(self, monkeypatch):
+        from etl import load_parties_victims as mod
+
+        calls = []
+        monkeypatch.setattr(mod, "load_table", lambda **kw: calls.append(kw["table_type"]) or False)
+
+        assert not hasattr(mod, "etl_run"), (
+            "loader should not self-track EtlRun; run_job is the single source of truth"
+        )
+        mod.run(table="victims")
+        assert calls == ["victims"]

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -166,6 +166,55 @@ def test_table_row_count_rejects_bad_identifier():
     assert _table_row_count(_FakeDB([]), None) is None
 
 
+class _FakeSession:
+    """Minimal Session stand-in for run_job: collects added rows, serves COUNTs."""
+
+    def __init__(self, counts=None):
+        self.added = []
+        self._counts = list(counts or [])
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def expunge(self, obj):
+        pass
+
+    def close(self):
+        pass
+
+    def execute(self, *_args, **_kwargs):
+        return _FakeResult(self._counts.pop(0) if self._counts else 0)
+
+
+def test_run_job_writes_naive_utc_timestamps(monkeypatch):
+    """EtlRun.started_at/finished_at are naive DateTime columns; the orchestrator
+    must write naive UTC (not tz-aware) or staleness math goes offset-dependent
+    on non-UTC servers (M-B12)."""
+    import types
+
+    from etl import orchestrator
+
+    job = Job(name="x", module="etl.x", table_name=None, source_type="none")
+    fake = _FakeSession()
+    monkeypatch.setattr(orchestrator, "SessionLocal", lambda: fake)
+    monkeypatch.setattr(
+        orchestrator.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    record = orchestrator.run_job(job, force_refresh=True)
+
+    assert record.started_at.tzinfo is None
+    assert record.finished_at.tzinfo is None
+
+
 def test_cli_dry_run():
     result = subprocess.run(
         [sys.executable, "-m", "etl.run_all", "--dry-run"],


### PR DESCRIPTION
Audit medium findings from `docs/audit-2026-07-01.md`, the `etl_runs` integrity cluster.

## What & why

**M-B8 — double-tracking / phantom freshness sources.** The crash and parties/victims loaders each created their *own* `EtlRun` row on top of the one the orchestrator's `run_job` already writes for every production invocation (`run_all → run_job → subprocess`). The self-created rows used inconsistent `source` names:
- `load_crashes` wrote `source="ccrs"` — a phantom source in `/api/freshness` (which groups by `EtlRun.source`); no job is named `ccrs` (jobs are `crashes_ccrs` / `crashes_switrs`), and it was hardcoded even when loading SWITRS years.
- `load_parties_victims` wrote `source="parties"`/`"victims"`/`"parties_victims"` — double-counting run history against the real `parties`/`victims` job rows.

`run_job` is now the single source of truth (it already tracks status, `rows_before`/`rows_after`, validation, and freshness). The loaders no longer self-track.

**M-B9 — silent partial success.** A page-fetch failure in the parties/victims loader `break`s the loop but the run still recorded success (`rows_loaded` unset). `load_table` now returns whether any page failed; `run()` exits non-zero on a partial load so `run_job` records an **error** instead of a silent green run. `load_crashes` likewise exits non-zero when batches fail (previously only reflected in its now-removed self-tracked row).

**M-B12 — timezone mixing.** `run_job` wrote tz-aware `datetime.now(timezone.utc)` into `EtlRun`'s **naive** `DateTime` columns, making staleness math offset-dependent on non-UTC servers. Added `_utc_now()` and use naive UTC consistently (matching `_utils.etl_run` and the rest of the ETL).

## Tests
- `test_run_job_writes_naive_utc_timestamps` — asserts `started_at`/`finished_at` are naive.
- `test_load_table_reports_failure_when_a_page_fetch_raises` + `test_run_exits_nonzero_when_a_table_had_a_fetch_failure`.
- No-self-tracking tests for both loaders.

488 backend unit tests pass; ruff clean. API/integration tests (need Postgres) not run locally — no API-router code changed; CI covers them.

## Deferred (assessed, not in this PR)
- **M-B10** — pg_dump password-on-cmdline was already fixed Wave-1 (`pipeline.run_backup` delegates to `etl/backup.py`). Scheduler/backup dedup is entangled with **M-I8** (four overlapping scheduling mechanisms); prod runs `python -m etl.pipeline`, so `etl/scheduler.py` looks dead, but retiring it + the systemd unit + cron is a prod-topology decision.
- **M-B11** — cross-worker in-memory state (rate limits 4×, cooldowns/cache quartered across 4 gunicorn workers) needs an infra decision (Redis vs DB-backed limiter vs single-worker).