### PR TITLE
Prod batch (2026-07-05): resilience + a11y + audit fixes (#356–#359 combined)

### DIFF
--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -14,6 +14,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.ai_prompt import (
@@ -42,6 +43,17 @@ _MAX_TOOL_ROUNDS = 3
 _MAX_TOOL_CALLS_PER_ROUND = 3
 _MAX_HISTORY = 10
 _ASK_TIMEOUT_SECONDS = 60.0
+# Per-query backstop for the AI-tool path. Below the 60s request deadline so a
+# runaway 11M-row aggregation is killed by Postgres and releases its pool
+# connection instead of outliving the (already-504'd) request.
+_STATEMENT_TIMEOUT_MS = 50_000
+
+
+def _apply_statement_timeout(db: Session, ms: int = _STATEMENT_TIMEOUT_MS) -> None:
+    """Bound every query on this dedicated, short-lived ask session. SET LOCAL
+    resets when the session's transaction ends (on close), so it can't leak the
+    timeout onto the next user of a pooled connection."""
+    db.execute(text(f"SET LOCAL statement_timeout = {int(ms)}"))
 
 
 class _AskAbandoned(Exception):
@@ -170,6 +182,7 @@ def _handle_ask(body: AskRequest) -> AskResponse | None:
     deadline = time.monotonic() + _ASK_TIMEOUT_SECONDS
     db = SessionLocal()
     try:
+        _apply_statement_timeout(db)
         return _handle_ask_inner(body, db, deadline)
     except _AskAbandoned:
         logger.warning("Ask request abandoned after timeout; stopped tool loop early")

--- a/backend/app/routers/pipeline_health.py
+++ b/backend/app/routers/pipeline_health.py
@@ -14,6 +14,7 @@ returns a simple status that monitoring tools can poll.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -27,6 +28,8 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import EtlRun
 from app.routers.etl import _verify_etl_key
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/pipeline", tags=["pipeline"])
 
@@ -58,6 +61,21 @@ class DbMetrics(BaseModel):
     dead_tuples_top5: list[dict]
     connection_count: int
     max_connections: int
+
+
+def _age_hours(now_naive: datetime, ts: datetime | None) -> float | None:
+    """Hours between ``ts`` and ``now_naive``, or None.
+
+    Normalizes an aware ``ts`` to naive UTC first. Postgres ``timestamptz``
+    columns (e.g. ``pg_stat_user_tables.last_analyze``) come back tz-aware, and
+    subtracting an aware value from the naive ``now`` raises — which used to be
+    swallowed by a bare except, leaving matview age permanently null (M-B4).
+    """
+    if ts is None:
+        return None
+    if ts.tzinfo is not None:
+        ts = ts.astimezone(timezone.utc).replace(tzinfo=None)
+    return round((now_naive - ts).total_seconds() / 3600, 1)
 
 
 @router.get("/health")
@@ -140,15 +158,12 @@ def pipeline_health(
             SELECT last_analyze FROM pg_stat_user_tables
             WHERE relname = 'mv_crashes_by_year'
         """)).scalar()
-        if last_analyze:
-            matview_age = round((now - last_analyze).total_seconds() / 3600, 1)
+        matview_age = _age_hours(now, last_analyze)
     except Exception:
-        pass
+        logger.warning("matview age query failed", exc_info=True)
 
     # Determine status
-    hours_since = None
-    if last_success:
-        hours_since = round((now - last_success).total_seconds() / 3600, 1)
+    hours_since = _age_hours(now, last_success)
 
     if hours_since is None or hours_since > 96:
         status = "unhealthy"

--- a/backend/etl/_utils.py
+++ b/backend/etl/_utils.py
@@ -406,7 +406,10 @@ def _check_arcgis_freshness(job: Job, last_run: EtlRun) -> FreshnessResult:
         return FreshnessResult(True, None, None, f"freshness check error: {exc}")
 
 
-_ALLOWED_FRESHNESS_TABLES = {"demographics", "weather", "unemployment_rates"}
+_ALLOWED_FRESHNESS_TABLES = {
+    "demographics", "weather", "unemployment_rates",
+    "fars_county_year", "tract_density_county_year",
+}
 
 
 def _check_federal_freshness(job: Job, last_run: EtlRun, db_session) -> FreshnessResult:

--- a/backend/tests/test_ask_timeout.py
+++ b/backend/tests/test_ask_timeout.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+from app.routers.ask import _apply_statement_timeout, _STATEMENT_TIMEOUT_MS
+
+
+def test_apply_statement_timeout_issues_set_local():
+    """The /ask session must bound each query so a runaway aggregation can't
+    hold a pool connection past the 60s request deadline."""
+    calls = []
+    db = SimpleNamespace(execute=lambda stmt, *a, **k: calls.append(str(stmt)))
+
+    _apply_statement_timeout(db)
+
+    assert len(calls) == 1
+    assert "statement_timeout" in calls[0].lower()
+    assert str(_STATEMENT_TIMEOUT_MS) in calls[0]
+
+
+def test_statement_timeout_is_below_the_request_deadline():
+    from app.routers.ask import _ASK_TIMEOUT_SECONDS
+    assert _STATEMENT_TIMEOUT_MS < _ASK_TIMEOUT_SECONDS * 1000

--- a/backend/tests/test_etl_utils.py
+++ b/backend/tests/test_etl_utils.py
@@ -343,3 +343,35 @@ class TestTrackEtlRunDecorator:
         record = fake_db.added[0]
         assert record.status == "error"
         assert record.error_message == "nope"
+
+
+# ---------------------------------------------------------------------------
+# Federal freshness allowlist (M-B6): fars + tract_density must be skippable
+# ---------------------------------------------------------------------------
+
+class TestFederalFreshnessAllowlist:
+    def _fars_job(self):
+        from etl.orchestrator import Job
+        return Job(
+            name="fars", module="etl.nhtsa_fars", source_type="federal",
+            freshness_table="fars_county_year",
+        )
+
+    def test_fars_and_tract_density_are_allowlisted(self):
+        assert "fars_county_year" in _utils._ALLOWED_FRESHNESS_TABLES
+        assert "tract_density_county_year" in _utils._ALLOWED_FRESHNESS_TABLES
+
+    def test_fars_skips_when_row_count_unchanged(self):
+        # Unchanged count must yield is_fresh=False (skip). Before the allowlist
+        # fix this returned is_fresh=True ("unknown freshness_table") so the job
+        # fully reloaded every pipeline run.
+        db = SimpleNamespace(execute=lambda *a, **k: SimpleNamespace(scalar=lambda: 1383))
+        last_run = SimpleNamespace(source_row_count=1383)
+        res = _utils._check_federal_freshness(self._fars_job(), last_run, db)
+        assert res.is_fresh is False
+
+    def test_fars_fresh_when_row_count_grew(self):
+        db = SimpleNamespace(execute=lambda *a, **k: SimpleNamespace(scalar=lambda: 1400))
+        last_run = SimpleNamespace(source_row_count=1383)
+        res = _utils._check_federal_freshness(self._fars_job(), last_run, db)
+        assert res.is_fresh is True

--- a/backend/tests/test_pipeline_health.py
+++ b/backend/tests/test_pipeline_health.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta, timezone
+
+from app.routers.pipeline_health import _age_hours
+
+
+def test_age_hours_none_when_ts_missing():
+    assert _age_hours(datetime(2026, 7, 4, 12, 0, 0), None) is None
+
+
+def test_age_hours_naive_timestamp():
+    now = datetime(2026, 7, 4, 12, 0, 0)
+    assert _age_hours(now, now - timedelta(hours=3)) == 3.0
+
+
+def test_age_hours_aware_timestamp_does_not_raise():
+    # Postgres timestamptz (e.g. pg_stat_user_tables.last_analyze) comes back
+    # tz-aware; subtracting it from the naive `now` used to raise → matview age
+    # was always null (M-B4). It must normalize and compute a real value.
+    now = datetime(2026, 7, 4, 12, 0, 0)  # naive UTC
+    aware_ts = datetime(2026, 7, 4, 6, 0, 0, tzinfo=timezone.utc)  # 6h earlier, aware
+    assert _age_hours(now, aware_ts) == 6.0
+
+
+def test_age_hours_aware_non_utc_offset():
+    now = datetime(2026, 7, 4, 12, 0, 0)  # naive UTC
+    # 10:00 at UTC+2 == 08:00 UTC == 4h before noon UTC
+    aware_ts = datetime(2026, 7, 4, 10, 0, 0, tzinfo=timezone(timedelta(hours=2)))
+    assert _age_hours(now, aware_ts) == 4.0

--- a/frontend/functions/_middleware.test.ts
+++ b/frontend/functions/_middleware.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { escapeHtmlAttr, buildContext, rewriteHtml } from "./_middleware";
+import { escapeHtmlAttr, buildContext, rewriteHtml, onRequest } from "./_middleware";
 
 const SAMPLE_HTML = `<!doctype html>
 <html>
@@ -90,5 +90,40 @@ describe("rewriteHtml injection hardening", () => {
     expect(out).toContain(`<meta name="description" content="California crash statistics for kern, los angeles.`);
     expect(out).toContain(`<meta property="og:type" content="article"`);
     expect(out).toContain(`<link rel="canonical" href="https://calsight.org/stats" />`);
+  });
+});
+
+describe("onRequest content-encoding handling", () => {
+  const crawlerReq = () =>
+    new Request("https://calsight.org/stats", {
+      headers: { "user-agent": "facebookexternalhit/1.1" },
+    });
+
+  it("drops content-encoding after decoding the body (fixes broken OG previews)", async () => {
+    // The upstream shell can be gzip/br; response.text() decodes it, so copying
+    // the original content-encoding onto the plain-text rewrite makes crawlers
+    // fail to parse.
+    const context = {
+      request: crawlerReq(),
+      next: async () =>
+        new Response("<!doctype html><head></head><body></body>", {
+          headers: { "content-type": "text/html", "content-encoding": "gzip" },
+        }),
+    };
+    const out = await onRequest(context as never);
+    expect(out.headers.get("content-encoding")).toBeNull();
+    const body = await out.text();
+    expect(out.headers.get("content-length")).toBe(
+      String(new TextEncoder().encode(body).length),
+    );
+  });
+
+  it("passes non-HTML responses through untouched", async () => {
+    const original = new Response("{}", {
+      headers: { "content-type": "application/json", "content-encoding": "gzip" },
+    });
+    const context = { request: crawlerReq(), next: async () => original };
+    const out = await onRequest(context as never);
+    expect(out).toBe(original);
   });
 });

--- a/frontend/functions/_middleware.ts
+++ b/frontend/functions/_middleware.ts
@@ -226,11 +226,15 @@ export const onRequest: PagesFunction = async (context) => {
   const html = await response.text();
   const rewritten = rewriteHtml(html, ctx);
 
+  // response.text() decoded any gzip/br, so the rewritten body is plain text.
+  // Drop the upstream content-encoding (and recompute content-length) or
+  // crawlers try to decompress plain text and OG previews break.
+  const headers = new Headers(response.headers);
+  headers.delete("content-encoding");
+  headers.set("content-length", new TextEncoder().encode(rewritten).length.toString());
+
   return new Response(rewritten, {
     status: response.status,
-    headers: {
-      ...Object.fromEntries(response.headers.entries()),
-      "content-length": new TextEncoder().encode(rewritten).length.toString(),
-    },
+    headers,
   });
 };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
+import { lazyWithRetry } from "./lib/lazyWithRetry";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { ThemeProvider } from "./context/ThemeContext";
@@ -20,13 +21,13 @@ import RebuildingBanner from "./components/RebuildingBanner";
 import { AiCompanionProvider } from "./components/ai/AiCompanion";
 import { AskAiProvider } from "./hooks/useAskAi";
 
-const MapPage = lazy(() => import("./pages/MapPage"));
-const StatsPage = lazy(() => import("./pages/StatsPage"));
-const AboutPage = lazy(() => import("./pages/AboutPage"));
-const AskAiPage = lazy(() => import("./pages/AskAiPage"));
-const PrivacyPage = lazy(() => import("./pages/PrivacyPage"));
-const AdminEtlPage = lazy(() => import("./pages/AdminEtlPage"));
-const NotFoundPage = lazy(() => import("./pages/NotFoundPage"));
+const MapPage = lazyWithRetry(() => import("./pages/MapPage"));
+const StatsPage = lazyWithRetry(() => import("./pages/StatsPage"));
+const AboutPage = lazyWithRetry(() => import("./pages/AboutPage"));
+const AskAiPage = lazyWithRetry(() => import("./pages/AskAiPage"));
+const PrivacyPage = lazyWithRetry(() => import("./pages/PrivacyPage"));
+const AdminEtlPage = lazyWithRetry(() => import("./pages/AdminEtlPage"));
+const NotFoundPage = lazyWithRetry(() => import("./pages/NotFoundPage"));
 
 export default function App() {
   return (

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -48,7 +48,7 @@ export default function Layout() {
         <NavBar />
       </ErrorBoundary>
       <OfflineIndicator />
-      <ErrorBoundary>
+      <ErrorBoundary resetKey={location.pathname}>
       {isMapPage ? (
         <main id="main-content" className="pt-12 pb-14 md:pt-16 md:pb-0 flex h-dvh overflow-hidden">
           <Outlet />

--- a/frontend/src/components/charts/CorrelationMatrix.test.tsx
+++ b/frontend/src/components/charts/CorrelationMatrix.test.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render as rtlRender, screen, within } from "@testing-library/react";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import CorrelationMatrix from "./CorrelationMatrix";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((q: string) => ({
+    matches: false, media: q, onchange: null,
+    addListener: vi.fn(), removeListener: vi.fn(),
+    addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {} unobserve() {} disconnect() {}
+};
+
+const render = (ui: ReactNode) =>
+  rtlRender(<ThemeProvider><CustomThemeProvider>{ui}</CustomThemeProvider></ThemeProvider>);
+
+const fields = [
+  { key: "rate", label: "Crash Rate", source: "x" },
+  { key: "pov", label: "Poverty", source: "y" },
+];
+// Asymmetric off-diagonals so each r-value string is unique in the DOM.
+const matrix = [
+  [1, 0.42],
+  [0.37, 1],
+];
+
+describe("CorrelationMatrix accessibility", () => {
+  it("exposes the matrix as an accessible table (role=img flattened the SVG cells)", () => {
+    render(<CorrelationMatrix fields={fields} matrix={matrix} countyCount={58} />);
+
+    const table = screen.getByRole("table", { name: /correlation matrix/i });
+    expect(within(table).getByRole("columnheader", { name: "Poverty" })).toBeInTheDocument();
+    expect(within(table).getByRole("rowheader", { name: "Crash Rate" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "0.42" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "0.37" })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/charts/CorrelationMatrix.tsx
+++ b/frontend/src/components/charts/CorrelationMatrix.tsx
@@ -220,8 +220,12 @@ export default function CorrelationMatrix({ fields, matrix, countyCount, countie
       </div>
 
       <p className="text-[9px] text-on-surface-variant/50 sm:hidden mb-1">Swipe to scroll</p>
-      <div style={{ overflowX: "auto", overflowY: "visible", WebkitOverflowScrolling: "touch" }}>
-        <svg width={svgW} height={svgH} className="block" style={{ overflow: "visible" }} role="img" aria-labelledby={titleId}>
+      {/* Visual grid is mouse-interactive but decorative to assistive tech —
+          role="img" flattened its cells out of the a11y tree, so a screen
+          reader got one opaque image. The real accessible representation is the
+          <table> below (arrow-key navigable, every r-value exposed). */}
+      <div style={{ overflowX: "auto", overflowY: "visible", WebkitOverflowScrolling: "touch" }} aria-hidden="true">
+        <svg width={svgW} height={svgH} className="block" style={{ overflow: "visible" }}>
           <title id={titleId}>Correlation matrix: Pearson r values across {countyCount} California counties for {n} metrics</title>
           <desc>A {n} by {n} grid showing pairwise Pearson correlation coefficients between crash, demographic, and environmental metrics. Blue cells indicate positive correlations, red cells indicate negative correlations. Click any cell to view a scatter plot.</desc>
           {/* cells first so labels paint on top */}
@@ -263,6 +267,31 @@ export default function CorrelationMatrix({ fields, matrix, countyCount, countie
           })}
         </svg>
       </div>
+
+      {/* Screen-reader-accessible representation of the matrix above. */}
+      <table className="sr-only">
+        <caption>
+          Correlation matrix: Pearson r values across {countyCount} California counties for {n} metrics.
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">Metric</th>
+            {fields.map((f) => (
+              <th key={f.label} scope="col">{f.label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {matrix.map((row, i) => (
+            <tr key={fields[i].label}>
+              <th scope="row">{fields[i].label}</th>
+              {row.map((r, j) => (
+                <td key={j}>{isNaN(r) ? "N/A" : r.toFixed(2)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
 
       {hoverCell && !selected && (
         <p className="text-xs text-on-surface-variant text-center">

--- a/frontend/src/components/charts/SimpleBarChart.test.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.test.tsx
@@ -52,6 +52,21 @@ const data = [
 beforeEach(() => cleanup());
 
 describe("SimpleBarChart keyboard accessibility", () => {
+  // role="img" makes an SVG's whole subtree presentational, so the role="button"
+  // bars would be hidden from screen readers. When interactive the chart must be
+  // a group (name preserved) so the buttons are actually exposed.
+  it("uses role=group (not img) when bars are interactive", () => {
+    render(<SimpleBarChart data={data} onBarClick={() => {}} />);
+    expect(screen.getByRole("group")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("uses role=img for a non-interactive (decorative) chart", () => {
+    render(<SimpleBarChart data={data} />);
+    expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(screen.queryByRole("group")).toBeNull();
+  });
+
   it("exposes clickable bars as focusable buttons with a data label", () => {
     render(<SimpleBarChart data={data} onBarClick={() => {}} />);
     const bars = screen.getAllByRole("button");

--- a/frontend/src/components/charts/SimpleBarChart.tsx
+++ b/frontend/src/components/charts/SimpleBarChart.tsx
@@ -114,7 +114,7 @@ export default function SimpleBarChart({
     const svgH = Math.max(height, data.length * rowH);
     return (
       <div className="w-full overflow-visible relative" style={{ height: svgH }}>
-        <svg ref={svgRef} width="100%" height={svgH} className="block" role="img" aria-labelledby={title ? `${titleId}-h` : undefined}
+        <svg ref={svgRef} width="100%" height={svgH} className="block" role={onBarClick ? "group" : "img"} aria-labelledby={title ? `${titleId}-h` : undefined}
           onTouchStart={(e) => {
             const svg = svgRef.current;
             if (!svg || !data.length) return;
@@ -167,7 +167,7 @@ export default function SimpleBarChart({
 
   return (
     <div className="w-full overflow-visible relative" style={{ height }}>
-      <svg ref={svgRef} width="100%" height={height} className="block overflow-visible" role="img" aria-labelledby={title ? `${titleId}-v` : undefined}
+      <svg ref={svgRef} width="100%" height={height} className="block overflow-visible" role={onBarClick ? "group" : "img"} aria-labelledby={title ? `${titleId}-v` : undefined}
         onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={`${titleId}-v`}>{title}</title>}
         {data.map((d, i) => {

--- a/frontend/src/components/ui/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.test.tsx
@@ -109,4 +109,28 @@ describe("ErrorBoundary", () => {
     rerender(<ErrorBoundary><Bomb /></ErrorBoundary>);
     expect(btn()).toHaveTextContent("Try again");
   });
+
+  it("clears its error when resetKey changes (e.g. route navigation) — M-F12", () => {
+    throwOnRender = true;
+    const { rerender } = render(<ErrorBoundary resetKey="/a"><Bomb /></ErrorBoundary>);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    // Navigate to a different route: child is healthy and resetKey changes.
+    throwOnRender = false;
+    rerender(<ErrorBoundary resetKey="/b"><Bomb /></ErrorBoundary>);
+
+    expect(screen.getByText("OK")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("stays latched when resetKey is unchanged", () => {
+    throwOnRender = true;
+    const { rerender } = render(<ErrorBoundary resetKey="/a"><Bomb /></ErrorBoundary>);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    // Same route, child now healthy — boundary must NOT auto-clear on its own.
+    throwOnRender = false;
+    rerender(<ErrorBoundary resetKey="/a"><Bomb /></ErrorBoundary>);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -10,6 +10,10 @@ interface Props {
   // falling through to the default UI. Omitting the prop entirely gives
   // you the default retry UI.
   fallback?: ReactNode;
+  // When this value changes, a latched error is cleared. Pass the route (e.g.
+  // location.pathname) so navigating away from a crashed page shows the new
+  // page instead of the stale error fallback (M-F12).
+  resetKey?: unknown;
 }
 
 interface State {
@@ -28,7 +32,13 @@ export class ErrorBoundary extends Component<Props, State> {
     console.error("[ErrorBoundary]", error, info.componentStack);
   }
 
-  componentDidUpdate(_prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    // Navigation (or any resetKey change) clears a latched error so the next
+    // route isn't hidden behind a stale fallback (M-F12).
+    if (prevProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false, retryCount: 0 });
+      return;
+    }
     // Child rendered successfully after a retry — reset count for the next error episode.
     if (prevState.hasError && !this.state.hasError) {
       this.setState({ retryCount: 0 });

--- a/frontend/src/hooks/useAskAi.test.tsx
+++ b/frontend/src/hooks/useAskAi.test.tsx
@@ -77,6 +77,30 @@ describe("useAskAi", () => {
     expect(result.current.error).toMatch(/wait/i);
   });
 
+  it("retry does not put the resent question in the LLM history twice (M-F6)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("answer"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAskAi(), { wrapper });
+
+    await act(async () => { await result.current.sendMessage("repeat me"); });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Jump past the per-question cooldown so retry actually re-fires.
+    const realNow = Date.now.bind(Date);
+    vi.spyOn(Date, "now").mockImplementation(() => realNow() + 20_000);
+
+    await act(async () => { result.current.retry(); });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const retryBody = JSON.parse((fetchMock.mock.calls[1][1] as RequestInit).body as string);
+    const occurrences = retryBody.history.filter(
+      (m: { content: string }) => m.content === "repeat me",
+    ).length;
+    expect(occurrences).toBe(1);
+  });
+
   it("shares one conversation across two consumers of the provider", async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse("shared answer"));
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/src/hooks/useAskAi.test.tsx
+++ b/frontend/src/hooks/useAskAi.test.tsx
@@ -101,6 +101,22 @@ describe("useAskAi", () => {
     expect(occurrences).toBe(1);
   });
 
+  it("retry fires during the local per-question cooldown (bypasses it)", async () => {
+    // The first send arms the local 15s cooldown at send-start. A naive retry
+    // would be blocked by that cooldown; retry() must bypass it.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("answer"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAskAi(), { wrapper });
+    await act(async () => { await result.current.sendMessage("q"); });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Retry immediately — do NOT advance the clock past the 15s cooldown.
+    await act(async () => { result.current.retry(); });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
   it("shares one conversation across two consumers of the provider", async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse("shared answer"));
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/src/hooks/useAskAi.tsx
+++ b/frontend/src/hooks/useAskAi.tsx
@@ -103,6 +103,9 @@ function useAskAiState(): AskAiApi {
   messagesRef.current = messages;
   const cooldownEndRef = useRef(cooldownEnd);
   cooldownEndRef.current = cooldownEnd;
+  // Only set by a server 429/503 backoff (not the local per-question cooldown),
+  // so retry() can bypass the local cooldown while still honoring server backoff.
+  const serverBackoffUntilRef = useRef(0);
   const inFlightRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -122,13 +125,17 @@ function useAskAiState(): AskAiApi {
     return () => { abortRef.current?.abort(); };
   }, []);
 
-  const sendMessage = useCallback(async (question: string) => {
+  const sendMessage = useCallback(async (question: string, opts?: { bypassLocalCooldown?: boolean }) => {
     if (!question.trim() || isLoading || inFlightRef.current) return;
-    // Respect the cooldown (including server 429/503 backoff) for every
-    // caller, not just the Ask AI page's send button — e.g. the AI
-    // companion's "Go deeper" and retry() must not bypass it.
-    if (Date.now() < cooldownEndRef.current) {
-      const remaining = Math.ceil((cooldownEndRef.current - Date.now()) / 1000);
+    // Respect the cooldown for every caller (the AI companion's "Go deeper"
+    // etc.). retry() passes bypassLocalCooldown so a fast failure's own local
+    // cooldown doesn't block the retry — but a server 429/503 backoff is still
+    // honored via serverBackoffUntilRef.
+    const guardUntil = opts?.bypassLocalCooldown
+      ? serverBackoffUntilRef.current
+      : cooldownEndRef.current;
+    if (Date.now() < guardUntil) {
+      const remaining = Math.ceil((guardUntil - Date.now()) / 1000);
       setError(`Please wait ${remaining}s before asking again.`);
       return;
     }
@@ -187,6 +194,7 @@ function useAskAiState(): AskAiApi {
           if (attempt < MAX_RETRIES - 1) continue;
           const data = await resp.json().catch(() => ({}));
           const retryAfter = data.retry_after || 60;
+          serverBackoffUntilRef.current = Date.now() + retryAfter * 1000;
           setCooldownEnd(Date.now() + retryAfter * 1000);
           setError(data.message || "All AI providers are busy. Try again shortly.");
           setIsLoading(false);
@@ -202,6 +210,7 @@ function useAskAiState(): AskAiApi {
             await new Promise((r) => setTimeout(r, retryAfter * 1000));
             continue;
           }
+          serverBackoffUntilRef.current = Date.now() + retryAfter * 1000;
           setCooldownEnd(Date.now() + retryAfter * 1000);
           setError(`Rate limit reached. Try again in ${retryAfter} seconds.`);
           setIsLoading(false);
@@ -267,7 +276,9 @@ function useAskAiState(): AskAiApi {
       // gets sent twice (M-F6).
       messagesRef.current = messagesRef.current.filter((m) => m !== lastUserMsg);
       setMessages((prev) => prev.filter((m) => m !== lastUserMsg));
-      sendMessage(lastUserMsg.content);
+      // Bypass the local per-question cooldown the failed send set; server
+      // 429/503 backoff is still honored.
+      sendMessage(lastUserMsg.content, { bypassLocalCooldown: true });
     }
   }, [sendMessage]);
 

--- a/frontend/src/hooks/useAskAi.tsx
+++ b/frontend/src/hooks/useAskAi.tsx
@@ -261,6 +261,11 @@ function useAskAiState(): AskAiApi {
     const lastUserMsg = [...messagesRef.current].reverse().find((m) => m.role === "user");
     if (lastUserMsg) {
       setError(null);
+      // Drop the failed question from the ref synchronously, not just via the
+      // async setMessages: sendMessage builds the LLM history from
+      // messagesRef.current on this same tick, so without this the question
+      // gets sent twice (M-F6).
+      messagesRef.current = messagesRef.current.filter((m) => m !== lastUserMsg);
       setMessages((prev) => prev.filter((m) => m !== lastUserMsg));
       sendMessage(lastUserMsg.content);
     }

--- a/frontend/src/hooks/useDashboardConfig.ts
+++ b/frontend/src/hooks/useDashboardConfig.ts
@@ -1,31 +1,13 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { DashboardConfig, ChartSlot, Dimension, Measure, ChartType, ChartOptions, PresetKey } from "../lib/dashboard/types";
-import { DIMENSIONS, MEASURES } from "../lib/dashboard/types";
 import { generateId } from "../lib/dashboard/types";
-import { buildPresetCharts, PRESET_KEYS, PRESETS } from "../lib/dashboard/presets";
+import { buildPresetCharts, PRESETS } from "../lib/dashboard/presets";
 import { decodeDashboard } from "../lib/dashboard/urlCodec";
+import { isValidConfig } from "../lib/dashboard/validateConfig";
 
 const STORAGE_KEY = "calsight-dashboard-v1";
 const URL_PARAM = "dashboard";
-
-const VALID_MODES = new Set(["simple", "advanced"]);
-
-function isValidConfig(p: unknown): p is DashboardConfig {
-  if (!p || typeof p !== "object") return false;
-  const c = p as Record<string, unknown>;
-  if (!VALID_MODES.has(c.mode as string)) return false;
-  if (!PRESET_KEYS.includes(c.preset as PresetKey)) return false;
-  if (!Array.isArray(c.charts)) return false;
-  return c.charts.every(
-    (s: Record<string, unknown>) =>
-      typeof s.id === "string" &&
-      typeof s.order === "number" &&
-      (DIMENSIONS as readonly string[]).includes(s.dimension as string) &&
-      (MEASURES as readonly string[]).includes(s.measure as string) &&
-      ["bar", "hbar", "line", "area", "donut", "treemap", "gauge", "stat", "polar", "lollipop", "radar", "scatter"].includes(s.chartType as string),
-  );
-}
 
 function loadInitialConfig(): DashboardConfig {
   if (typeof window === "undefined") return { mode: "simple", preset: "overview", charts: [] };

--- a/frontend/src/hooks/useDashboardKeyboard.test.tsx
+++ b/frontend/src/hooks/useDashboardKeyboard.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { useDashboardKeyboard } from "./useDashboardKeyboard";
+import { PRESET_KEYS } from "../lib/dashboard/presets";
+
+type Props = Parameters<typeof useDashboardKeyboard>[0];
+function Harness(props: Props) {
+  useDashboardKeyboard(props);
+  return <input data-testid="field" />;
+}
+
+const noop = () => {};
+
+describe("useDashboardKeyboard", () => {
+  it("maps number keys 1-8 to the preset at that index", () => {
+    const onSetPreset = vi.fn();
+    render(<Harness onSetMode={noop} onSetPreset={onSetPreset} onCloseConfig={noop} />);
+    fireEvent.keyDown(document, { key: "1" });
+    fireEvent.keyDown(document, { key: "3" });
+    expect(onSetPreset).toHaveBeenNthCalledWith(1, PRESET_KEYS[0]);
+    expect(onSetPreset).toHaveBeenNthCalledWith(2, PRESET_KEYS[2]);
+  });
+
+  it("B enters builder/advanced mode; Escape closes config", () => {
+    const onSetMode = vi.fn();
+    const onCloseConfig = vi.fn();
+    render(<Harness onSetMode={onSetMode} onSetPreset={noop} onCloseConfig={onCloseConfig} />);
+    fireEvent.keyDown(document, { key: "b" });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onSetMode).toHaveBeenCalledWith("advanced");
+    expect(onCloseConfig).toHaveBeenCalledOnce();
+  });
+
+  it("ignores shortcuts while an input is focused", () => {
+    const onSetPreset = vi.fn();
+    render(<Harness onSetMode={noop} onSetPreset={onSetPreset} onCloseConfig={noop} />);
+    screen.getByTestId("field").focus();
+    fireEvent.keyDown(document, { key: "1" });
+    expect(onSetPreset).not.toHaveBeenCalled();
+  });
+
+  it("removes its listener on unmount", () => {
+    const onSetPreset = vi.fn();
+    const { unmount } = render(
+      <Harness onSetMode={noop} onSetPreset={onSetPreset} onCloseConfig={noop} />,
+    );
+    unmount();
+    fireEvent.keyDown(document, { key: "2" });
+    expect(onSetPreset).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when disabled", () => {
+    const onSetPreset = vi.fn();
+    render(<Harness onSetMode={noop} onSetPreset={onSetPreset} onCloseConfig={noop} enabled={false} />);
+    fireEvent.keyDown(document, { key: "1" });
+    expect(onSetPreset).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useSavedDashboards.test.tsx
+++ b/frontend/src/hooks/useSavedDashboards.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useSavedDashboards } from "./useSavedDashboards";
+import { PRESET_KEYS } from "../lib/dashboard/presets";
+import { DIMENSIONS, MEASURES } from "../lib/dashboard/types";
+
+const KEY = "calsight-saved-dashboards-v1";
+const validConfig = {
+  mode: "simple",
+  preset: PRESET_KEYS[0],
+  charts: [{ id: "a", order: 0, dimension: DIMENSIONS[0], measure: MEASURES[0], chartType: "bar" }],
+};
+const entry = (id: string, config: unknown) => ({
+  id, name: id, savedAt: new Date().toISOString(), config,
+});
+
+beforeEach(() => localStorage.clear());
+
+describe("useSavedDashboards (M-F5)", () => {
+  it("load returns null for a corrupt saved config instead of a crashing one", () => {
+    localStorage.setItem(KEY, JSON.stringify([entry("bad", { mode: "garbage", charts: "nope" })]));
+    const { result } = renderHook(() => useSavedDashboards());
+    expect(result.current.load("bad")).toBeNull();
+  });
+
+  it("load returns a valid saved config unchanged", () => {
+    localStorage.setItem(KEY, JSON.stringify([entry("ok", validConfig)]));
+    const { result } = renderHook(() => useSavedDashboards());
+    expect(result.current.load("ok")).toEqual(validConfig);
+  });
+
+  it("drops garbage array entries so list doesn't choke", () => {
+    localStorage.setItem(KEY, JSON.stringify([null, "x", 42, entry("ok", validConfig)]));
+    const { result } = renderHook(() => useSavedDashboards());
+    expect(result.current.list()).toHaveLength(1);
+    expect(result.current.list()[0].id).toBe("ok");
+  });
+});

--- a/frontend/src/hooks/useSavedDashboards.ts
+++ b/frontend/src/hooks/useSavedDashboards.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { DashboardConfig } from "../lib/dashboard/types";
+import { isValidConfig } from "../lib/dashboard/validateConfig";
 
 const STORAGE_KEY = "calsight-saved-dashboards-v1";
 const MAX_SAVES = 20;
@@ -22,13 +23,25 @@ function generateId(): string {
   );
 }
 
+function isSavedShape(d: unknown): d is SavedDashboard {
+  if (!d || typeof d !== "object") return false;
+  const e = d as Record<string, unknown>;
+  return (
+    typeof e.id === "string" &&
+    typeof e.name === "string" &&
+    typeof e.savedAt === "string" &&
+    !!e.config && typeof e.config === "object"
+  );
+}
+
 function readFromStorage(): SavedDashboard[] {
   try {
     const raw = safeGetItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed;
+    // Drop garbage entries so list/rename/remove can't choke on them.
+    return parsed.filter(isSavedShape);
   } catch {
     return [];
   }
@@ -67,7 +80,10 @@ export function useSavedDashboards() {
   const load = useCallback((id: string): DashboardConfig | null => {
     const current = readFromStorage();
     const entry = current.find((d) => d.id === id);
-    return entry?.config ?? null;
+    // Validate before handing back a config from storage — a corrupt or
+    // older-schema save would otherwise crash the dashboard on apply (M-F5).
+    if (entry && isValidConfig(entry.config)) return entry.config;
+    return null;
   }, []);
 
   const remove = useCallback(

--- a/frontend/src/lib/dashboard/validateConfig.test.ts
+++ b/frontend/src/lib/dashboard/validateConfig.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isValidConfig } from "./validateConfig";
+import { PRESET_KEYS } from "./presets";
+import { DIMENSIONS, MEASURES } from "./types";
+
+const valid = {
+  mode: "simple",
+  preset: PRESET_KEYS[0],
+  charts: [{ id: "a", order: 0, dimension: DIMENSIONS[0], measure: MEASURES[0], chartType: "bar" }],
+};
+
+describe("isValidConfig", () => {
+  it("accepts a well-formed config", () => {
+    expect(isValidConfig(valid)).toBe(true);
+  });
+
+  it("rejects non-objects", () => {
+    expect(isValidConfig(null)).toBe(false);
+    expect(isValidConfig("x")).toBe(false);
+    expect(isValidConfig(42)).toBe(false);
+  });
+
+  it("rejects an invalid mode or unknown preset", () => {
+    expect(isValidConfig({ ...valid, mode: "bogus" })).toBe(false);
+    expect(isValidConfig({ ...valid, preset: "not-a-preset" })).toBe(false);
+  });
+
+  it("rejects when charts is not an array", () => {
+    expect(isValidConfig({ ...valid, charts: "nope" })).toBe(false);
+  });
+
+  it("rejects a chart with an invalid dimension/measure/chartType", () => {
+    expect(isValidConfig({ ...valid, charts: [{ id: "a", order: 0, dimension: "bad", measure: MEASURES[0], chartType: "bar" }] })).toBe(false);
+    expect(isValidConfig({ ...valid, charts: [{ id: "a", order: 0, dimension: DIMENSIONS[0], measure: MEASURES[0], chartType: "xyz" }] })).toBe(false);
+  });
+
+  it("does not throw on a null/garbage chart element", () => {
+    expect(isValidConfig({ ...valid, charts: [null] })).toBe(false);
+    expect(isValidConfig({ ...valid, charts: ["x"] })).toBe(false);
+  });
+});

--- a/frontend/src/lib/dashboard/validateConfig.ts
+++ b/frontend/src/lib/dashboard/validateConfig.ts
@@ -1,0 +1,34 @@
+import type { DashboardConfig, PresetKey } from "./types";
+import { DIMENSIONS, MEASURES } from "./types";
+import { PRESET_KEYS } from "./presets";
+
+const VALID_MODES = new Set(["simple", "advanced"]);
+const VALID_CHART_TYPES = new Set([
+  "bar", "hbar", "line", "area", "donut", "treemap", "gauge",
+  "stat", "polar", "lollipop", "radar", "scatter",
+]);
+
+/**
+ * Structural validation for a persisted/deep-linked DashboardConfig. Used before
+ * applying anything that came from localStorage, a saved dashboard, or a URL — a
+ * corrupt or older-schema config would otherwise render into a crash. Never
+ * throws, even on `charts: [null]`.
+ */
+export function isValidConfig(p: unknown): p is DashboardConfig {
+  if (!p || typeof p !== "object") return false;
+  const c = p as Record<string, unknown>;
+  if (!VALID_MODES.has(c.mode as string)) return false;
+  if (!PRESET_KEYS.includes(c.preset as PresetKey)) return false;
+  if (!Array.isArray(c.charts)) return false;
+  return c.charts.every((s) => {
+    if (!s || typeof s !== "object") return false;
+    const chart = s as Record<string, unknown>;
+    return (
+      typeof chart.id === "string" &&
+      typeof chart.order === "number" &&
+      (DIMENSIONS as readonly string[]).includes(chart.dimension as string) &&
+      (MEASURES as readonly string[]).includes(chart.measure as string) &&
+      VALID_CHART_TYPES.has(chart.chartType as string)
+    );
+  });
+}

--- a/frontend/src/lib/lazyWithRetry.test.ts
+++ b/frontend/src/lib/lazyWithRetry.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { retryDynamicImport } from "./lazyWithRetry";
+
+const mod = { default: () => null };
+
+describe("retryDynamicImport", () => {
+  it("returns the module on first success", async () => {
+    const factory = vi.fn().mockResolvedValue(mod);
+    await expect(retryDynamicImport(factory, 2, 0)).resolves.toBe(mod);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a failed import and succeeds", async () => {
+    const factory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Failed to fetch dynamically imported module"))
+      .mockRejectedValueOnce(new Error("chunk 404"))
+      .mockResolvedValue(mod);
+    await expect(retryDynamicImport(factory, 2, 0)).resolves.toBe(mod);
+    expect(factory).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows after exhausting retries so the error boundary can catch it", async () => {
+    const factory = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(retryDynamicImport(factory, 2, 0)).rejects.toThrow("boom");
+    expect(factory).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/lib/lazyWithRetry.ts
+++ b/frontend/src/lib/lazyWithRetry.ts
@@ -1,0 +1,32 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+
+/**
+ * Retry a dynamic `import()` a few times before giving up.
+ *
+ * After a deploy the previous build's chunk hashes 404, so a user with the old
+ * `index.html` open hits "Failed to fetch dynamically imported module" the first
+ * time they navigate to a not-yet-loaded route. A single retry usually resolves
+ * it (the CDN serves the new chunk); if every attempt fails we rethrow so the
+ * surrounding ErrorBoundary shows its retry/reload UI instead of hanging on the
+ * Suspense spinner forever.
+ */
+export async function retryDynamicImport<T>(
+  factory: () => Promise<T>,
+  retries = 2,
+  delayMs = 300,
+): Promise<T> {
+  try {
+    return await factory();
+  } catch (err) {
+    if (retries <= 0) throw err;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return retryDynamicImport(factory, retries - 1, delayMs);
+  }
+}
+
+/** `React.lazy` with transient chunk-load retries. Drop-in for `lazy()`. */
+export function lazyWithRetry<T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  return lazy(() => retryDynamicImport(factory));
+}

--- a/frontend/src/lib/theme/persistence.test.ts
+++ b/frontend/src/lib/theme/persistence.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { loadCustomization } from "./persistence";
+import { getDefaultCustomization } from "./presets";
+
+const KEY = "calsight-theme-customization";
+
+beforeEach(() => localStorage.clear());
+
+describe("loadCustomization — resilient to corrupt/legacy stored themes (M-F2)", () => {
+  it("returns the default when nothing is stored", () => {
+    expect(loadCustomization()).toEqual(getDefaultCustomization());
+  });
+
+  it("does not crash and heals a stored theme whose colors is the wrong type", () => {
+    // The old shape check only tested truthiness, so a string `colors` passed
+    // through and blew up downstream, crashing the app into a reload loop.
+    localStorage.setItem(KEY, JSON.stringify({
+      activePreset: "custom",
+      colors: "corrupt",
+      chart: { palette: "default", customColors: [] },
+      cardStyle: "elevated",
+      density: "comfortable",
+      typeScale: "default",
+      customVars: {},
+    }));
+    const result = loadCustomization();
+    expect(typeof result.colors.primary).toBe("string");
+    expect(typeof result.colors.error).toBe("string");
+  });
+
+  it("fills missing nested fields from the default (legacy partial theme)", () => {
+    localStorage.setItem(KEY, JSON.stringify({ colors: { primary: "1 2 3" } }));
+    const result = loadCustomization();
+    expect(result.colors.primary).toBe("1 2 3");           // kept
+    expect(Array.isArray(result.chart.customColors)).toBe(true); // filled
+    expect(result.cardStyle).toBe(getDefaultCustomization().cardStyle);
+  });
+
+  it("coerces a non-array customColors to the default", () => {
+    localStorage.setItem(KEY, JSON.stringify({
+      chart: { palette: "custom", customColors: "nope" },
+    }));
+    expect(Array.isArray(loadCustomization().chart.customColors)).toBe(true);
+  });
+
+  it("returns the default and clears the key on unparseable JSON", () => {
+    localStorage.setItem(KEY, "{not json");
+    expect(loadCustomization()).toEqual(getDefaultCustomization());
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("preserves a fully valid stored theme", () => {
+    const valid = { ...getDefaultCustomization(), activePreset: "midnight" as const, colors: { primary: "10 20 30", tertiary: "40 50 60", error: "70 80 90" } };
+    localStorage.setItem(KEY, JSON.stringify(valid));
+    expect(loadCustomization()).toEqual(valid);
+  });
+});

--- a/frontend/src/lib/theme/persistence.ts
+++ b/frontend/src/lib/theme/persistence.ts
@@ -4,25 +4,68 @@
 
 import type { ThemeCustomization, ExportedTheme } from "./types";
 import { getDefaultCustomization } from "./presets";
-import { safeGetItem, safeSetItem } from "../safeStorage";
+import { safeGetItem, safeSetItem, safeRemoveItem } from "../safeStorage";
 
 const STORAGE_KEY = "calsight-theme-customization";
 
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function asString<T extends string>(v: unknown, fallback: T): T {
+  return typeof v === "string" ? (v as T) : fallback;
+}
+
+/**
+ * Rebuild a guaranteed-valid customization from an untrusted parsed value,
+ * taking each field only when it has the right *type* and otherwise falling
+ * back to the default. The old code only checked truthiness (`!parsed.colors`),
+ * so a legacy/corrupt theme with e.g. `colors` as a string slipped through and
+ * crashed the app on apply — and because the crash handler's "Reload" never
+ * cleared the theme key, the app reload-looped (M-F2). This makes any parseable
+ * value safe, and partial/legacy themes hydrate from the default.
+ */
+function hydrateCustomization(raw: unknown): ThemeCustomization {
+  const def = getDefaultCustomization();
+  if (!isObject(raw)) return def;
+  const colors = isObject(raw.colors) ? raw.colors : {};
+  const chart = isObject(raw.chart) ? raw.chart : {};
+  return {
+    activePreset: asString(raw.activePreset, def.activePreset),
+    colors: {
+      primary: asString(colors.primary, def.colors.primary),
+      tertiary: asString(colors.tertiary, def.colors.tertiary),
+      error: asString(colors.error, def.colors.error),
+    },
+    chart: {
+      palette: asString(chart.palette, def.chart.palette),
+      customColors: Array.isArray(chart.customColors)
+        ? chart.customColors.filter((c): c is string => typeof c === "string")
+        : def.chart.customColors,
+    },
+    cardStyle: asString(raw.cardStyle, def.cardStyle),
+    density: asString(raw.density, def.density),
+    typeScale: asString(raw.typeScale, def.typeScale),
+    customVars: isObject(raw.customVars)
+      ? (Object.fromEntries(
+          Object.entries(raw.customVars).filter(([, v]) => typeof v === "string"),
+        ) as Record<string, string>)
+      : def.customVars,
+  };
+}
+
 /**
  * Load persisted customization from localStorage.
- * Returns the default if nothing is stored or if the stored value is invalid.
+ * Returns a fully-valid customization even if the stored value is corrupt or
+ * from an older schema. Unparseable JSON is cleared so it can't reload-loop.
  */
 export function loadCustomization(): ThemeCustomization {
   const raw = safeGetItem(STORAGE_KEY);
   if (!raw) return getDefaultCustomization();
   try {
-    const parsed = JSON.parse(raw) as ThemeCustomization;
-    // Basic shape validation
-    if (!parsed.colors || !parsed.chart || !parsed.cardStyle) {
-      return getDefaultCustomization();
-    }
-    return parsed;
+    return hydrateCustomization(JSON.parse(raw));
   } catch {
+    safeRemoveItem(STORAGE_KEY);
     return getDefaultCustomization();
   }
 }

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -194,20 +194,23 @@ function StatsPageInner() {
   const [closeConfigTrigger, setCloseConfigTrigger] = useState(0);
   const handleCloseConfig = useCallback(() => setCloseConfigTrigger((n) => n + 1), []);
 
-  // Dashboard keyboard shortcuts: 1-8 presets, B for builder, Escape to close config
-  useDashboardKeyboard({
-    onSetMode: dashboard.setMode,
-    onSetPreset: dashboard.setPreset,
-    onCloseConfig: handleCloseConfig,
-  });
-
-  // Clear drill state and cross-filter when preset changes
+  // Switching preset must clear drill + cross-filter, otherwise a single-county
+  // drill carries into the new preset and its statewide charts read as that one
+  // county (M-F4). Both the mouse (PresetPicker) and keyboard (1-8) paths go
+  // through this one handler so they can't diverge.
   const handlePresetSelect = useCallback((key: Parameters<typeof dashboard.setPreset>[0]) => {
     timelapse.pause();
     resetDrill();
     crossFilter.clearCrossFilter();
     dashboard.setPreset(key);
   }, [timelapse, resetDrill, crossFilter, dashboard]);
+
+  // Dashboard keyboard shortcuts: 1-8 presets, B for builder, Escape to close config
+  useDashboardKeyboard({
+    onSetMode: dashboard.setMode,
+    onSetPreset: handlePresetSelect,
+    onCloseConfig: handleCloseConfig,
+  });
 
   function handleClearAll() {
     timelapse.pause();


### PR DESCRIPTION
**Single-merge batch** combining the four verified PRs from this session's audit-remediation work, so they ship together in one deploy. All four touch disjoint files — merged with zero conflicts.

## What's in it
**#356 — resilience & correctness (10 fixes):** `lazyWithRetry` (route chunk recovery), M-F2 theme-heal, M-F4 keyboard-preset reset, M-F5 saved-dashboard validation, M-F12 ErrorBoundary reset-on-nav, M-F6 retry-history dedup, M-B4 `matview_age` tz fix, + 3 Fable-audit fixes (SVG `role=group` a11y, retry-cooldown bypass, freshness allowlist for `fars`/`tract_density`).

**#357 — `/ask` query backstop:** `SET LOCAL statement_timeout=50s` so a runaway 11M-row AI-tool query is killed and releases its pool connection instead of outliving the request.

**#358 — CorrelationMatrix a11y:** the `role=img` grid hid all 841 r-values from screen readers; now an accessible `<table>` (the visual SVG is `aria-hidden`).

**#359 — crawler `content-encoding` fix:** the OG-tag middleware copied the upstream gzip header onto its decoded body, breaking link previews; now stripped.

## Verification
- **Backend 739 tests** (unit + integration via Docker test-pg) + **frontend 665 tests**, tsc + eslint clean — run on this combined branch.
- Real-browser (Playwright) confirmed the two visible a11y fixes: bar-chart buttons exposed in the AX tree, and the correlation table's 841 cells navigable.

## From the two Fable 5 audits — deliberately NOT here (need your call)
- Proxy-aware client IP (rate limits are global behind the CF tunnel) — needs confirming the tunnel forwards `CF-Connecting-IP`.
- M-B11 per-worker rate-limit/cache dilution — needs Redis.
- Public stats/street-level scan caching — needs a matview (bigger effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)