### PR TITLE
fix(etl): audit highs — amended-crash severity, CCRS year discovery, R2 min-keep

### DIFF
--- a/backend/etl/_utils.py
+++ b/backend/etl/_utils.py
@@ -44,6 +44,7 @@ from sqlalchemy import desc, text
 
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import EtlRun
+from etl.ckan_api import discover_resource_ids
 
 if TYPE_CHECKING:
     from etl.orchestrator import Job
@@ -331,14 +332,30 @@ def check_source_freshness(job: Job, db_session) -> FreshnessResult:
     return FreshnessResult(True, None, None, f"unknown source_type {job.source_type!r}")
 
 
+def _resolve_ckan_freshness_resource(job: Job) -> str | None:
+    """The resource id whose last_modified decides whether this job runs.
+
+    Jobs with a freshness_ckan_prefix probe the newest discovered year's
+    resource (see Job.freshness_ckan_prefix); everything else — and any
+    discovery failure — uses the pinned freshness_resource_id.
+    """
+    prefix = getattr(job, "freshness_ckan_prefix", None)
+    if prefix:
+        discovered = discover_resource_ids(prefix)
+        if discovered:
+            return discovered[max(discovered)]
+    return job.freshness_resource_id
+
+
 def _check_ckan_freshness(job: Job, last_run: EtlRun) -> FreshnessResult:
-    if not job.freshness_resource_id:
+    resource_id = _resolve_ckan_freshness_resource(job)
+    if not resource_id:
         return FreshnessResult(True, None, None, "ckan type but no resource_id")
 
     try:
         resp = get_with_retry(
             CKAN_RESOURCE_SHOW_URL,
-            params={"id": job.freshness_resource_id},
+            params={"id": resource_id},
             timeout=15.0,
         )
         resource = resp.json().get("result", {})

--- a/backend/etl/backfill_derived.py
+++ b/backend/etl/backfill_derived.py
@@ -806,6 +806,57 @@ def backfill_severity(db):
     logger.info("Severity: %d property damage only", r.rowcount)
 
 
+def repair_drifted_derived(db) -> int:
+    """Fix derived columns that disagree with the raw values they derive from.
+
+    Before 2026-07 the upsert didn't recompute derived columns, so a CHP
+    amendment (a victim dying within 30 days, a corrected crash_datetime)
+    left severity and the datetime extract columns stale — and the
+    NULL-guarded backfills above never touch a populated row. This repairs
+    the drift already sitting in prod and keeps acting as a nightly
+    invariant check.
+
+    The IS DISTINCT FROM guard means only genuinely inconsistent rows get
+    new tuple versions: after the first pass this is a read-mostly scan per
+    year with ~zero writes (no daily WAL churn — the M7 lesson). Rows whose
+    severity is still NULL are left for backfill_severity to fill first.
+    """
+    total = 0
+    for year in _all_crash_year_range(db):
+        r = db.execute(text("""
+            UPDATE crashes SET
+                severity = CASE
+                    WHEN number_killed > 0 THEN 'Fatal'
+                    WHEN number_injured > 0 THEN 'Injury'
+                    ELSE 'Property Damage Only'
+                END,
+                crash_year = EXTRACT(YEAR FROM crash_datetime)::smallint,
+                crash_month = EXTRACT(MONTH FROM crash_datetime)::smallint,
+                crash_hour = EXTRACT(HOUR FROM crash_datetime)::smallint,
+                day_of_week_num = (EXTRACT(ISODOW FROM crash_datetime)::smallint - 1)
+            WHERE crash_datetime >= :start AND crash_datetime < :end
+              AND severity IS NOT NULL
+              AND (
+                severity IS DISTINCT FROM CASE
+                    WHEN number_killed > 0 THEN 'Fatal'
+                    WHEN number_injured > 0 THEN 'Injury'
+                    ELSE 'Property Damage Only'
+                END
+                OR crash_year IS DISTINCT FROM EXTRACT(YEAR FROM crash_datetime)::smallint
+                OR crash_month IS DISTINCT FROM EXTRACT(MONTH FROM crash_datetime)::smallint
+                OR crash_hour IS DISTINCT FROM EXTRACT(HOUR FROM crash_datetime)::smallint
+                OR day_of_week_num IS DISTINCT FROM (EXTRACT(ISODOW FROM crash_datetime)::smallint - 1)
+              )
+        """), {"start": f"{year}-01-01", "end": f"{year + 1}-01-01"})
+        db.commit()
+        if r.rowcount > 0:
+            logger.info("Derived-drift repair %d: %d rows", year, r.rowcount)
+            total += r.rowcount
+
+    logger.info("Derived-drift repair done: %d rows", total)
+    return total
+
+
 @track_etl_run("backfill")
 def run():
     """Run all the backfills in order. Land area first since density needs it."""
@@ -820,6 +871,7 @@ def run():
         backfill_day_of_week(db)
         backfill_county_name(db)
         backfill_severity(db)
+        repair_drifted_derived(db)
         backfill_pedestrian_flags(db)
         backfill_alcohol_flags(db)
         backfill_distraction_flags(db)

--- a/backend/etl/backup.py
+++ b/backend/etl/backup.py
@@ -124,8 +124,17 @@ def upload_to_r2(filepath: Path) -> bool:
         return False
 
 
-def rotate_r2_backups(retention_days: int = RETENTION_DAYS) -> int:
-    """Delete backups older than retention_days from R2. Returns count removed."""
+def rotate_r2_backups(
+    retention_days: int = RETENTION_DAYS,
+    min_keep: int = MIN_KEEP_BACKUPS,
+) -> int:
+    """Delete backups older than retention_days from R2. Returns count removed.
+
+    Like the local rotation, the newest min_keep dumps are protected
+    regardless of age: if pg_dump silently fails for longer than the
+    retention window, the offsite copies — the ones that survive the box
+    dying — must not rotate to zero.
+    """
     access_key = os.environ.get("R2_ACCESS_KEY_ID")
     secret_key = os.environ.get("R2_SECRET_ACCESS_KEY")
     endpoint_url = os.environ.get("R2_ENDPOINT_URL")
