### PR TITLE
fix(a11y): keyboard bars, dialog focus trap, segmented-control semantics (M-F16/F17/F18)

### DIFF
--- a/frontend/src/components/ask/StoryCanvasPanel.test.tsx
+++ b/frontend/src/components/ask/StoryCanvasPanel.test.tsx
@@ -157,6 +157,26 @@ describe("StoryCanvasPanel", () => {
     });
   });
 
+  describe("focus trap", () => {
+    it("wraps Tab from the last focusable back to the first", () => {
+      wrap(<Harness open onClose={() => {}} />);
+      const dialog = screen.getByRole("dialog");
+      const focusables = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      expect(focusables.length).toBeGreaterThan(1);
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      act(() => { last.focus(); });
+      fireEvent.keyDown(dialog, { key: "Tab" });
+
+      expect(document.activeElement).toBe(first);
+    });
+  });
+
   describe("focus return on close", () => {
     it("returns focus to the trigger element when the panel is closed", () => {
       function FocusHarness() {

--- a/frontend/src/components/ask/StoryCanvasPanel.tsx
+++ b/frontend/src/components/ask/StoryCanvasPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import { useStoryCanvas } from "../../hooks/useStoryCanvas";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import InlineChart from "./InlineChart";
 
 interface Props {
@@ -16,28 +17,10 @@ export default function StoryCanvasPanel({ open, onClose, onExportPng, onExportP
     title, blocks, count, setTitle, addNote, updateNote, moveBlock, removeBlock, clear,
   } = useStoryCanvas();
   const panelRef = useRef<HTMLDivElement>(null);
-  const returnFocusRef = useRef<HTMLElement | null>(null);
 
-  // Capture the focused element before opening; restore it when closing.
-  // Combined into one [open] effect to guarantee capture happens before panel steals focus.
-  useEffect(() => {
-    if (open) {
-      returnFocusRef.current = document.activeElement as HTMLElement | null;
-      panelRef.current?.focus();
-    } else {
-      returnFocusRef.current?.focus();
-    }
-  }, [open]);
-
-  // Escape closes. On the document (not the dialog div) to avoid attaching a
-  // key handler to a non-interactive element (jsx-a11y) and to catch the key
-  // regardless of where focus sits inside the panel.
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  // Make the aria-modal dialog actually modal: trap Tab focus, restore focus on
+  // close, and close on Escape (shared with AiCompanion via the hook).
+  useFocusTrap(panelRef, open, onClose);
 
   if (!open) return null;
 

--- a/frontend/src/components/charts/SimpleBarChart.test.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.test.tsx
@@ -1,0 +1,90 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import { ThemeProvider } from "../../context/ThemeContext";
+import SimpleBarChart from "./SimpleBarChart";
+
+const render = (ui: ReactNode) =>
+  rtlRender(
+    <ThemeProvider>
+      <CustomThemeProvider>{ui}</CustomThemeProvider>
+    </ThemeProvider>,
+  );
+
+// jsdom lacks these; SimpleBarChart reads matchMedia (reduced-motion) and
+// observes its size on mount.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+globalThis.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+const data = [
+  { label: "Mon", value: 10 },
+  { label: "Tue", value: 20 },
+];
+
+beforeEach(() => cleanup());
+
+describe("SimpleBarChart keyboard accessibility", () => {
+  it("exposes clickable bars as focusable buttons with a data label", () => {
+    render(<SimpleBarChart data={data} onBarClick={() => {}} />);
+    const bars = screen.getAllByRole("button");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("button", { name: /Mon: 10/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Tue: 20/ })).toBeInTheDocument();
+  });
+
+  it("activates a bar with Enter and Space", () => {
+    const onBarClick = vi.fn();
+    render(<SimpleBarChart data={data} onBarClick={onBarClick} />);
+    const bars = screen.getAllByRole("button");
+
+    fireEvent.keyDown(bars[1], { key: "Enter" });
+    expect(onBarClick).toHaveBeenCalledWith(data[1], 1);
+
+    fireEvent.keyDown(bars[0], { key: " " });
+    expect(onBarClick).toHaveBeenCalledWith(data[0], 0);
+    expect(onBarClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not make bars interactive when there is no click handler", () => {
+    render(<SimpleBarChart data={data} />);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("supports the same keyboard affordance in horizontal layout", () => {
+    const onBarClick = vi.fn();
+    render(<SimpleBarChart data={data} layout="horizontal" onBarClick={onBarClick} />);
+    const bars = screen.getAllByRole("button");
+    expect(bars).toHaveLength(2);
+    fireEvent.keyDown(bars[0], { key: "Enter" });
+    expect(onBarClick).toHaveBeenCalledWith(data[0], 0);
+  });
+});

--- a/frontend/src/components/charts/SimpleBarChart.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.tsx
@@ -27,6 +27,8 @@ interface SimpleBarChartProps {
   title?: string;
   onBarClick?: (item: BarItem, idx: number) => void;
   getHighlight?: (item: BarItem, idx: number) => BarHighlight;
+  /** Accessible name for a clickable bar. Defaults to "label: value". */
+  barLabel?: (item: BarItem, idx: number) => string;
 }
 
 export default function SimpleBarChart({
@@ -43,6 +45,7 @@ export default function SimpleBarChart({
   title,
   onBarClick,
   getHighlight,
+  barLabel,
 }: SimpleBarChartProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
@@ -76,6 +79,29 @@ export default function SimpleBarChart({
     const idx = Math.max(0, Math.min(n - 1, Math.floor((touchX - padL) / slotW)));
     setHover({ idx, x: e.touches[0].clientX, y: e.touches[0].clientY });
   }, [data.length]);
+
+  // Keyboard/AT affordance for clickable bars: without this the drill-down /
+  // cross-filter is mouse-only (M-F16). When there's no click handler the bars
+  // stay decorative inside the chart's role="img".
+  const barButtonProps = (d: BarItem, i: number) =>
+    onBarClick
+      ? ({
+          role: "button",
+          tabIndex: 0,
+          "aria-label": barLabel ? barLabel(d, i) : `${d.label}: ${d.value.toLocaleString()}`,
+          onKeyDown: (e: React.KeyboardEvent<SVGRectElement>) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onBarClick(d, i);
+            }
+          },
+          onFocus: (e: React.FocusEvent<SVGRectElement>) => {
+            const r = e.currentTarget.getBoundingClientRect();
+            setHover({ idx: i, x: r.left + r.width / 2, y: r.top });
+          },
+          onBlur: () => setHover(null),
+        } as const)
+      : {};
 
   if (!data.length) return null;
   const rawMax = Math.max(...data.map((d) => d.value), 1);
@@ -123,6 +149,7 @@ export default function SimpleBarChart({
                   onClick={() => onBarClick?.(d, i)}
                   className="cursor-pointer"
                   style={{ transition: "opacity 0.15s ease" }}
+                  {...barButtonProps(d, i)}
                 />
               </g>
             );
@@ -189,6 +216,7 @@ export default function SimpleBarChart({
                 onMouseLeave={() => setHover(null)}
                 onClick={() => onBarClick?.(d, i)}
                 className="cursor-pointer"
+                {...barButtonProps(d, i)}
               />
               {showXAxis && (() => {
                 const skipInterval = slotW < 28 ? Math.ceil(28 / slotW) : 1;

--- a/frontend/src/components/map/LayersPanel.test.tsx
+++ b/frontend/src/components/map/LayersPanel.test.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { LayersStateProvider, useLayersState } from "../../hooks/useLayersState";
 import { CustomThemeProvider } from "../../context/CustomThemeContext";
 import { ThemeProvider } from "../../context/ThemeContext";
@@ -82,6 +82,41 @@ describe("LayersPanel toggle accessibility", () => {
     const choropleth = screen.getByRole("switch", { name: "Shade by Measure" });
     expect(choropleth).toHaveAttribute("aria-checked", "false");
     expect(choropleth).not.toHaveAttribute("aria-disabled");
+  });
+});
+
+// ── Single-select segmented controls (M-F18) ──────────────────────────
+// These groups previously conveyed the active choice by background colour
+// only, with no group semantics or pressed state for assistive tech.
+
+describe("LayersPanel segmented-control accessibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("names the Measure group and marks the active option pressed", () => {
+    render(<Harness />);
+    const group = screen.getByRole("group", { name: /measure/i });
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
+
+    const unpressed = within(group).getAllByRole("button", { pressed: false })[0];
+    fireEvent.click(unpressed);
+    expect(unpressed).toHaveAttribute("aria-pressed", "true");
+    // Still exactly one selected.
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
+  });
+
+  it("names the Color palette group and marks the active swatch pressed", () => {
+    render(<Harness />);
+    const group = screen.getByRole("group", { name: /palette/i });
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
+  });
+
+  it("exposes the heatmap Resolution group once the statewide layer is on", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("switch", { name: "Statewide" }));
+    const group = screen.getByRole("group", { name: /resolution/i });
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
   });
 });
 

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -167,7 +167,7 @@ export default function LayersPanel() {
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
                 Resolution
               </span>
-              <div className="flex gap-1.5">
+              <div className="flex gap-1.5" role="group" aria-label="Heatmap resolution">
                 {([
                   { key: "low" as const, label: "Low" },
                   { key: "medium" as const, label: "Medium" },
@@ -175,6 +175,7 @@ export default function LayersPanel() {
                   <button
                     key={key}
                     onClick={() => setHeatmapResolution(key)}
+                    aria-pressed={heatmapResolution === key}
                     className={`px-2.5 py-1 rounded-md text-[11px] font-semibold transition-colors ${
                       heatmapResolution === key
                         ? "bg-primary text-on-primary"
@@ -247,11 +248,12 @@ export default function LayersPanel() {
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
                 Color By
               </span>
-              <div className="flex flex-wrap gap-1.5">
+              <div className="flex flex-wrap gap-1.5" role="group" aria-label="Highway color metric">
                 {HIGHWAY_METRICS.map(({ key, label }) => (
                   <button
                     key={key}
                     onClick={() => setHighwayMetric(key)}
+                    aria-pressed={highwayMetric === key}
                     className={`px-2.5 py-1 rounded-md text-[11px] font-semibold transition-colors ${
                       highwayMetric === key
                         ? "bg-primary text-on-primary"
@@ -303,13 +305,14 @@ export default function LayersPanel() {
         <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
           Measure
         </span>
-        <div className="space-y-2">
+        <div className="space-y-2" role="group" aria-label="Measure">
           {Object.values(MEASURES).map((m) => {
             const active = measure === m.key;
             return (
               <button
                 key={m.key}
                 onClick={() => setMeasure(m.key)}
+                aria-pressed={active}
                 className="flex items-center gap-3 w-full text-left cursor-pointer"
               >
                 <span className={`w-4 h-4 rounded-full flex-shrink-0 flex items-center justify-center transition-colors ${
@@ -332,11 +335,12 @@ export default function LayersPanel() {
         <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
           Color Palette
         </span>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3" role="group" aria-label="Color palette">
           {(Object.keys(PALETTES) as PaletteKey[]).map((key) => (
             <button
               key={key}
               onClick={() => setPalette(key)}
+              aria-pressed={activePalette === key}
               className={`p-2 rounded-xl text-left transition-all ${
                 activePalette === key ? "bg-primary-container" : "hover:bg-surface-container"
               }`}

--- a/frontend/src/hooks/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,69 @@
+import { useRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+import { useFocusTrap } from "./useFocusTrap";
+
+function Dialog({ active, onClose }: { active: boolean; onClose: () => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, active, onClose);
+  if (!active) return null;
+  return (
+    <div ref={ref} role="dialog" aria-modal="true" tabIndex={-1}>
+      <button>first</button>
+      <button>middle</button>
+      <button>last</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe("useFocusTrap", () => {
+  it("moves focus into the dialog when it activates", () => {
+    render(<Dialog active onClose={() => {}} />);
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+  });
+
+  it("wraps Tab from the last focusable back to the first", () => {
+    render(<Dialog active onClose={() => {}} />);
+    const dialog = screen.getByRole("dialog");
+    act(() => { screen.getByText("last").focus(); });
+
+    fireEvent.keyDown(dialog, { key: "Tab" });
+
+    expect(document.activeElement).toBe(screen.getByText("first"));
+  });
+
+  it("wraps Shift+Tab from the first focusable back to the last", () => {
+    render(<Dialog active onClose={() => {}} />);
+    const dialog = screen.getByRole("dialog");
+    act(() => { screen.getByText("first").focus(); });
+
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByText("last"));
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = vi.fn();
+    render(<Dialog active onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("restores focus to the element focused before activation", () => {
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    act(() => { outside.focus(); });
+
+    const { rerender } = render(<Dialog active={false} onClose={() => {}} />);
+    rerender(<Dialog active onClose={() => {}} />);
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+
+    rerender(<Dialog active={false} onClose={() => {}} />);
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,70 @@
+import { useEffect, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Make an `aria-modal` dialog behave modally: while `active`, trap keyboard
+ * focus inside `ref`, close on Escape, and restore focus to whatever was
+ * focused before it opened.
+ *
+ * This is the canonical trap first written inline in AiCompanion — extracted so
+ * other dialogs (StoryCanvasPanel, …) don't reimplement it and drift. The Tab
+ * handler is a native listener on the dialog node (not a JSX onKeyDown) so it
+ * doesn't trip jsx-a11y's no-noninteractive-element-interactions rule; Escape
+ * lives on the document so it fires wherever focus sits.
+ *
+ * @param ref     the dialog container (rendered while `active`, `tabIndex={-1}`)
+ * @param active  whether the dialog is currently open
+ * @param onClose called when Escape is pressed
+ */
+export function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+  onClose?: () => void,
+) {
+  // Escape → close. Separate effect so a changing `onClose` identity doesn't
+  // re-run the focus capture/restore below (which would steal focus mid-open).
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [active, onClose]);
+
+  // Focus capture + Tab trap + restore.
+  useEffect(() => {
+    if (!active) return;
+    const node = ref.current;
+    const restore = document.activeElement as HTMLElement | null;
+    node?.focus();
+
+    const onTab = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !node) return;
+      const focusables = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) {
+        // Nothing to move to — keep focus on the dialog itself.
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const activeEl = document.activeElement;
+      if (e.shiftKey && (activeEl === first || activeEl === node)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && activeEl === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    node?.addEventListener("keydown", onTab);
+    return () => {
+      node?.removeEventListener("keydown", onTab);
+      restore?.focus?.();
+    };
+  }, [active, ref]);
+}

--- a/frontend/tests/a11y-focus-trap.spec.ts
+++ b/frontend/tests/a11y-focus-trap.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = "http://localhost:5174";
+
+// Real-browser verification of the Story Canvas focus trap (audit M-F17).
+// jsdom can't move focus on a real Tab keypress, so the unit tests only prove
+// the handler logic; this drives actual Tab / Shift+Tab / Escape in Chromium.
+// Hermetic: the Story Canvas is pure client state, so no backend/AI is needed.
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+test("Story Canvas traps Tab focus inside the dialog and closes on Escape", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("calsight-intro-seen", "1");
+    localStorage.setItem("calsight-insight-seen", "1");
+  });
+
+  await page.goto(`${BASE_URL}/ask`);
+  await page.getByRole("button", { name: /open story canvas/i }).click();
+
+  const dialog = page.getByRole("dialog", { name: /story/i });
+  await expect(dialog).toBeVisible();
+
+  // Add a note so the dialog has several focusable controls to cycle through.
+  await page.getByRole("button", { name: "+ Add note" }).click();
+
+  const focusables = dialog.locator(FOCUSABLE);
+  const count = await focusables.count();
+  expect(count).toBeGreaterThan(1);
+  const first = focusables.first();
+  const last = focusables.last();
+
+  // Tab from the last focusable wraps back to the first.
+  await last.focus();
+  await page.keyboard.press("Tab");
+  await expect(first).toBeFocused();
+
+  // Shift+Tab from the first wraps to the last.
+  await first.focus();
+  await page.keyboard.press("Shift+Tab");
+  await expect(last).toBeFocused();
+
+  // Tabbing forward many times never escapes the dialog.
+  for (let i = 0; i < count + 3; i++) await page.keyboard.press("Tab");
+  const stillTrapped = await page.evaluate(
+    () => document.activeElement?.closest('[role="dialog"]') != null,
+  );
+  expect(stillTrapped).toBe(true);
+
+  // Escape closes it.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});


### PR DESCRIPTION
Audit accessibility mediums from `docs/audit-2026-07-01.md` — the cluster that contradicts the README's accessibility claim. Each fix is TDD'd.

## M-F16 — chart drill-down was mouse-only
`SimpleBarChart` bar `<rect>`s had `onClick` but no `tabIndex`/`role`/key handler, so keyboard and AT users couldn't drill down or cross-filter. Clickable bars are now `role="button"`, `tabIndex=0`, carry an `aria-label` (`"label: value"`, overridable via a new `barLabel` prop), activate on **Enter/Space**, and reveal the tooltip on focus. Bars with no click handler stay decorative inside the chart's `role="img"`.

## M-F17 — StoryCanvasPanel claimed `aria-modal` but didn't trap focus
Tab escaped to the page behind the dialog. Extracted the canonical trap already living inline in `AiCompanion` into a shared **`useFocusTrap`** hook (capture + restore focus, Escape-to-close, Tab/Shift+Tab wrap) and wired `StoryCanvasPanel` to it. Per the "don't rewrite working code" guideline, `AiCompanion` is left untouched — it can adopt the hook in a follow-up.

## M-F18 — segmented controls conveyed selection by colour only
The Resolution, Highway "Color By", Measure, and Color-palette groups showed the active option with a background colour and nothing announced to AT. Each group is now `role="group"` + `aria-label`, and each option carries `aria-pressed`. Chose **toggle-button** semantics over `radiogroup` deliberately: the buttons keep their existing per-button Tab order and Enter/Space activation, avoiding a half-implemented roving-tabindex radio pattern that would mislead AT.

## Tests
- `useFocusTrap`: focus moves in on activate, Tab wraps both directions, Escape closes, focus restores on deactivate.
- `SimpleBarChart`: focusable buttons + labels, Enter/Space activation, both layouts, and the non-interactive case.
- `StoryCanvasPanel`: Tab-trap integration (existing Escape + focus-return tests still pass, now via the hook).
- `LayersPanel`: group name + single `aria-pressed` option for Measure, palette, and (after enabling Statewide) Resolution.

**626 frontend tests pass; `tsc -b` and eslint clean.** Independent of #353 (that PR is backend-only).