### PR TITLE
fix(a11y): accessible table for CorrelationMatrix (Fable audit HIGH)

### DIFF
--- a/frontend/src/components/charts/CorrelationMatrix.test.tsx
+++ b/frontend/src/components/charts/CorrelationMatrix.test.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render as rtlRender, screen, within } from "@testing-library/react";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import CorrelationMatrix from "./CorrelationMatrix";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+const render = (ui: ReactNode) =>
+  rtlRender(<ThemeProvider><CustomThemeProvider>{ui}</CustomThemeProvider></ThemeProvider>);
+
+const fields = [
+  { key: "rate", label: "Crash Rate", source: "x" },
+  { key: "pov", label: "Poverty", source: "y" },
+];
+// Asymmetric off-diagonals so each r-value string is unique in the DOM.
+const matrix = [
+  [1, 0.42],
+  [0.37, 1],
+];
+
+describe("CorrelationMatrix accessibility", () => {
+  it("exposes the matrix as an accessible table (role=img flattened the SVG cells)", () => {
+    render(<CorrelationMatrix fields={fields} matrix={matrix} countyCount={58} />);
+
+    const table = screen.getByRole("table", { name: /correlation matrix/i });
+    expect(within(table).getByRole("columnheader", { name: "Poverty" })).toBeInTheDocument();
+    expect(within(table).getByRole("rowheader", { name: "Crash Rate" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "0.42" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "0.37" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/charts/CorrelationMatrix.tsx
+++ b/frontend/src/components/charts/CorrelationMatrix.tsx
@@ -220,8 +220,12 @@ export default function CorrelationMatrix({ fields, matrix, countyCount, countie
       </div>
 
       <p className="text-[9px] text-on-surface-variant/50 sm:hidden mb-1">Swipe to scroll</p>
-      <div style={{ overflowX: "auto", overflowY: "visible", WebkitOverflowScrolling: "touch" }}>
-        <svg width={svgW} height={svgH} className="block" style={{ overflow: "visible" }} role="img" aria-labelledby={titleId}>
+      {/* Visual grid is mouse-interactive but decorative to assistive tech —
+          role="img" flattened its cells out of the a11y tree, so a screen
+          reader got one opaque image. The real accessible representation is the
+          <table> below (arrow-key navigable, every r-value exposed). */}
+      <div style={{ overflowX: "auto", overflowY: "visible", WebkitOverflowScrolling: "touch" }} aria-hidden="true">
+        <svg width={svgW} height={svgH} className="block" style={{ overflow: "visible" }}>
           <title id={titleId}>Correlation matrix: Pearson r values across {countyCount} California counties for {n} metrics</title>
           <desc>A {n} by {n} grid showing pairwise Pearson correlation coefficients between crash, demographic, and environmental metrics. Blue cells indicate positive correlations, red cells indicate negative correlations. Click any cell to view a scatter plot.</desc>
           {/* cells first so labels paint on top */}
@@ -263,6 +267,31 @@ export default function CorrelationMatrix({ fields, matrix, countyCount, countie
           })}
         </svg>
       </div>
+
+      {/* Screen-reader-accessible representation of the matrix above. */}
+      <table className="sr-only">
+        <caption>
+          Correlation matrix: Pearson r values across {countyCount} California counties for {n} metrics.
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Metric</th>
+            {fields.map((f) => (
+              <th key={f.label} scope="col">{f.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {matrix.map((row, i) => (
+            <tr key={fields[i].label}>
+              <th scope="row">{fields[i].label}</th>
+              {row.map((r, j) => (
+                <td key={j}>{isNaN(r) ? "N/A" : r.toFixed(2)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
 
       {hoverCell && !selected && (
         <p className="text-xs text-on-surface-variant text-center">


### PR DESCRIPTION
The Fable 5 frontend audit's #1 finding. The correlation grid was a single `role="img"` SVG containing `role="img"` cells, so a screen reader received **one opaque image** and none of the 841 r-values, and the click-to-scatter interaction was mouse-only. (`role="img"` also makes descendants presentational, so the per-cell `aria-label`s never reached AT.)

**Fix:** the visual SVG is now `aria-hidden` (decorative), and a real `<table>` — caption + `scope` column/row headers + every r-value — is the accessible representation. Screen readers navigate it with arrow keys in table mode; no 841-tab-stop explosion (which a per-cell-button approach would cause).

**Verified live (Playwright, real prod data):** the accessible table renders with 29 metric headers and **all 841 r-value cells**, captioned; the redundant visual SVG is confirmed hidden from AT. 1 unit test.

Branched off `main` (independent of #356/#357).

Note: this covers the *perceivability* gap (SR users can now read the whole matrix). The keyboard *open-scatter-detail* interaction remains mouse/visual — a smaller follow-up.