### PR TITLE
Audit P2 mediums: etl_runs integrity (M-B8/B9/B12) + a11y (M-F16/F17/F18)

### DIFF
--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -32,7 +32,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.cities_match import normalize_name
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
-from app.models import City, Crash, EtlRun
+from app.models import City, Crash
 
 logging.basicConfig(
     level=logging.INFO,
@@ -270,18 +270,12 @@ def run(
     if loaded:
         logger.info("Years already loaded: %s", {y: f"{c:,}" for y, c in sorted(loaded.items())})
 
-    # Create an EtlRun record to track this run
-    etl_run = EtlRun(
-        source="ccrs",
-        status="running",
-        started_at=datetime.now(timezone.utc).replace(tzinfo=None),
-    )
-    db.add(etl_run)
-    db.commit()
-    logger.info("Created EtlRun id=%d", etl_run.id)
-
+    # No self-tracking EtlRun here: the orchestrator's run_job is the single
+    # source of truth for etl_runs (source = the job name, e.g. crashes_ccrs).
+    # A row created here (source="ccrs") was a phantom /api/freshness source and
+    # double-counted run history (M-B8). Batch failures are surfaced by exiting
+    # non-zero, which run_job records as an error.
     total_rows = 0
-    error_message = None
 
     try:
         # Partition years into SWITRS vs CCRS and drop already-loaded years
@@ -380,23 +374,14 @@ def run(
         # Summary
         logger.info("Done. %d total rows upserted, %d batches failed.", total_rows, failed_batches)
 
-        etl_run.status = "partial_success" if failed_batches > 0 else "success"
-        etl_run.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
-        etl_run.rows_loaded = total_rows
+        # Surface partial failures loudly: exit non-zero so the orchestrator
+        # records the job as errored instead of a silent green run.
         if failed_batches > 0:
-            etl_run.error_message = f"{failed_batches} batch(es) failed during load"
-        db.commit()
+            logger.error("%d batch(es) failed during load", failed_batches)
+            sys.exit(1)
 
     except Exception as exc:
-        error_message = str(exc)
         logger.error("ETL run failed: %s", exc)
-        try:
-            etl_run.status = "error"
-            etl_run.finished_at = datetime.now(timezone.utc).replace(tzinfo=None)
-            etl_run.error_message = error_message
-            db.commit()
-        except Exception:
-            db.rollback()
         sys.exit(1)
 
     finally:

--- a/backend/etl/load_parties_victims.py
+++ b/backend/etl/load_parties_victims.py
@@ -28,6 +28,7 @@ Usage:
 import argparse
 import gc
 import logging
+import sys
 import time
 from datetime import datetime
 
@@ -36,7 +37,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import CrashParty, CrashVictim
-from etl._utils import etl_run
 
 logging.basicConfig(
     level=logging.INFO,
@@ -214,11 +214,17 @@ def load_table(
     end_year: int,
     force: bool,
 ):
-    """Generic loader for parties or victims."""
+    """Generic loader for parties or victims.
+
+    Returns True if any page fetch failed (a partial load). Callers must treat
+    this as a failure — otherwise a truncated load records a silent success
+    (M-B9).
+    """
     db = SessionLocal()
 
     try:
         total_rows = 0
+        had_failure = False
 
         for year in range(start_year, end_year + 1):
             if year not in resource_ids:
@@ -235,6 +241,7 @@ def load_table(
                     result = _fetch_page(resource_id, offset)
                 except Exception as exc:
                     logger.error("%s year %d failed at offset %d: %s", table_type, year, offset, exc)
+                    had_failure = True
                     break
 
                 total = result["total"]
@@ -288,6 +295,7 @@ def load_table(
             db.expunge_all()
 
         logger.info("Done. %d total %s records upserted.", total_rows, table_type)
+        return had_failure
 
     finally:
         db.close()
@@ -299,7 +307,13 @@ def run(
     table: str | None = None,
     force: bool = False,
 ):
-    """Main entry point."""
+    """Main entry point.
+
+    No self-tracking EtlRun here: the orchestrator's run_job owns the etl_runs
+    row (source = the job name, "parties" / "victims"). Tracking it again here
+    double-counted run history (M-B8). A partial load exits non-zero so run_job
+    records an error instead of a silent success (M-B9).
+    """
     source_name = table if table in ("parties", "victims") else "parties_victims"
 
     eff_start = effective_start_year(start_year, force, datetime.now().year)
@@ -310,34 +324,38 @@ def run(
         start_year,
     )
 
-    with etl_run(source_name):
-        if table is None or table == "parties":
-            load_table(
-                table_type="parties",
-                resource_ids=PARTIES_RESOURCE_IDS,
-                model_class=CrashParty,
-                transform_fn=transform_party,
-                upsert_cols=_PARTY_UPSERT_COLS,
-                constraint_name="uq_parties_party_source",
-                id_field="party_id",
-                start_year=eff_start,
-                end_year=end_year,
-                force=force,
-            )
+    had_failure = False
+    if table is None or table == "parties":
+        had_failure |= load_table(
+            table_type="parties",
+            resource_ids=PARTIES_RESOURCE_IDS,
+            model_class=CrashParty,
+            transform_fn=transform_party,
+            upsert_cols=_PARTY_UPSERT_COLS,
+            constraint_name="uq_parties_party_source",
+            id_field="party_id",
+            start_year=eff_start,
+            end_year=end_year,
+            force=force,
+        )
 
-        if table is None or table == "victims":
-            load_table(
-                table_type="victims",
-                resource_ids=VICTIMS_RESOURCE_IDS,
-                model_class=CrashVictim,
-                transform_fn=transform_victim,
-                upsert_cols=_VICTIM_UPSERT_COLS,
-                constraint_name="uq_victims_victim_source",
-                id_field="victim_id",
-                start_year=eff_start,
-                end_year=end_year,
-                force=force,
-            )
+    if table is None or table == "victims":
+        had_failure |= load_table(
+            table_type="victims",
+            resource_ids=VICTIMS_RESOURCE_IDS,
+            model_class=CrashVictim,
+            transform_fn=transform_victim,
+            upsert_cols=_VICTIM_UPSERT_COLS,
+            constraint_name="uq_victims_victim_source",
+            id_field="victim_id",
+            start_year=eff_start,
+            end_year=end_year,
+            force=force,
+        )
+
+    if had_failure:
+        logger.error("Partial load: one or more page fetches failed")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 SourceType = Literal["ckan", "arcgis", "federal", "none"]
 
 
+def _utc_now() -> datetime:
+    """Naive UTC 'now'. EtlRun.started_at/finished_at are naive DateTime columns,
+    so writing tz-aware values makes staleness math offset-dependent on non-UTC
+    servers. Match the rest of the ETL code, which stores naive UTC (M-B12)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 @dataclass
 class Job:
     name: str
@@ -165,8 +172,8 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
             record = EtlRun(
                 source=job.name,
                 status="skipped_unchanged",
-                started_at=datetime.now(timezone.utc),
-                finished_at=datetime.now(timezone.utc),
+                started_at=_utc_now(),
+                finished_at=_utc_now(),
                 triggered_by=triggered_by,
                 error_message=freshness.reason,
                 validation_status="skipped",
@@ -185,7 +192,7 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
     record = EtlRun(
         source=job.name,
         status="running",
-        started_at=datetime.now(timezone.utc),
+        started_at=_utc_now(),
         triggered_by=triggered_by,
         rows_before=rows_before,
     )
@@ -227,14 +234,14 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
             record.validation_status = val_status
             record.diff_summary = diff_summary
 
-        record.finished_at = datetime.now(timezone.utc)
+        record.finished_at = _utc_now()
         db.commit()
         logger.info("Job %s finished in %.1fs (status=%s)", job.name, elapsed, record.status)
 
     except subprocess.TimeoutExpired:
         record.status = "error"
         record.error_message = f"Job timed out after {job.timeout}s"
-        record.finished_at = datetime.now(timezone.utc)
+        record.finished_at = _utc_now()
         record.validation_status = "skipped"
         db.commit()
         logger.error("Job %s timed out", job.name)
@@ -242,7 +249,7 @@ def run_job(job: Job, triggered_by: str = "manual", force_refresh: bool = False)
     except Exception as exc:
         record.status = "error"
         record.error_message = str(exc)[:2000]
-        record.finished_at = datetime.now(timezone.utc)
+        record.finished_at = _utc_now()
         record.validation_status = "skipped"
         db.commit()
         logger.exception("Job %s failed unexpectedly", job.name)
@@ -263,14 +270,14 @@ def _cleanup_zombie_runs() -> int:
             db.query(EtlRun)
             .filter(
                 EtlRun.status == "running",
-                EtlRun.started_at < datetime.now(timezone.utc) - timedelta(hours=1),
+                EtlRun.started_at < _utc_now() - timedelta(hours=1),
             )
             .all()
         )
         for z in zombies:
             z.status = "error"
             z.error_message = "Zombie cleanup: process was killed or never finished"
-            z.finished_at = datetime.now(timezone.utc)
+            z.finished_at = _utc_now()
         db.commit()
         if zombies:
             logger.info("Cleaned up %d zombie etl_runs", len(zombies))
@@ -360,8 +367,8 @@ def _run_pipeline_locked(
             record = EtlRun(
                 source=job.name,
                 status="skipped",
-                started_at=datetime.now(timezone.utc),
-                finished_at=datetime.now(timezone.utc),
+                started_at=_utc_now(),
+                finished_at=_utc_now(),
                 triggered_by=triggered_by,
                 error_message=f"Blocked by failed deps: {', '.join(blocked_by)}",
                 validation_status="skipped",
@@ -386,8 +393,8 @@ def _run_pipeline_locked(
             record = EtlRun(
                 source=job.name,
                 status="skipped_unchanged",
-                started_at=datetime.now(timezone.utc),
-                finished_at=datetime.now(timezone.utc),
+                started_at=_utc_now(),
+                finished_at=_utc_now(),
                 triggered_by=triggered_by,
                 error_message=f"All dependencies unchanged: {', '.join(job.depends_on)}",
                 validation_status="skipped",

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -118,3 +118,28 @@ class TestSelectYearsToLoad:
         )
         assert 2026 in ccrs and 2027 in ccrs
         assert 2025 in skipped
+
+
+class TestNoSelfTracking:
+    """M-B8: load_crashes must not create its own EtlRun row. The orchestrator's
+    run_job is the single tracker; a self-created row (source='ccrs') is a phantom
+    source in /api/freshness and double-counts run history."""
+
+    def test_run_does_not_construct_an_etl_run(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from etl import load_crashes as mod
+
+        etl_run_ctor = MagicMock()
+        # raising=False: the loader no longer imports EtlRun at all, which is
+        # exactly the fix — if it ever references mod.EtlRun again this mock
+        # would catch it.
+        monkeypatch.setattr(mod, "EtlRun", etl_run_ctor, raising=False)
+        monkeypatch.setattr(mod, "SessionLocal", lambda: MagicMock())
+        monkeypatch.setattr(mod, "build_city_lookup", lambda db: {})
+        monkeypatch.setattr(mod, "get_loaded_years", lambda db: {})
+        # No years to load → run() does only bookkeeping, no network.
+        monkeypatch.setattr(mod, "select_years_to_load", lambda *a, **k: ([], [], []))
+
+        mod.run(start_year=2016, end_year=2016, source_filter="ccrs")
+
+        etl_run_ctor.assert_not_called()

--- a/backend/tests/test_load_parties_victims.py
+++ b/backend/tests/test_load_parties_victims.py
@@ -1,5 +1,7 @@
 """Tests for the parties & victims ETL transform functions."""
 
+import pytest
+
 from etl.load_parties_victims import (
     transform_party,
     transform_victim,
@@ -218,3 +220,59 @@ class TestLoadTableMemoryCleanup:
             f"gc.collect() should fire per batch (expected >=2, got {len(gc_calls)})"
         )
         fake_db.expunge_all.assert_called()
+
+
+class TestPartialFailureIsLoud:
+    """M-B9: a page-fetch failure must not be recorded as a silent success."""
+
+    def test_load_table_reports_failure_when_a_page_fetch_raises(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from etl import load_parties_victims as mod
+
+        def boom(_rid, _off):
+            raise RuntimeError("CKAN 500")
+
+        monkeypatch.setattr(mod, "_fetch_page", boom)
+        monkeypatch.setattr(mod, "SessionLocal", lambda: MagicMock())
+
+        had_failure = mod.load_table(
+            table_type="parties",
+            resource_ids={2026: "fake-id"},
+            model_class=MagicMock(),
+            transform_fn=mod.transform_party,
+            upsert_cols=["collision_id"],
+            constraint_name="uq_parties_party_source",
+            id_field="party_id",
+            start_year=2026,
+            end_year=2026,
+            force=False,
+        )
+
+        assert had_failure is True
+
+    def test_run_exits_nonzero_when_a_table_had_a_fetch_failure(self, monkeypatch):
+        from etl import load_parties_victims as mod
+
+        monkeypatch.setattr(mod, "load_table", lambda **kw: True)
+
+        with pytest.raises(SystemExit) as exc:
+            mod.run(table="parties")
+
+        assert exc.value.code != 0
+
+
+class TestNoSelfTracking:
+    """M-B8: the orchestrator owns EtlRun; the loader must not create its own
+    (double-tracking that inflates run history + phantom /api/freshness sources)."""
+
+    def test_run_does_not_open_its_own_etl_run(self, monkeypatch):
+        from etl import load_parties_victims as mod
+
+        calls = []
+        monkeypatch.setattr(mod, "load_table", lambda **kw: calls.append(kw["table_type"]) or False)
+
+        assert not hasattr(mod, "etl_run"), (
+            "loader should not self-track EtlRun; run_job is the single source of truth"
+        )
+        mod.run(table="victims")
+        assert calls == ["victims"]

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -166,6 +166,55 @@ def test_table_row_count_rejects_bad_identifier():
     assert _table_row_count(_FakeDB([]), None) is None
 
 
+class _FakeSession:
+    """Minimal Session stand-in for run_job: collects added rows, serves COUNTs."""
+
+    def __init__(self, counts=None):
+        self.added = []
+        self._counts = list(counts or [])
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def expunge(self, obj):
+        pass
+
+    def close(self):
+        pass
+
+    def execute(self, *_args, **_kwargs):
+        return _FakeResult(self._counts.pop(0) if self._counts else 0)
+
+
+def test_run_job_writes_naive_utc_timestamps(monkeypatch):
+    """EtlRun.started_at/finished_at are naive DateTime columns; the orchestrator
+    must write naive UTC (not tz-aware) or staleness math goes offset-dependent
+    on non-UTC servers (M-B12)."""
+    import types
+
+    from etl import orchestrator
+
+    job = Job(name="x", module="etl.x", table_name=None, source_type="none")
+    fake = _FakeSession()
+    monkeypatch.setattr(orchestrator, "SessionLocal", lambda: fake)
+    monkeypatch.setattr(
+        orchestrator.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    record = orchestrator.run_job(job, force_refresh=True)
+
+    assert record.started_at.tzinfo is None
+    assert record.finished_at.tzinfo is None
+
+
 def test_cli_dry_run():
     result = subprocess.run(
         [sys.executable, "-m", "etl.run_all", "--dry-run"],

--- a/frontend/src/components/ask/StoryCanvasPanel.test.tsx
+++ b/frontend/src/components/ask/StoryCanvasPanel.test.tsx
@@ -157,6 +157,26 @@ describe("StoryCanvasPanel", () => {
     });
   });
 
+  describe("focus trap", () => {
+    it("wraps Tab from the last focusable back to the first", () => {
+      wrap(<Harness open onClose={() => {}} />);
+      const dialog = screen.getByRole("dialog");
+      const focusables = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+        ),
+      );
+      expect(focusables.length).toBeGreaterThan(1);
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      act(() => { last.focus(); });
+      fireEvent.keyDown(dialog, { key: "Tab" });
+
+      expect(document.activeElement).toBe(first);
+    });
+  });
+
   describe("focus return on close", () => {
     it("returns focus to the trigger element when the panel is closed", () => {
       function FocusHarness() {

--- a/frontend/src/components/ask/StoryCanvasPanel.tsx
+++ b/frontend/src/components/ask/StoryCanvasPanel.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import { useStoryCanvas } from "../../hooks/useStoryCanvas";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
 import InlineChart from "./InlineChart";
 
 interface Props {
@@ -16,28 +17,10 @@ export default function StoryCanvasPanel({ open, onClose, onExportPng, onExportP
     title, blocks, count, setTitle, addNote, updateNote, moveBlock, removeBlock, clear,
   } = useStoryCanvas();
   const panelRef = useRef<HTMLDivElement>(null);
-  const returnFocusRef = useRef<HTMLElement | null>(null);
 
-  // Capture the focused element before opening; restore it when closing.
-  // Combined into one [open] effect to guarantee capture happens before panel steals focus.
-  useEffect(() => {
-    if (open) {
-      returnFocusRef.current = document.activeElement as HTMLElement | null;
-      panelRef.current?.focus();
-    } else {
-      returnFocusRef.current?.focus();
-    }
-  }, [open]);
-
-  // Escape closes. On the document (not the dialog div) to avoid attaching a
-  // key handler to a non-interactive element (jsx-a11y) and to catch the key
-  // regardless of where focus sits inside the panel.
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  // Make the aria-modal dialog actually modal: trap Tab focus, restore focus on
+  // close, and close on Escape (shared with AiCompanion via the hook).
+  useFocusTrap(panelRef, open, onClose);
 
   if (!open) return null;
 

--- a/frontend/src/components/charts/SimpleBarChart.test.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.test.tsx
@@ -1,0 +1,90 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import { ThemeProvider } from "../../context/ThemeContext";
+import SimpleBarChart from "./SimpleBarChart";
+
+const render = (ui: ReactNode) =>
+  rtlRender(
+    <ThemeProvider>
+      <CustomThemeProvider>{ui}</CustomThemeProvider>
+    </ThemeProvider>,
+  );
+
+// jsdom lacks these; SimpleBarChart reads matchMedia (reduced-motion) and
+// observes its size on mount.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+globalThis.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+const data = [
+  { label: "Mon", value: 10 },
+  { label: "Tue", value: 20 },
+];
+
+beforeEach(() => cleanup());
+
+describe("SimpleBarChart keyboard accessibility", () => {
+  it("exposes clickable bars as focusable buttons with a data label", () => {
+    render(<SimpleBarChart data={data} onBarClick={() => {}} />);
+    const bars = screen.getAllByRole("button");
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toHaveAttribute("tabindex", "0");
+    expect(screen.getByRole("button", { name: /Mon: 10/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Tue: 20/ })).toBeInTheDocument();
+  });
+
+  it("activates a bar with Enter and Space", () => {
+    const onBarClick = vi.fn();
+    render(<SimpleBarChart data={data} onBarClick={onBarClick} />);
+    const bars = screen.getAllByRole("button");
+
+    fireEvent.keyDown(bars[1], { key: "Enter" });
+    expect(onBarClick).toHaveBeenCalledWith(data[1], 1);
+
+    fireEvent.keyDown(bars[0], { key: " " });
+    expect(onBarClick).toHaveBeenCalledWith(data[0], 0);
+    expect(onBarClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not make bars interactive when there is no click handler", () => {
+    render(<SimpleBarChart data={data} />);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("supports the same keyboard affordance in horizontal layout", () => {
+    const onBarClick = vi.fn();
+    render(<SimpleBarChart data={data} layout="horizontal" onBarClick={onBarClick} />);
+    const bars = screen.getAllByRole("button");
+    expect(bars).toHaveLength(2);
+    fireEvent.keyDown(bars[0], { key: "Enter" });
+    expect(onBarClick).toHaveBeenCalledWith(data[0], 0);
+  });
+});

--- a/frontend/src/components/charts/SimpleBarChart.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.tsx
@@ -27,6 +27,8 @@ interface SimpleBarChartProps {
   title?: string;
   onBarClick?: (item: BarItem, idx: number) => void;
   getHighlight?: (item: BarItem, idx: number) => BarHighlight;
+  /** Accessible name for a clickable bar. Defaults to "label: value". */
+  barLabel?: (item: BarItem, idx: number) => string;
 }
 
 export default function SimpleBarChart({
@@ -43,6 +45,7 @@ export default function SimpleBarChart({
   title,
   onBarClick,
   getHighlight,
+  barLabel,
 }: SimpleBarChartProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
@@ -76,6 +79,29 @@ export default function SimpleBarChart({
     const idx = Math.max(0, Math.min(n - 1, Math.floor((touchX - padL) / slotW)));
     setHover({ idx, x: e.touches[0].clientX, y: e.touches[0].clientY });
   }, [data.length]);
+
+  // Keyboard/AT affordance for clickable bars: without this the drill-down /
+  // cross-filter is mouse-only (M-F16). When there's no click handler the bars
+  // stay decorative inside the chart's role="img".
+  const barButtonProps = (d: BarItem, i: number) =>
+    onBarClick
+      ? ({
+          role: "button",
+          tabIndex: 0,
+          "aria-label": barLabel ? barLabel(d, i) : `${d.label}: ${d.value.toLocaleString()}`,
+          onKeyDown: (e: React.KeyboardEvent<SVGRectElement>) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onBarClick(d, i);
+            }
+          },
+          onFocus: (e: React.FocusEvent<SVGRectElement>) => {
+            const r = e.currentTarget.getBoundingClientRect();
+            setHover({ idx: i, x: r.left + r.width / 2, y: r.top });
+          },
+          onBlur: () => setHover(null),
+        } as const)
+      : {};
 
   if (!data.length) return null;
   const rawMax = Math.max(...data.map((d) => d.value), 1);
@@ -123,6 +149,7 @@ export default function SimpleBarChart({
                   onClick={() => onBarClick?.(d, i)}
                   className="cursor-pointer"
                   style={{ transition: "opacity 0.15s ease" }}
+                  {...barButtonProps(d, i)}
                 />
               </g>
             );
@@ -189,6 +216,7 @@ export default function SimpleBarChart({
                 onMouseLeave={() => setHover(null)}
                 onClick={() => onBarClick?.(d, i)}
                 className="cursor-pointer"
+                {...barButtonProps(d, i)}
               />
               {showXAxis && (() => {
                 const skipInterval = slotW < 28 ? Math.ceil(28 / slotW) : 1;

--- a/frontend/src/components/map/LayersPanel.test.tsx
+++ b/frontend/src/components/map/LayersPanel.test.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from "react";
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { LayersStateProvider, useLayersState } from "../../hooks/useLayersState";
 import { CustomThemeProvider } from "../../context/CustomThemeContext";
 import { ThemeProvider } from "../../context/ThemeContext";
@@ -82,6 +82,41 @@ describe("LayersPanel toggle accessibility", () => {
     const choropleth = screen.getByRole("switch", { name: "Shade by Measure" });
     expect(choropleth).toHaveAttribute("aria-checked", "false");
     expect(choropleth).not.toHaveAttribute("aria-disabled");
+  });
+});
+
+// ── Single-select segmented controls (M-F18) ──────────────────────────
+// These groups previously conveyed the active choice by background colour
+// only, with no group semantics or pressed state for assistive tech.
+
+describe("LayersPanel segmented-control accessibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("names the Measure group and marks the active option pressed", () => {
+    render(<Harness />);
+    const group = screen.getByRole("group", { name: /measure/i });
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
+
+    const unpressed = within(group).getAllByRole("button", { pressed: false })[0];
+    fireEvent.click(unpressed);
+    expect(unpressed).toHaveAttribute("aria-pressed", "true");
+    // Still exactly one selected.
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
+  });
+
+  it("names the Color palette group and marks the active swatch pressed", () => {
+    render(<Harness />);
+    const group = screen.getByRole("group", { name: /palette/i });
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
+  });
+
+  it("exposes the heatmap Resolution group once the statewide layer is on", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("switch", { name: "Statewide" }));
+    const group = screen.getByRole("group", { name: /resolution/i });
+    expect(within(group).getAllByRole("button", { pressed: true })).toHaveLength(1);
   });
 });
 

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -167,7 +167,7 @@ export default function LayersPanel() {
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
                 Resolution
               </span>
-              <div className="flex gap-1.5">
+              <div className="flex gap-1.5" role="group" aria-label="Heatmap resolution">
                 {([
                   { key: "low" as const, label: "Low" },
                   { key: "medium" as const, label: "Medium" },
@@ -175,6 +175,7 @@ export default function LayersPanel() {
                   <button
                     key={key}
                     onClick={() => setHeatmapResolution(key)}
+                    aria-pressed={heatmapResolution === key}
                     className={`px-2.5 py-1 rounded-md text-[11px] font-semibold transition-colors ${
                       heatmapResolution === key
                         ? "bg-primary text-on-primary"
@@ -247,11 +248,12 @@ export default function LayersPanel() {
               <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant">
                 Color By
               </span>
-              <div className="flex flex-wrap gap-1.5">
+              <div className="flex flex-wrap gap-1.5" role="group" aria-label="Highway color metric">
                 {HIGHWAY_METRICS.map(({ key, label }) => (
                   <button
                     key={key}
                     onClick={() => setHighwayMetric(key)}
+                    aria-pressed={highwayMetric === key}
                     className={`px-2.5 py-1 rounded-md text-[11px] font-semibold transition-colors ${
                       highwayMetric === key
                         ? "bg-primary text-on-primary"
@@ -303,13 +305,14 @@ export default function LayersPanel() {
         <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
           Measure
         </span>
-        <div className="space-y-2">
+        <div className="space-y-2" role="group" aria-label="Measure">
           {Object.values(MEASURES).map((m) => {
             const active = measure === m.key;
             return (
               <button
                 key={m.key}
                 onClick={() => setMeasure(m.key)}
+                aria-pressed={active}
                 className="flex items-center gap-3 w-full text-left cursor-pointer"
               >
                 <span className={`w-4 h-4 rounded-full flex-shrink-0 flex items-center justify-center transition-colors ${
@@ -332,11 +335,12 @@ export default function LayersPanel() {
         <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
           Color Palette
         </span>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3" role="group" aria-label="Color palette">
           {(Object.keys(PALETTES) as PaletteKey[]).map((key) => (
             <button
               key={key}
               onClick={() => setPalette(key)}
+              aria-pressed={activePalette === key}
               className={`p-2 rounded-xl text-left transition-all ${
                 activePalette === key ? "bg-primary-container" : "hover:bg-surface-container"
               }`}

--- a/frontend/src/hooks/useFocusTrap.test.tsx
+++ b/frontend/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,69 @@
+import { useRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+import { useFocusTrap } from "./useFocusTrap";
+
+function Dialog({ active, onClose }: { active: boolean; onClose: () => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, active, onClose);
+  if (!active) return null;
+  return (
+    <div ref={ref} role="dialog" aria-modal="true" tabIndex={-1}>
+      <button>first</button>
+      <button>middle</button>
+      <button>last</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe("useFocusTrap", () => {
+  it("moves focus into the dialog when it activates", () => {
+    render(<Dialog active onClose={() => {}} />);
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+  });
+
+  it("wraps Tab from the last focusable back to the first", () => {
+    render(<Dialog active onClose={() => {}} />);
+    const dialog = screen.getByRole("dialog");
+    act(() => { screen.getByText("last").focus(); });
+
+    fireEvent.keyDown(dialog, { key: "Tab" });
+
+    expect(document.activeElement).toBe(screen.getByText("first"));
+  });
+
+  it("wraps Shift+Tab from the first focusable back to the last", () => {
+    render(<Dialog active onClose={() => {}} />);
+    const dialog = screen.getByRole("dialog");
+    act(() => { screen.getByText("first").focus(); });
+
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByText("last"));
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = vi.fn();
+    render(<Dialog active onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("restores focus to the element focused before activation", () => {
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    act(() => { outside.focus(); });
+
+    const { rerender } = render(<Dialog active={false} onClose={() => {}} />);
+    rerender(<Dialog active onClose={() => {}} />);
+    expect(document.activeElement).toBe(screen.getByRole("dialog"));
+
+    rerender(<Dialog active={false} onClose={() => {}} />);
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
+  });
+});

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,70 @@
+import { useEffect, type RefObject } from "react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Make an `aria-modal` dialog behave modally: while `active`, trap keyboard
+ * focus inside `ref`, close on Escape, and restore focus to whatever was
+ * focused before it opened.
+ *
+ * This is the canonical trap first written inline in AiCompanion — extracted so
+ * other dialogs (StoryCanvasPanel, …) don't reimplement it and drift. The Tab
+ * handler is a native listener on the dialog node (not a JSX onKeyDown) so it
+ * doesn't trip jsx-a11y's no-noninteractive-element-interactions rule; Escape
+ * lives on the document so it fires wherever focus sits.
+ *
+ * @param ref     the dialog container (rendered while `active`, `tabIndex={-1}`)
+ * @param active  whether the dialog is currently open
+ * @param onClose called when Escape is pressed
+ */
+export function useFocusTrap(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+  onClose?: () => void,
+) {
+  // Escape → close. Separate effect so a changing `onClose` identity doesn't
+  // re-run the focus capture/restore below (which would steal focus mid-open).
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [active, onClose]);
+
+  // Focus capture + Tab trap + restore.
+  useEffect(() => {
+    if (!active) return;
+    const node = ref.current;
+    const restore = document.activeElement as HTMLElement | null;
+    node?.focus();
+
+    const onTab = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !node) return;
+      const focusables = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusables.length === 0) {
+        // Nothing to move to — keep focus on the dialog itself.
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const activeEl = document.activeElement;
+      if (e.shiftKey && (activeEl === first || activeEl === node)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && activeEl === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    node?.addEventListener("keydown", onTab);
+    return () => {
+      node?.removeEventListener("keydown", onTab);
+      restore?.focus?.();
+    };
+  }, [active, ref]);
+}

--- a/frontend/tests/a11y-focus-trap.spec.ts
+++ b/frontend/tests/a11y-focus-trap.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = "http://localhost:5174";
+
+// Real-browser verification of the Story Canvas focus trap (audit M-F17).
+// jsdom can't move focus on a real Tab keypress, so the unit tests only prove
+// the handler logic; this drives actual Tab / Shift+Tab / Escape in Chromium.
+// Hermetic: the Story Canvas is pure client state, so no backend/AI is needed.
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+test("Story Canvas traps Tab focus inside the dialog and closes on Escape", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("calsight-intro-seen", "1");
+    localStorage.setItem("calsight-insight-seen", "1");
+  });
+
+  await page.goto(`${BASE_URL}/ask`);
+  await page.getByRole("button", { name: /open story canvas/i }).click();
+
+  const dialog = page.getByRole("dialog", { name: /story/i });
+  await expect(dialog).toBeVisible();
+
+  // Add a note so the dialog has several focusable controls to cycle through.
+  await page.getByRole("button", { name: "+ Add note" }).click();
+
+  const focusables = dialog.locator(FOCUSABLE);
+  const count = await focusables.count();
+  expect(count).toBeGreaterThan(1);
+  const first = focusables.first();
+  const last = focusables.last();
+
+  // Tab from the last focusable wraps back to the first.
+  await last.focus();
+  await page.keyboard.press("Tab");
+  await expect(first).toBeFocused();
+
+  // Shift+Tab from the first wraps to the last.
+  await first.focus();
+  await page.keyboard.press("Shift+Tab");
+  await expect(last).toBeFocused();
+
+  // Tabbing forward many times never escapes the dialog.
+  for (let i = 0; i < count + 3; i++) await page.keyboard.press("Tab");
+  const stillTrapped = await page.evaluate(
+    () => document.activeElement?.closest('[role="dialog"]') != null,
+  );
+  expect(stillTrapped).toBe(true);
+
+  // Escape closes it.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+});


### PR DESCRIPTION
Combined review branch for the two P2 audit-medium slices (supersedes #353 + #354, which are the same commits split by concern). Backend and frontend changes touch disjoint files. Every fix is TDD'd.

---
## Backend — `etl_runs` integrity (was #353)

- **M-B8** — the crash and parties/victims loaders each created their *own* `EtlRun` on top of the one `run_job` already writes, with mismatched `source` names (`"ccrs"` is a phantom `/api/freshness` source; `"parties"`/`"victims"` double-counted history). `run_job` is now the single source of truth; loaders no longer self-track.
- **M-B9** — a page-fetch failure in the parties/victims loader used to record success. `load_table` now returns whether any page failed; `run()` exits non-zero so `run_job` records an error. `load_crashes` likewise exits non-zero on failed batches.
- **M-B12** — `run_job` wrote tz-aware timestamps into `EtlRun`'s naive columns (offset-dependent staleness on non-UTC servers). Added `_utc_now()`; naive UTC everywhere.

488 backend unit tests pass; ruff clean.

## Frontend — accessibility (was #354)

- **M-F16** — `SimpleBarChart` clickable bars are now `role="button"`, focusable, labeled, and activate on Enter/Space (drill-down was mouse-only).
- **M-F17** — `StoryCanvasPanel` claimed `aria-modal` but never trapped focus. Extracted the canonical trap from `AiCompanion` into a shared **`useFocusTrap`** hook and wired the panel to it. `AiCompanion` left untouched.
- **M-F18** — Resolution / Highway "Color By" / Measure / Palette segmented controls now expose `role="group"` + `aria-label` and `aria-pressed` (previously colour-only). Toggle-button semantics, not radiogroup — keeps existing Tab order.

626 frontend tests pass; `tsc -b` + eslint clean.

## Real-browser verification (Playwright)
- New `a11y-focus-trap.spec.ts` drives **real Tab / Shift+Tab / Escape** in Chromium and asserts the Story Canvas focus trap holds — the one change with a genuine jsdom gap. Passing.
- Existing `story-export.spec.ts` re-run green against this branch (confirms the refactored panel still works).

## Deferred (assessed, not here)
- **M-B10** — pg_dump password-on-cmdline already fixed Wave-1; scheduler/backup dedup is entangled with M-I8 (needs the canonical-scheduler call).
- **M-B11** — cross-worker in-memory state needs an infra decision (Redis vs DB-backed limiter).