### PR TITLE
hotfix(etl): skip CCRS years with no published resource (prod incident — stale crash data)

### DIFF
--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -230,6 +230,20 @@ def select_years_to_load(
     return switrs_years, ccrs_years, skipped
 
 
+def ccrs_years_with_resources(years, available) -> list[int]:
+    """Keep only CCRS years that have a published CKAN resource.
+
+    end_year auto-advances to the current year + 1 so new calendar years don't
+    need a manual edit — but the next year's CKAN resource doesn't exist until
+    its data is published. Attempting it raised KeyError (RESOURCE_IDS[year]) →
+    a failed batch → the whole nightly crashes_ccrs job errored and, with
+    loud-failure, cascaded to every dependent (stale freshness). Skip unpublished
+    years so the load stays green until the resource lands.
+    """
+    available = set(available)
+    return [y for y in years if y in available]
+
+
 def run(
     start_year: int = DEFAULT_START_YEAR,
     end_year: int = DEFAULT_END_YEAR,
@@ -339,7 +353,16 @@ def run(
         # Each page (~32K records) is fetched, transformed, and upserted
         # before fetching the next — no full-year memory buffer needed.
         if ccrs_years:
-            from etl.ckan_api import fetch_crashes_for_year  # noqa: PLC0415
+            from etl.ckan_api import fetch_crashes_for_year, RESOURCE_IDS  # noqa: PLC0415
+
+            no_resource = [y for y in ccrs_years if y not in RESOURCE_IDS]
+            if no_resource:
+                logger.info(
+                    "Skipping CCRS years with no published resource yet: %s "
+                    "(end_year auto-advances past available data)",
+                    no_resource,
+                )
+            ccrs_years = ccrs_years_with_resources(ccrs_years, RESOURCE_IDS)
 
             for year in ccrs_years:
                 year_rows = 0

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -143,3 +143,26 @@ class TestNoSelfTracking:
         mod.run(start_year=2016, end_year=2016, source_filter="ccrs")
 
         etl_run_ctor.assert_not_called()
+
+
+class TestCcrsYearsWithResources:
+    """Regression for the 2026-07-05 prod incident: crashes_ccrs errored on
+    year 2027 (end_year = current+1) because RESOURCE_IDS has no 2027 yet →
+    KeyError → failed batch → whole job errored (cascaded to dependents)."""
+
+    def test_drops_years_with_no_published_resource(self):
+        from etl.load_crashes import ccrs_years_with_resources
+        available = {2016, 2024, 2025, 2026}
+        assert ccrs_years_with_resources([2025, 2026, 2027], available) == [2025, 2026]
+
+    def test_keeps_order_of_present_years(self):
+        from etl.load_crashes import ccrs_years_with_resources
+        assert ccrs_years_with_resources([2016, 2026], {2016, 2026}) == [2016, 2026]
+
+    def test_real_resource_ids_skip_the_next_calendar_year(self):
+        from etl.load_crashes import ccrs_years_with_resources
+        from etl.ckan_api import RESOURCE_IDS
+        latest = max(RESOURCE_IDS)
+        # the auto-advanced next year is not loadable; the latest published one is
+        assert ccrs_years_with_resources([latest + 1], RESOURCE_IDS) == []
+        assert ccrs_years_with_resources([latest], RESOURCE_IDS) == [latest]


### PR DESCRIPTION
**Prod incident.** `crashes_ccrs` has errored the last two nights (07-04 hung → zombie-killed; 07-05 exit 1), leaving crash freshness **stale ~66h**. Root cause diagnosed from prod `etl_runs` (read-only):

```
CCRS year 2026 complete: 171829 rows
Starting CCRS year 2027...
ERROR  CCRS year 2027 failed entirely: 2027   ← RESOURCE_IDS[2027] KeyError
Done. 572042 total rows upserted, 1 batches failed.
ERROR  1 batch(es) failed during load          ← exit 1 (loud-failure), cascades to dependents
```

`end_year` auto-advances to `current_year + 1` (= 2027), but `RESOURCE_IDS` only has 2016–2026, so `fetch_crashes_for_year(2027)` raises `KeyError`. That one "failed batch" makes the whole job exit non-zero (the loud-failure behavior from #353/#355), so every dependent (`parties`, `victims`, `backfill`, `matviews`, `insights`…) is skipped → stale. **The actual 2016–2026 load was fine** (572k rows ingested).

**Fix:** `ccrs_years_with_resources()` drops years absent from `RESOURCE_IDS`, so an unpublished future year is **skipped and logged**, not treated as a failure. When the 2027 resource is published, it's picked up automatically. 3 unit tests; full backend suite (740) green.

⏰ Worth merging before tonight's 02:00 UTC run so crash data catches up. Independent of #360.

**Separate (not fixed here, needs your hands — prod write):** the orphaned legacy freshness rows `materialized_views` / `backfill_derived` / `traffic_volumes` still read stale — one-time `DELETE FROM etl_runs WHERE source IN (...)`.