@@ -149,18 +158,25 @@ def rotate_r2_backups(retention_days: int = RETENTION_DAYS) -> int:
             return 0
 
         cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=retention_days)
-        removed = 0
+
+        # Parse every dump's date first so the newest min_keep can be
+        # protected; unparseable names are left alone entirely.
+        dated: list[tuple[datetime, str]] = []
         for obj in resp["Contents"]:
             fname = obj["Key"].split("/")[-1]
             try:
                 date_str = fname.replace("calsight_", "").replace(".dump", "")
-                file_date = datetime.strptime(date_str, "%Y-%m-%d")
-                if file_date < cutoff:
-                    s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
-                    removed += 1
-                    logger.info("Rotated from R2: %s", fname)
+                dated.append((datetime.strptime(date_str, "%Y-%m-%d"), obj["Key"]))
             except (ValueError, KeyError):
                 continue
+        dated.sort(reverse=True)  # newest first
+
+        removed = 0
+        for file_date, key in dated[min_keep:]:
+            if file_date < cutoff:
+                s3.delete_object(Bucket=bucket_name, Key=key)
+                removed += 1
+                logger.info("Rotated from R2: %s", key.split("/")[-1])
 
         if removed:
             logger.info("Rotated %d R2 backup(s) older than %d days", removed, retention_days)

--- a/backend/etl/ckan_api.py
+++ b/backend/etl/ckan_api.py
@@ -17,6 +17,7 @@ The CKAN DataStore Search API returns JSON like:
 We paginate using limit/offset until all records are fetched.
 """
 
+import re
 import time
 import logging
 from datetime import datetime
@@ -26,12 +27,20 @@ import httpx
 logger = logging.getLogger(__name__)
 
 CKAN_BASE_URL = "https://data.ca.gov/api/3/action/datastore_search"
+CKAN_PACKAGE_SHOW_URL = "https://data.ca.gov/api/3/action/package_show"
+# The CCRS dataset ("package") on data.ca.gov that contains every yearly
+# Crashes_/Parties_/InjuredWitnessPassengers_ resource.
+CCRS_PACKAGE_ID = "80c6a49d-c6b3-40ba-86d8-379c9741b4be"
 PAGE_SIZE = 32000
 MAX_RETRIES = 3
 BACKOFF_BASE = 2  # seconds
 
 # Each year of CCRS data has a separate CKAN resource ID.
 # These IDs were sourced from data.ca.gov's CCRS dataset listing.
+# They are the offline fallback — discover_resource_ids() below finds new
+# calendar years automatically, so this map no longer needs a manual edit
+# every January (the cause of the 2026-07-05 staleness incident's sequel:
+# a 2027 that would never load while freshness reported green).
 RESOURCE_IDS = {
     2016: "3d5f2586-cf68-4213-aa1c-60df37399d10",
     2017: "4784664d-b7cf-4427-af25-7c7307bad56c",
@@ -45,6 +54,61 @@ RESOURCE_IDS = {
     2025: "9f4fc839-122d-4595-a146-43bc4ed16f46",
     2026: "b8ce0ca4-b4e9-490d-b4d1-1f4ec48cbefb",
 }
+
+# Successful discoveries, keyed by resource-name prefix. One package_show per
+# prefix per process is plenty — the orchestrator and each loader run in their
+# own process, and resources don't appear mid-run. Failures are NOT cached so
+# a transient outage doesn't pin an empty result for the whole process.
+_DISCOVERY_CACHE: dict[str, dict[int, str]] = {}
+
+
+def discover_resource_ids(prefix: str) -> dict[int, str]:
+    """Discover per-year CKAN resource ids by listing the CCRS package.
+
+    CHP publishes one resource per calendar year named ``<prefix>_<year>``
+    (e.g. ``Crashes_2026``, ``Parties_2026``). Listing the package finds new
+    years the moment they're published, instead of waiting for someone to
+    hand-edit RESOURCE_IDS each January.
+
+    Returns {} on any failure — callers merge over the static maps, so a
+    discovery outage degrades to exactly the old hardcoded behavior.
+    """
+    if prefix in _DISCOVERY_CACHE:
+        return _DISCOVERY_CACHE[prefix]
+
+    try:
+        resp = httpx.get(
+            CKAN_PACKAGE_SHOW_URL, params={"id": CCRS_PACKAGE_ID}, timeout=30.0
+        )
+        resp.raise_for_status()
+        resources = resp.json()["result"]["resources"]
+    except Exception as exc:
+        logger.warning(
+            "CCRS resource discovery failed (%s); falling back to static ids", exc
+        )
+        return {}
+
+    pattern = re.compile(rf"{re.escape(prefix)}_(20\d\d)")
+    found: dict[int, str] = {}
+    for res in resources:
+        match = pattern.fullmatch(str(res.get("name", "")).strip())
+        # datastore_active=False means the resource exists but its DataStore
+        # isn't loaded — datastore_search would 404, so don't offer it.
+        if match and res.get("datastore_active") and res.get("id"):
+            found[int(match.group(1))] = res["id"]
+
+    logger.info("Discovered %d %s_* resources: %s", len(found), prefix, sorted(found))
+    _DISCOVERY_CACHE[prefix] = found
+    return found
+
+
+def merged_resource_ids(prefix: str, static_ids: dict[int, str]) -> dict[int, str]:
+    """The static year->resource map with freshly discovered years merged over it.
+
+    Discovery wins on conflict (CHP occasionally re-creates a resource under a
+    new id); the static map covers discovery outages and is never mutated.
+    """
+    return {**static_ids, **discover_resource_ids(prefix)}
 
 
 def _safe_int(value):
@@ -175,7 +239,7 @@ def transform_ccrs(record: dict) -> dict:
     }
 
 
-def fetch_crashes_for_year(year: int):
+def fetch_crashes_for_year(year: int, resource_ids: dict[int, str] | None = None):
     """Yield batches of crash records for a given year from the CKAN DataStore API.
 
     Instead of loading an entire year into memory, this generator yields one
