### PR TITLE
fix(seo): crawler middleware drops content-encoding after decoding body (Fable audit)

### DIFF
--- a/frontend/functions/_middleware.test.ts
+++ b/frontend/functions/_middleware.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { escapeHtmlAttr, buildContext, rewriteHtml } from "./_middleware";
+import { escapeHtmlAttr, buildContext, rewriteHtml, onRequest } from "./_middleware";
 
 const SAMPLE_HTML = `<!doctype html>
 <html>
@@ -90,5 +90,40 @@ describe("rewriteHtml injection hardening", () => {
     expect(out).toContain(`<meta name="description" content="California crash statistics for kern, los angeles.`);
     expect(out).toContain(`<meta property="og:type" content="article"`);
     expect(out).toContain(`<link rel="canonical" href="https://calsight.org/stats" />`);
+  });
+});
+
+describe("onRequest content-encoding handling", () => {
+  const crawlerReq = () =>
+    new Request("https://calsight.org/stats", {
+      headers: { "user-agent": "facebookexternalhit/1.1" },
+    });
+
+  it("drops content-encoding after decoding the body (fixes broken OG previews)", async () => {
+    // The upstream shell can be gzip/br; response.text() decodes it, so copying
+    // the original content-encoding onto the plain-text rewrite makes crawlers
+    // fail to parse.
+    const context = {
+      request: crawlerReq(),
+      next: async () =>
+        new Response("<!doctype html><head></head><body></body>", {
+          headers: { "content-type": "text/html", "content-encoding": "gzip" },
+        }),
+    };
+    const out = await onRequest(context as never);
+    expect(out.headers.get("content-encoding")).toBeNull();
+    const body = await out.text();
+    expect(out.headers.get("content-length")).toBe(
+      String(new TextEncoder().encode(body).length),
+    );
+  });
+
+  it("passes non-HTML responses through untouched", async () => {
+    const original = new Response("{}", {
+      headers: { "content-type": "application/json", "content-encoding": "gzip" },
+    });
+    const context = { request: crawlerReq(), next: async () => original };
+    const out = await onRequest(context as never);
+    expect(out).toBe(original);
   });
 });

--- a/frontend/functions/_middleware.ts
+++ b/frontend/functions/_middleware.ts
@@ -226,11 +226,15 @@ export const onRequest: PagesFunction = async (context) => {
   const html = await response.text();
   const rewritten = rewriteHtml(html, ctx);
 
+  // response.text() decoded any gzip/br, so the rewritten body is plain text.
+  // Drop the upstream content-encoding (and recompute content-length) or
+  // crawlers try to decompress plain text and OG previews break.
+  const headers = new Headers(response.headers);
+  headers.delete("content-encoding");
+  headers.set("content-length", new TextEncoder().encode(rewritten).length.toString());
+
   return new Response(rewritten, {
     status: response.status,
-    headers: {
-      ...Object.fromEntries(response.headers.entries()),
-      "content-length": new TextEncoder().encode(rewritten).length.toString(),
-    },
+    headers,
   });
 };


### PR DESCRIPTION
Fable 5 frontend audit finding #5 (MED). The crawler middleware (`frontend/functions/_middleware.ts`) rewrites OG/meta tags for crawler user-agents: it calls `response.text()` (which decodes any gzip/br), rewrites the HTML, then returned it while **copying the upstream `content-encoding` header verbatim**. So a compressed shell became a plain-text body labeled `content-encoding: gzip` → crawlers try to decompress plain text and fail → broken OG/link previews (the exact thing this middleware exists to produce).

**Fix:** build a fresh `Headers`, `delete("content-encoding")`, and recompute `content-length`. 2 tests (drops encoding on the HTML path; passes non-HTML responses through untouched).

Branched off `main`.

---
**Note on the sibling finding (#7, URL filter param validation):** deliberately *not* here — `weather`/`lighting`/`collision_type`/`road_type`/`driver_age` flow to the API without allow-list validation, but the valid-value sets aren't centralized and hardcoding them risks drift with the backend. It's a robustness (not security) gap — worth its own pass with a shared source of truth.