### PR TITLE
fix(ai): percentile tier silently broke under severity filters (audit HIGH)

### DIFF
--- a/frontend/src/lib/ai/measureMetric.test.ts
+++ b/frontend/src/lib/ai/measureMetric.test.ts
@@ -50,10 +50,22 @@ describe("filtersToDistributionParams", () => {
     expect(out.county).toBeUndefined();
     expect(out.year).toBeUndefined();
   });
-  it("serializes severities and causes as CSV", () => {
+  it("serializes severities as backend slugs, causes as CSV", () => {
+    // The snapshot carries display names ("Fatal"), but the backend's
+    // severity parser only accepts slugs — sending display names 4xxes the
+    // distribution call and silently kills the percentile tier whenever a
+    // severity filter is active.
     const out = filtersToDistributionParams({ ...allEmpty, severities: ["Fatal", "Injury"], causes: ["dui"] });
-    expect(out.severity).toBe("Fatal,Injury");
+    expect(out.severity).toBe("fatal,injury");
     expect(out.cause).toBe("dui");
+  });
+  it("slugifies Property Damage Only", () => {
+    const out = filtersToDistributionParams({ ...allEmpty, severities: ["Property Damage Only"] });
+    expect(out.severity).toBe("property-damage-only");
+  });
+  it("passes already-slugged severities through unchanged", () => {
+    const out = filtersToDistributionParams({ ...allEmpty, severities: ["fatal"] });
+    expect(out.severity).toBe("fatal");
   });
   it("serializes boolean involvement flags as 'true'/'false'", () => {
     expect(filtersToDistributionParams({ ...allEmpty, alcohol: true }).alcohol).toBe("true");

--- a/frontend/src/lib/ai/measureMetric.ts
+++ b/frontend/src/lib/ai/measureMetric.ts
@@ -18,6 +18,16 @@ export function normalizeCounty(name: string): string {
   return name.trim().toLowerCase();
 }
 
+/** The snapshot carries severity display names; the backend's severity parser
+ *  accepts only these slugs and 422s on anything else. Same mapping as
+ *  useHighwayRankings — unknown values pass through so already-slugged input
+ *  keeps working. */
+const SEVERITY_SLUG: Record<string, string> = {
+  Fatal: "fatal",
+  Injury: "injury",
+  "Property Damage Only": "property-damage-only",
+};
+
 /** Serialize the population-narrowing filters into /api/stats/distribution
  *  query params so the per-county distribution reflects the SAME population as
  *  the subject. `counties` and `years` are deliberately excluded: the
@@ -25,7 +35,9 @@ export function normalizeCounty(name: string): string {
  *  and the year is passed separately via the `year` param. */
 export function filtersToDistributionParams(f: FilterSnapshot): Record<string, string> {
   const out: Record<string, string> = {};
-  if (f.severities.length) out.severity = f.severities.join(",");
+  if (f.severities.length) {
+    out.severity = f.severities.map((s) => SEVERITY_SLUG[s] ?? s).join(",");
+  }
   if (f.causes.length) out.cause = f.causes.join(",");
   if (f.weather.length) out.weather = f.weather.join(",");
   if (f.lighting.length) out.lighting = f.lighting.join(",");


### PR DESCRIPTION
Frontend HIGH from tonight's audit: `filtersToDistributionParams` sent severity **display names** (`Fatal`) where the backend requires **slugs** (`fatal`), so with any severity filter active the `/api/stats/distribution` call 422'd and the county percentile narrative silently vanished — no error surfaced anywhere. This defeated the intent of the filter-aware distribution work (e2c9abf), and the unit test at `measureMetric.test.ts:55` asserted the buggy output.

Fix mirrors the `SEVERITY_SLUG` map already used by `useHighwayRankings` (unknown values pass through, so already-slugged input keeps working).

Root-cause note: this whole class of bug (see also audit M1–M3) comes from each consumer re-serializing filter state its own way — a shared filters→API-params serializer is the durable fix and is on the refinement backlog.

Tests: updated the baked-in assertion + 2 new cases; frontend suite **664 passed**, tsc clean.