@@ -190,7 +254,10 @@ def fetch_crashes_for_year(year: int):
     represent malformed source rows that can't be uniquely identified.
 
     Args:
-        year: The crash year to fetch (must be in RESOURCE_IDS).
+        year: The crash year to fetch (must be in the resource map).
+        resource_ids: year -> CKAN resource id map. Defaults to the static
+            RESOURCE_IDS; the loader passes the discovery-merged map so newly
+            published years work without a code change.
 
     Yields:
         tuple of (batch: list[dict], offset: int, total: int)
@@ -202,7 +269,9 @@ def fetch_crashes_for_year(year: int):
         KeyError: If year is not in RESOURCE_IDS.
         httpx.HTTPStatusError / httpx.RequestError: If all retries fail.
     """
-    resource_id = RESOURCE_IDS[year]  # KeyError if year not found — intentional
+    if resource_ids is None:
+        resource_ids = RESOURCE_IDS
+    resource_id = resource_ids[year]  # KeyError if year not found — intentional
 
     logger.info("Fetching CCRS data for %d (resource_id=%s)", year, resource_id)
 

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -24,6 +24,7 @@ def build_default_registry() -> JobRegistry:
         max_drop_pct=5,
         source_type="ckan",
         freshness_resource_id="b8ce0ca4-b4e9-490d-b4d1-1f4ec48cbefb",
+        freshness_ckan_prefix="Crashes",
     ))
     registry.register(Job(
         name="parties",
@@ -36,6 +37,7 @@ def build_default_registry() -> JobRegistry:
         timeout=21600,
         source_type="ckan",
         freshness_resource_id="348a4266-bbb6-439f-b6c7-0018cc79f0fe",
+        freshness_ckan_prefix="Parties",
     ))
     registry.register(Job(
         name="victims",
@@ -48,6 +50,7 @@ def build_default_registry() -> JobRegistry:
         timeout=14400,
         source_type="ckan",
         freshness_resource_id="bbe0c38e-d0eb-4152-86e2-0b0895e66ba9",
+        freshness_ckan_prefix="InjuredWitnessPassengers",
     ))
     registry.register(Job(
         name="demographics",

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -27,7 +27,7 @@ import sys
 import tempfile
 from datetime import datetime, timezone
 
-from sqlalchemy import extract, func
+from sqlalchemy import SmallInteger, case, cast, extract, func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.cities_match import normalize_name
@@ -175,6 +175,23 @@ def upsert_crashes(
     update_set = {col: stmt.excluded[col] for col in _UPSERT_COLUMNS}
     update_set["coord_county_mismatch"] = None
     update_set["coord_validated_at"] = None
+    # CHP amends records after first publication — most importantly when a
+    # victim dies within 30 days and number_killed goes 0 -> 1. The backfills
+    # that populate these derived columns are NULL-guarded (they never touch a
+    # populated row), so recompute them here from the amended values. Computing
+    # inline (rather than resetting to NULL for the backfill, like the coord
+    # columns above) avoids a window where severity filters miss the row.
+    excluded = stmt.excluded
+    update_set["severity"] = case(
+        (excluded["number_killed"] > 0, "Fatal"),
+        (excluded["number_injured"] > 0, "Injury"),
+        else_="Property Damage Only",
+    )
+    dt = excluded["crash_datetime"]
+    update_set["crash_year"] = cast(extract("year", dt), SmallInteger)
+    update_set["crash_month"] = cast(extract("month", dt), SmallInteger)
+    update_set["crash_hour"] = cast(extract("hour", dt), SmallInteger)
+    update_set["day_of_week_num"] = cast(extract("isodow", dt) - 1, SmallInteger)
     stmt = stmt.on_conflict_do_update(
         constraint="uq_crashes_collision_source",
         set_=update_set,

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -230,6 +230,20 @@ def select_years_to_load(
     return switrs_years, ccrs_years, skipped
 
 
+def ccrs_years_with_resources(years, available) -> list[int]:
+    """Keep only CCRS years that have a published CKAN resource.
+
+    end_year auto-advances to the current year + 1 so new calendar years don't
+    need a manual edit — but the next year's CKAN resource doesn't exist until
+    its data is published. Attempting it raised KeyError (RESOURCE_IDS[year]) →
+    a failed batch → the whole nightly crashes_ccrs job errored and, with
+    loud-failure, cascaded to every dependent (stale freshness). Skip unpublished
+    years so the load stays green until the resource lands.
+    """
+    available = set(available)
+    return [y for y in years if y in available]
+
+
 def run(
     start_year: int = DEFAULT_START_YEAR,
     end_year: int = DEFAULT_END_YEAR,
@@ -339,7 +353,16 @@ def run(
         # Each page (~32K records) is fetched, transformed, and upserted
         # before fetching the next — no full-year memory buffer needed.
         if ccrs_years:
-            from etl.ckan_api import fetch_crashes_for_year  # noqa: PLC0415
+            from etl.ckan_api import fetch_crashes_for_year, RESOURCE_IDS  # noqa: PLC0415
+
+            no_resource = [y for y in ccrs_years if y not in RESOURCE_IDS]
+            if no_resource:
+                logger.info(
+                    "Skipping CCRS years with no published resource yet: %s "
+                    "(end_year auto-advances past available data)",
+                    no_resource,
+                )
+            ccrs_years = ccrs_years_with_resources(ccrs_years, RESOURCE_IDS)
 
             for year in ccrs_years:
                 year_rows = 0

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -33,6 +33,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from app.cities_match import normalize_name
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import City, Crash
+from etl.alerts import AlertLevel, send_alert
 
 logging.basicConfig(
     level=logging.INFO,
@@ -261,6 +262,34 @@ def ccrs_years_with_resources(years, available) -> list[int]:
     return [y for y in years if y in available]
 
 
+def alert_if_current_year_unpublished(
+    available, today_year: int | None = None
+) -> bool:
+    """WARN loudly when the current calendar year has no CCRS resource.
+
+    Silently skipping an unpublished year is right for the auto-advanced NEXT
+    year, but if the CURRENT year is missing, an entire year of crashes never
+    loads — and freshness masks it: the pinned prior-year resource stops
+    changing, the job records skipped_unchanged daily, and /api/freshness
+    reports "confirmed sync". That state must page a human. Self-quiets once
+    CHP publishes the resource (discovery picks it up on the next run).
+
+    Returns True if the alert fired.
+    """
+    if today_year is None:
+        today_year = datetime.now(timezone.utc).year
+    if today_year in set(available):
+        return False
+    send_alert(
+        AlertLevel.WARNING,
+        f"CCRS has no published crashes resource for {today_year}",
+        f"The {today_year} crash load is being skipped every run. If CHP has "
+        f"published the resource under a new name, resource discovery missed "
+        f"it — check the data.ca.gov CCRS dataset and etl/ckan_api.py.",
+    )
+    return True
+
+
 def run(
     start_year: int = DEFAULT_START_YEAR,
     end_year: int = DEFAULT_END_YEAR,
@@ -370,23 +399,32 @@ def run(
         # Each page (~32K records) is fetched, transformed, and upserted
         # before fetching the next — no full-year memory buffer needed.
         if ccrs_years:
-            from etl.ckan_api import fetch_crashes_for_year, RESOURCE_IDS  # noqa: PLC0415
+            from etl.ckan_api import (  # noqa: PLC0415
+                RESOURCE_IDS,
+                fetch_crashes_for_year,
+                merged_resource_ids,
+            )
 
-            no_resource = [y for y in ccrs_years if y not in RESOURCE_IDS]
+            # Static ids + anything newly published on data.ca.gov, so a new
+            # calendar year starts loading without a code change.
+            available = merged_resource_ids("Crashes", RESOURCE_IDS)
+
+            no_resource = [y for y in ccrs_years if y not in available]
             if no_resource:
                 logger.info(
                     "Skipping CCRS years with no published resource yet: %s "
                     "(end_year auto-advances past available data)",
                     no_resource,
                 )
-            ccrs_years = ccrs_years_with_resources(ccrs_years, RESOURCE_IDS)
+            ccrs_years = ccrs_years_with_resources(ccrs_years, available)
+            alert_if_current_year_unpublished(available)
 
             for year in ccrs_years:
                 year_rows = 0
                 try:
                     logger.info("Starting CCRS year %d...", year)
 
-                    for batch, offset, total in fetch_crashes_for_year(year):
+                    for batch, offset, total in fetch_crashes_for_year(year, available):
                         try:
                             count = upsert_crashes(db, batch, city_lookup=city_lookup)
                             db.commit()

--- a/backend/etl/load_parties_victims.py
+++ b/backend/etl/load_parties_victims.py
@@ -37,6 +37,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
 from app.models import CrashParty, CrashVictim
+from etl.ckan_api import merged_resource_ids
 
 logging.basicConfig(
     level=logging.INFO,
@@ -328,7 +329,7 @@ def run(
     if table is None or table == "parties":
         had_failure |= load_table(
             table_type="parties",
-            resource_ids=PARTIES_RESOURCE_IDS,
+            resource_ids=merged_resource_ids("Parties", PARTIES_RESOURCE_IDS),
             model_class=CrashParty,
             transform_fn=transform_party,
             upsert_cols=_PARTY_UPSERT_COLS,
@@ -342,7 +343,9 @@ def run(
     if table is None or table == "victims":
         had_failure |= load_table(
             table_type="victims",
-            resource_ids=VICTIMS_RESOURCE_IDS,
+            resource_ids=merged_resource_ids(
+                "InjuredWitnessPassengers", VICTIMS_RESOURCE_IDS
+            ),
             model_class=CrashVictim,
             transform_fn=transform_victim,
             upsert_cols=_VICTIM_UPSERT_COLS,

--- a/backend/etl/orchestrator.py
+++ b/backend/etl/orchestrator.py
@@ -41,6 +41,13 @@ class Job:
     freshness_resource_id: str | None = None
     freshness_url: str | None = None
     freshness_table: str | None = None
+    # CCRS resource-name prefix ("Crashes", "Parties", ...). When set, the
+    # freshness probe resolves the NEWEST discovered year's resource instead
+    # of the pinned freshness_resource_id — otherwise, the January a new year
+    # is published, the pinned prior-year resource stops changing and the job
+    # would skip as "unchanged" forever while a whole year goes missing.
+    # freshness_resource_id remains the fallback when discovery fails.
+    freshness_ckan_prefix: str | None = None
 
 
 class JobRegistry:

--- a/backend/scripts/check_ai_quality.py
+++ b/backend/scripts/check_ai_quality.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import json
+import os
 import sys
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -98,7 +99,12 @@ TEST_CASES = [
 
 
 def run():
-    engine = create_engine("postgresql://calsight:calsight_dev@100.121.46.16:5433/calsight")
+    # No hardcoded fallback: this file is public, and a committed connection
+    # string is a leaked credential even when it only resolves on the tailnet.
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        sys.exit("Set DATABASE_URL (see module docstring for usage).")
+    engine = create_engine(db_url)
     Session = sessionmaker(bind=engine)
     db = Session()
 

--- a/backend/tests/api/test_upsert_derived.py
+++ b/backend/tests/api/test_upsert_derived.py
@@ -1,0 +1,134 @@
+"""Amended-crash regression tests for the upsert's derived columns.
+
+CHP amends CCRS records after first publication — most importantly when a
+victim dies within 30 days and number_killed goes 0 -> 1. The nightly upsert
+re-loads the current and previous year, but the derived columns (severity and
+the crash_datetime extracts) were historically written only by NULL-guarded
+backfills, so an amended row kept its stale derived values forever: a fatal
+crash stayed 'Property Damage Only' in every severity filter and matview.
+
+These tests exercise the real ON CONFLICT path against Postgres.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from app.models import Crash
+from etl.load_crashes import upsert_crashes
+
+pytestmark = pytest.mark.integration
+
+
+def _loader_row(**overrides) -> dict:
+    """A row shaped like the CCRS loader produces (keys = _UPSERT_COLUMNS + key)."""
+    row = {
+        "collision_id": 999_000_111,
+        "crash_datetime": datetime(2026, 3, 14, 21, 30),
+        "day_of_week": "Saturday",
+        "county_code": 19,
+        "city_name": None,
+        "city_id": None,
+        "latitude": 34.05,
+        "longitude": -118.24,
+        "collision_type": "Rear End",
+        "primary_factor": "Speeding",
+        "motor_vehicle_involved_with": "Other Motor Vehicle",
+        "number_killed": 0,
+        "number_injured": 0,
+        "weather": "Clear",
+        "road_condition": "Dry",
+        "lighting": "Dark",
+        "is_highway": False,
+        "is_freeway": False,
+        "primary_road": "MAIN ST",
+        "secondary_road": "1ST ST",
+        "hit_run": None,
+        "pedestrian_involved": False,
+        "data_source": "ccrs",
+    }
+    row.update(overrides)
+    return row
+
+
+def _seed_backfilled_crash(db_session, **overrides) -> None:
+    """Insert a crash in its post-backfill state (derived columns populated)."""
+    # The session-scoped seed inserts crashes with explicit ids, which leaves
+    # the sequence behind — advance it so this insert doesn't collide.
+    db_session.execute(text(
+        "SELECT setval('crashes_id_seq', (SELECT COALESCE(MAX(id), 1) FROM crashes))"
+    ))
+    base = _loader_row(**overrides)
+    dt = base["crash_datetime"]
+    db_session.add(Crash(
+        **base,
+        severity="Property Damage Only",
+        crash_year=dt.year,
+        crash_month=dt.month,
+        crash_hour=dt.hour,
+        day_of_week_num=dt.weekday(),
+    ))
+    db_session.flush()
+
+
+def _fetch(db_session, collision_id: int) -> Crash:
+    db_session.expire_all()
+    return (
+        db_session.query(Crash)
+        .filter(Crash.collision_id == collision_id, Crash.data_source == "ccrs")
+        .one()
+    )
+
+
+class TestAmendedCrashSeverity:
+    def test_death_amendment_upgrades_severity_to_fatal(self, db_session):
+        _seed_backfilled_crash(db_session)
+
+        upsert_crashes(db_session, [_loader_row(number_killed=1)])
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.number_killed == 1
+        assert crash.severity == "Fatal"
+
+    def test_injury_amendment_upgrades_severity_to_injury(self, db_session):
+        _seed_backfilled_crash(db_session)
+
+        upsert_crashes(db_session, [_loader_row(number_injured=2)])
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.severity == "Injury"
+
+    def test_unamended_row_keeps_severity(self, db_session):
+        _seed_backfilled_crash(db_session)
+
+        upsert_crashes(db_session, [_loader_row()])
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.severity == "Property Damage Only"
+
+    def test_null_counts_mean_property_damage_only(self, db_session):
+        # CCRS sometimes reports null counts; the backfill treats null as 0.
+        _seed_backfilled_crash(db_session)
+
+        upsert_crashes(
+            db_session, [_loader_row(number_killed=None, number_injured=None)]
+        )
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.severity == "Property Damage Only"
+
+
+class TestAmendedCrashDatetimeExtracts:
+    def test_corrected_datetime_recomputes_extract_columns(self, db_session):
+        _seed_backfilled_crash(db_session)
+
+        # CHP corrects the crash to New Year's Eve 2025, 23:05 (a Wednesday).
+        corrected = datetime(2025, 12, 31, 23, 5)
+        upsert_crashes(db_session, [_loader_row(crash_datetime=corrected)])
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.crash_year == 2025
+        assert crash.crash_month == 12
+        assert crash.crash_hour == 23
+        assert crash.day_of_week_num == 2  # 0=Mon .. 2=Wed

