### PR TITLE
Edge-cost hardening (part 1): statement_timeout backstop on /ask

### DIFF
--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.ai_prompt import (
@@ -42,6 +43,17 @@ _MAX_TOOL_ROUNDS = 3
 _MAX_TOOL_CALLS_PER_ROUND = 3
 _MAX_HISTORY = 10
 _ASK_TIMEOUT_SECONDS = 60.0
+# Per-query backstop for the AI-tool path. Below the 60s request deadline so a
+# runaway 11M-row aggregation is killed by Postgres and releases its pool
+# connection instead of outliving the (already-504'd) request.
+_STATEMENT_TIMEOUT_MS = 50_000
+
+
+def _apply_statement_timeout(db: Session, ms: int = _STATEMENT_TIMEOUT_MS) -> None:
+    """Bound every query on this dedicated, short-lived ask session. SET LOCAL
+    resets when the session's transaction ends (on close), so it can't leak the
+    timeout onto the next user of a pooled connection."""
+    db.execute(text(f"SET LOCAL statement_timeout = {int(ms)}"))
 
 
 class _AskAbandoned(Exception):
@@ -170,6 +182,7 @@ def _handle_ask(body: AskRequest) -> AskResponse | None:
     deadline = time.monotonic() + _ASK_TIMEOUT_SECONDS
     db = SessionLocal()
     try:
+        _apply_statement_timeout(db)
         return _handle_ask_inner(body, db, deadline)
     except _AskAbandoned:
         logger.warning("Ask request abandoned after timeout; stopped tool loop early")

--- a/backend/tests/test_ask_timeout.py
+++ b/backend/tests/test_ask_timeout.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+from app.routers.ask import _apply_statement_timeout, _STATEMENT_TIMEOUT_MS
+
+
+def test_apply_statement_timeout_issues_set_local():
+    """The /ask session must bound each query so a runaway aggregation can't
+    hold a pool connection past the 60s request deadline."""
+    calls = []
+    db = SimpleNamespace(execute=lambda stmt, *a, **k: calls.append(str(stmt)))
+
+    _apply_statement_timeout(db)
+
+    assert len(calls) == 1
+    assert "statement_timeout" in calls[0].lower()
+    assert str(_STATEMENT_TIMEOUT_MS) in calls[0]
+
+
+def test_statement_timeout_is_below_the_request_deadline():
+    from app.routers.ask import _ASK_TIMEOUT_SECONDS
+    assert _STATEMENT_TIMEOUT_MS < _ASK_TIMEOUT_SECONDS * 1000


### PR DESCRIPTION
First slice of the "request-cost control at the edge" cluster that **both** Fable 5 audits flagged as the top availability risk.

## This PR — `/ask` query backstop (HIGH)
The AI-tool path (`ai_tools.py`) aggregates the 11M-row `crashes` table with no `statement_timeout`, on a worker thread that *deliberately outlives the request*: `asyncio.wait_for` returns 504 at 60s but the thread keeps executing tool queries on its pooled connection. A handful of concurrent `/ask` 504s can leave threads scanning, holding pool connections (pool is 10/worker) → checkout blocking → degraded API.

Fix: the dedicated ask session now runs `SET LOCAL statement_timeout = 50s` (below the 60s request deadline), so Postgres kills a runaway query and releases the connection. `LOCAL` resets when the session's transaction ends (on close), so it can't leak the timeout onto the next user of a pooled connection. 2 unit tests.

## Deliberately *not* in this PR (honest follow-ups)
- **Proxy-aware client IP (HIGH):** behind the Cloudflare tunnel, `get_remote_address` returns the tunnel's IP, so every user shares one rate-limit bucket. The fix (trust `CF-Connecting-IP`/`X-Forwarded-For`) is security-sensitive and **depends on confirming the tunnel forwards the header** — needs a decision + prod check, so it's not bundled here.
- **Public stats/street-level slowness (MED-HIGH):** `/stats/distribution`, `/intersections`, `/corridors` do uncached 11M-row scans on every Stats visit. A statement_timeout there is only a backstop against *hangs*; the real fix is caching / a precomputed matview (bigger effort).
- **Per-worker rate-limit/cache dilution (M-B11):** needs a shared store (Redis) — infra decision.

Independent of #356 (different files); branched off `main`.