--- a/backend/tests/api/test_upsert_derived.py
+++ b/backend/tests/api/test_upsert_derived.py
@@ -21,6 +21,18 @@ from etl.load_crashes import upsert_crashes
 pytestmark = pytest.mark.integration
 
 
+@pytest.fixture(autouse=True)
+def _cleanup_test_crash(db_session):
+    """repair_drifted_derived commits per year (module style), which ends the
+    conftest's rollback-isolation transaction — so remove the test crash
+    explicitly and commit, restoring the shared test DB either way."""
+    yield
+    db_session.execute(text(
+        "DELETE FROM crashes WHERE collision_id = 999000111"
+    ))
+    db_session.commit()
+
+
 def _loader_row(**overrides) -> dict:
     """A row shaped like the CCRS loader produces (keys = _UPSERT_COLUMNS + key)."""
     row = {
@@ -132,3 +144,53 @@ class TestAmendedCrashDatetimeExtracts:
         assert crash.crash_month == 12
         assert crash.crash_hour == 23
         assert crash.day_of_week_num == 2  # 0=Mon .. 2=Wed
+
+
+class TestRepairDriftedDerived:
+    """One-shot + nightly self-heal for rows amended BEFORE the upsert learned
+    to recompute derived columns: severity and the crash_datetime extracts can
+    disagree with the raw values they derive from. The repair must fix exactly
+    the drifted rows and leave consistent rows untouched."""
+
+    def test_repairs_severity_that_disagrees_with_counts(self, db_session):
+        from etl.backfill_derived import repair_drifted_derived
+
+        # Prod state left by the old upsert: killed=1 but severity still PDO.
+        _seed_backfilled_crash(db_session, number_killed=1)
+
+        repaired = repair_drifted_derived(db_session)
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.severity == "Fatal"
+        assert repaired >= 1
+
+    def test_repairs_stale_datetime_extracts(self, db_session):
+        from etl.backfill_derived import repair_drifted_derived
+
+        # crash_datetime was corrected but the extract columns kept old values.
+        _seed_backfilled_crash(db_session)
+        db_session.execute(text(
+            "UPDATE crashes SET crash_year = 2020, crash_month = 1, "
+            "crash_hour = 4, day_of_week_num = 0 "
+            "WHERE collision_id = 999000111 AND data_source = 'ccrs'"
+        ))
+        db_session.flush()
+
+        repair_drifted_derived(db_session)
+
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.crash_year == 2026
+        assert crash.crash_month == 3
+        assert crash.crash_hour == 21
+        assert crash.day_of_week_num == 5  # 2026-03-14 is a Saturday
+
+    def test_consistent_rows_are_not_rewritten(self, db_session):
+        from etl.backfill_derived import repair_drifted_derived
+
+        _seed_backfilled_crash(db_session)  # PDO with 0/0 counts — consistent
+
+        repaired = repair_drifted_derived(db_session)
+
+        assert repaired == 0
+        crash = _fetch(db_session, 999_000_111)
+        assert crash.severity == "Property Damage Only"

--- a/backend/tests/test_backup_rotation.py
+++ b/backend/tests/test_backup_rotation.py
@@ -55,3 +55,82 @@ def test_keeps_everything_within_retention(tmp_path):
 
     assert removed == 0
     assert len(list(tmp_path.glob("calsight_*.dump"))) == 5
+
+
+# ---------------------------------------------------------------------------
+# rotate_r2_backups — the OFFSITE copies need the same min_keep guard.
+# Without it, 8+ days of silently failing pg_dumps rotates R2 to zero — the
+# exact scenario offsite backups exist for (local box dies with stale dumps).
+# ---------------------------------------------------------------------------
+
+import sys
+from types import SimpleNamespace
+
+from etl.backup import rotate_r2_backups
+
+
+class _FakeS3:
+    def __init__(self, keys):
+        self.keys = keys
+        self.deleted = []
+
+    def list_objects_v2(self, Bucket, Prefix):
+        return {"Contents": [{"Key": k} for k in self.keys]}
+
+    def delete_object(self, Bucket, Key):
+        self.deleted.append(Key)
+
+
+def _r2_env(monkeypatch, s3):
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "s")
+    monkeypatch.setenv("R2_ENDPOINT_URL", "https://r2.example")
+    monkeypatch.setenv("R2_BUCKET_NAME", "bucket")
+    fake_boto3 = SimpleNamespace(client=lambda *a, **kw: s3)
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+
+def _key(days: int) -> str:
+    return f"backups/calsight_{_days_ago(days)}.dump"
+
+
+def test_r2_keeps_min_recent_even_when_all_are_old(monkeypatch):
+    s3 = _FakeS3([_key(n) for n in range(100, 105)])
+    _r2_env(monkeypatch, s3)
+
+    removed = rotate_r2_backups(retention_days=7, min_keep=3)
+
+    assert removed == 2
+    assert len(s3.deleted) == 2
+    # the two OLDEST were deleted; the newest three survive
+    assert set(s3.deleted) == {_key(103), _key(104)}
+
+
+def test_r2_removes_old_dumps_beyond_min_keep(monkeypatch):
+    s3 = _FakeS3([_key(n) for n in (0, 1, 2, 30, 31)])
+    _r2_env(monkeypatch, s3)
+
+    removed = rotate_r2_backups(retention_days=7, min_keep=3)
+
+    assert removed == 2
+    assert set(s3.deleted) == {_key(30), _key(31)}
+
+
+def test_r2_keeps_everything_within_retention(monkeypatch):
+    s3 = _FakeS3([_key(n) for n in range(0, 5)])
+    _r2_env(monkeypatch, s3)
+
+    removed = rotate_r2_backups(retention_days=7, min_keep=3)
+
+    assert removed == 0
+    assert s3.deleted == []
+
+
+def test_r2_unparseable_names_are_never_deleted(monkeypatch):
+    s3 = _FakeS3(["backups/calsight_notadate.dump", _key(100), _key(101), _key(102), _key(103)])
+    _r2_env(monkeypatch, s3)
+
+    removed = rotate_r2_backups(retention_days=7, min_keep=3)
+
+    assert "backups/calsight_notadate.dump" not in s3.deleted
+    assert removed == 1  # only the oldest parseable dump beyond min_keep

--- a/backend/tests/test_backup_rotation.py
+++ b/backend/tests/test_backup_rotation.py
@@ -5,9 +5,11 @@ local recovery point: at least `min_keep` of the most-recent dumps survive
 regardless of age.
 """
 
+import sys
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
-from etl.backup import rotate_backups
+from etl.backup import rotate_backups, rotate_r2_backups
 
 
 def _make_dump(directory, date_str: str):
@@ -62,12 +64,6 @@ def test_keeps_everything_within_retention(tmp_path):
 # Without it, 8+ days of silently failing pg_dumps rotates R2 to zero — the
 # exact scenario offsite backups exist for (local box dies with stale dumps).
 # ---------------------------------------------------------------------------
-
-import sys
-from types import SimpleNamespace
-
-from etl.backup import rotate_r2_backups
-
 
 class _FakeS3:
     def __init__(self, keys):

--- a/backend/tests/test_ckan_api.py
+++ b/backend/tests/test_ckan_api.py
@@ -283,3 +283,105 @@ class TestFetchCrashesForYear:
         assert len(results) == 2
         collision_ids = {r["collision_id"] for r in results}
         assert collision_ids == {111, 222}
+
+
+# ---------------------------------------------------------------------------
+# Resource discovery (Jan-2027 regression: hardcoded RESOURCE_IDS meant a new
+# calendar year's resource was never picked up until a manual code change,
+# while freshness kept reporting green against the pinned prior-year resource)
+# ---------------------------------------------------------------------------
+
+def _mock_package_show(resources: list[dict]) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"result": {"resources": resources}}
+    return mock_resp
+
+
+_PACKAGE_RESOURCES = [
+    {"name": "Raw Data Template", "id": "template-id", "datastore_active": False},
+    {"name": "Crashes_2026", "id": "crashes-2026-id", "datastore_active": True},
+    {"name": "Crashes_2027", "id": "crashes-2027-id", "datastore_active": True},
+    {"name": "Parties_2026", "id": "parties-2026-id", "datastore_active": True},
+    {"name": "InjuredWitnessPassengers_2026", "id": "victims-2026-id", "datastore_active": True},
+    # A resource CKAN knows about but whose datastore isn't loaded yet must
+    # not be offered for loading — datastore_search would 404 on it.
+    {"name": "Crashes_2028", "id": "crashes-2028-id", "datastore_active": False},
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_discovery_cache():
+    from etl import ckan_api
+    getattr(ckan_api, "_DISCOVERY_CACHE", {}).clear()
+    yield
+    getattr(ckan_api, "_DISCOVERY_CACHE", {}).clear()
+
+
+class TestDiscoverResourceIds:
+    @patch("etl.ckan_api.httpx.get")
+    def test_finds_years_matching_prefix(self, mock_get):
+        from etl.ckan_api import discover_resource_ids
+        mock_get.return_value = _mock_package_show(_PACKAGE_RESOURCES)
+
+        found = discover_resource_ids("Crashes")
+
+        assert found == {2026: "crashes-2026-id", 2027: "crashes-2027-id"}
+
+    @patch("etl.ckan_api.httpx.get")
+    def test_parties_prefix_does_not_match_crashes(self, mock_get):
+        from etl.ckan_api import discover_resource_ids
+        mock_get.return_value = _mock_package_show(_PACKAGE_RESOURCES)
+
+        assert discover_resource_ids("Parties") == {2026: "parties-2026-id"}
+
+    @patch("etl.ckan_api.httpx.get")
+    def test_network_failure_returns_empty(self, mock_get):
+        from etl.ckan_api import discover_resource_ids
+        mock_get.side_effect = httpx.ConnectError("boom")
+
+        assert discover_resource_ids("Crashes") == {}
+
+    @patch("etl.ckan_api.httpx.get")
+    def test_result_is_cached_per_process(self, mock_get):
+        from etl.ckan_api import discover_resource_ids
+        mock_get.return_value = _mock_package_show(_PACKAGE_RESOURCES)
+
+        discover_resource_ids("Crashes")
+        discover_resource_ids("Crashes")
+
+        assert mock_get.call_count == 1
+
+    @patch("etl.ckan_api.httpx.get")
+    def test_failure_is_not_cached(self, mock_get):
+        from etl.ckan_api import discover_resource_ids
+        mock_get.side_effect = [
+            httpx.ConnectError("boom"),
+            _mock_package_show(_PACKAGE_RESOURCES),
+        ]
+
+        assert discover_resource_ids("Crashes") == {}
+        assert discover_resource_ids("Crashes") == {2026: "crashes-2026-id", 2027: "crashes-2027-id"}
+
+
+class TestMergedResourceIds:
+    @patch("etl.ckan_api.httpx.get")
+    def test_discovered_year_extends_static_map(self, mock_get):
+        from etl.ckan_api import merged_resource_ids
+        mock_get.return_value = _mock_package_show(_PACKAGE_RESOURCES)
+        static = {2025: "static-2025", 2026: "static-2026"}
+
+        merged = merged_resource_ids("Crashes", static)
+
+        assert merged[2027] == "crashes-2027-id"  # new year discovered
+        assert merged[2025] == "static-2025"      # static entries preserved
+        assert merged[2026] == "crashes-2026-id"  # discovery is fresher, wins
+
+    @patch("etl.ckan_api.httpx.get")
+    def test_discovery_failure_degrades_to_static(self, mock_get):
+        from etl.ckan_api import merged_resource_ids
+        mock_get.side_effect = httpx.ConnectError("boom")
+        static = {2025: "static-2025", 2026: "static-2026"}
+
+        assert merged_resource_ids("Crashes", static) == static

--- a/backend/tests/test_etl_utils.py
+++ b/backend/tests/test_etl_utils.py
@@ -375,3 +375,79 @@ class TestFederalFreshnessAllowlist:
         last_run = SimpleNamespace(source_row_count=1383)
         res = _utils._check_federal_freshness(self._fars_job(), last_run, db)
         assert res.is_fresh is True
+
+
+# ---------------------------------------------------------------------------
+# _check_ckan_freshness — dynamic resource resolution (Jan-2027 regression)
+# ---------------------------------------------------------------------------
+
+def _ckan_job(prefix=None, pinned="pinned-resource-id", name="crashes_ccrs"):
+    return SimpleNamespace(
+        name=name,
+        source_type="ckan",
+        freshness_resource_id=pinned,
+        freshness_ckan_prefix=prefix,
+    )
+
+
+def _finished_run():
+    from datetime import datetime
+    return SimpleNamespace(source_row_count=100, finished_at=datetime(2027, 1, 10))
+
+
+class TestCkanFreshnessDynamicResource:
+    """When CHP publishes a new calendar year, the pinned prior-year resource
+    stops changing and freshness would skip the job forever, masking a whole
+    missing year as 'confirmed sync'. Jobs with a freshness_ckan_prefix must
+    probe the NEWEST discovered year's resource instead of the pinned one."""
+
+    def test_probes_newest_discovered_resource(self, monkeypatch):
+        probed = {}
+
+        def fake_get(url, params=None, **kw):
+            probed["id"] = params["id"]
+            return _make_response(
+                200, b'{"result": {"last_modified": "2027-06-01T00:00:00"}}'
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        monkeypatch.setattr(
+            _utils, "discover_resource_ids",
+            lambda prefix: {2026: "crashes-2026-id", 2027: "crashes-2027-id"},
+        )
+
+        result = _utils._check_ckan_freshness(_ckan_job(prefix="Crashes"), _finished_run())
+
+        assert probed["id"] == "crashes-2027-id"
+        assert result.is_fresh is True
+
+    def test_discovery_failure_falls_back_to_pinned(self, monkeypatch):
+        probed = {}
+
+        def fake_get(url, params=None, **kw):
+            probed["id"] = params["id"]
+            return _make_response(
+                200, b'{"result": {"last_modified": "2027-06-01T00:00:00"}}'
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        monkeypatch.setattr(_utils, "discover_resource_ids", lambda prefix: {})
+
+        _utils._check_ckan_freshness(_ckan_job(prefix="Crashes"), _finished_run())
+
+        assert probed["id"] == "pinned-resource-id"
+
+    def test_no_prefix_uses_pinned(self, monkeypatch):
+        probed = {}
+
+        def fake_get(url, params=None, **kw):
+            probed["id"] = params["id"]
+            return _make_response(
+                200, b'{"result": {"last_modified": "2027-06-01T00:00:00"}}'
+            )
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+
+        _utils._check_ckan_freshness(_ckan_job(prefix=None), _finished_run())
+
+        assert probed["id"] == "pinned-resource-id"

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -166,3 +166,43 @@ class TestCcrsYearsWithResources:
         # the auto-advanced next year is not loadable; the latest published one is
         assert ccrs_years_with_resources([latest + 1], RESOURCE_IDS) == []
         assert ccrs_years_with_resources([latest], RESOURCE_IDS) == [latest]
+
+
+class TestAlertCurrentYearUnpublished:
+    """H2 follow-through to the 2026-07-05 incident fix: silently skipping an
+    unpublished year is correct for the auto-advanced NEXT year, but if the
+    CURRENT calendar year has no resource, an entire year of crashes is
+    missing while /api/freshness reports green (the pinned prior-year resource
+    stops changing -> daily skipped_unchanged -> 'confirmed sync'). That state
+    must page a human."""
+
+    def test_missing_current_year_sends_warning(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from etl import load_crashes as mod
+
+        alert = MagicMock()
+        monkeypatch.setattr(mod, "send_alert", alert)
+
+        fired = mod.alert_if_current_year_unpublished(
+            {2025: "a", 2026: "b"}, today_year=2027,
+        )
+
+        assert fired is True
+        alert.assert_called_once()
+        level, title = alert.call_args[0][0], alert.call_args[0][1]
+        assert level.value == "warning"
+        assert "2027" in title
+
+    def test_present_current_year_is_quiet(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from etl import load_crashes as mod
+
+        alert = MagicMock()
+        monkeypatch.setattr(mod, "send_alert", alert)
+
+        fired = mod.alert_if_current_year_unpublished(
+            {2026: "b", 2027: "c"}, today_year=2027,
+        )
+
+        assert fired is False
+        alert.assert_not_called()

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -143,3 +143,26 @@ class TestNoSelfTracking:
         mod.run(start_year=2016, end_year=2016, source_filter="ccrs")
 
         etl_run_ctor.assert_not_called()
+
+
+class TestCcrsYearsWithResources:
+    """Regression for the 2026-07-05 prod incident: crashes_ccrs errored on
+    year 2027 (end_year = current+1) because RESOURCE_IDS has no 2027 yet →
+    KeyError → failed batch → whole job errored (cascaded to dependents)."""
+
+    def test_drops_years_with_no_published_resource(self):
+        from etl.load_crashes import ccrs_years_with_resources
+        available = {2016, 2024, 2025, 2026}
+        assert ccrs_years_with_resources([2025, 2026, 2027], available) == [2025, 2026]
+
+    def test_keeps_order_of_present_years(self):
+        from etl.load_crashes import ccrs_years_with_resources
+        assert ccrs_years_with_resources([2016, 2026], {2016, 2026}) == [2016, 2026]
+
+    def test_real_resource_ids_skip_the_next_calendar_year(self):
+        from etl.load_crashes import ccrs_years_with_resources
+        from etl.ckan_api import RESOURCE_IDS
+        latest = max(RESOURCE_IDS)
+        # the auto-advanced next year is not loadable; the latest published one is
+        assert ccrs_years_with_resources([latest + 1], RESOURCE_IDS) == []
+        assert ccrs_years_with_resources([latest], RESOURCE_IDS) == [latest]


### PR DESCRIPTION
Fixes the two HIGH backend findings + one HIGH infra finding from tonight's audit. Based on the #361 hotfix branch (merge #361 first; this PR then shrinks to 3 commits).

## 1. Amended crashes kept stale severity (silent fatal undercount)

The nightly upsert re-loads current+previous year and updates `number_killed`/`number_injured`, but `severity` and the `crash_datetime` extract columns are populated by NULL-guarded backfills that never touch a populated row. When CHP amends a record (e.g. a victim dies within 30 days, killed 0→1), the row stayed 'Property Damage Only' forever — in every severity filter, matview, and YoY metric. Now the ON CONFLICT update recomputes `severity`, `crash_year`, `crash_month`, `crash_hour`, and `day_of_week_num` inline from the amended values (inline, not reset-to-NULL, so there's no window where filters miss the row). Real-Postgres regression tests included.

**Note for after merge:** already-stale rows in prod won't self-heal until those years are re-upserted. A one-shot repair is: `UPDATE crashes SET severity = CASE WHEN number_killed > 0 THEN 'Fatal' WHEN number_injured > 0 THEN 'Injury' ELSE 'Property Damage Only' END WHERE severity IS DISTINCT FROM (that CASE)` — happy to wire that into a migration/backfill if you want it automated.

## 2. January 2027: ingestion would silently stop while freshness reports green

`RESOURCE_IDS` is hardcoded through 2026. In January 2027 the new year's resource would never load (crashes, parties, and victims), and the freshness probe — pinned to the 2026 resource — would record `skipped_unchanged` daily, i.e. "confirmed sync" while a whole year is missing. Same class as the 2026-07-05 incident, on a timer.

- `discover_resource_ids()` lists the CCRS CKAN package and finds `Crashes_/Parties_/InjuredWitnessPassengers_<year>` resources (datastore-active only, per-process cache, failure degrades to the static maps — verified the name pattern against the live package today).
- The three CCRS jobs' freshness probes now resolve the **newest discovered year's** resource (`Job.freshness_ckan_prefix`), falling back to the pinned id.
- If the **current** calendar year has no crashes resource, a WARNING webhook fires every run until it's published — the one state freshness would otherwise actively mask.

## 3. R2 rotation could delete every offsite backup

Local rotation protects the newest 3 dumps regardless of age; R2 rotation deleted everything older than 7 days unconditionally — so 8+ days of silently failing pg_dumps rotates the offsite copies (the ones that survive the box dying) to zero. Same min_keep guard applied.

## Tests

Backend suite: **761 passed** (21 new: 5 real-Postgres upsert regression, 12 discovery/freshness/alert, 4 R2 rotation).