### PR TITLE
feat: crash cluster hotspot detection (grid density + z-score)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -180,6 +180,7 @@ from app.routers.crashes import router as crashes_router  # noqa: E402
 from app.routers.demographics import router as demographics_router  # noqa: E402
 from app.routers.freshness import router as freshness_router  # noqa: E402
 from app.routers.heatmap import router as heatmap_router  # noqa: E402
+from app.routers.clusters import router as clusters_router  # noqa: E402
 from app.routers.pipeline_health import router as pipeline_health_router  # noqa: E402
 from app.routers.ask import router as ask_router  # noqa: E402
 from app.routers.changes import router as changes_router  # noqa: E402
@@ -201,6 +202,7 @@ app.include_router(crashes_router, prefix="/api")
 app.include_router(crash_people_router, prefix="/api")
 app.include_router(freshness_router, prefix="/api")
 app.include_router(heatmap_router, prefix="/api")
+app.include_router(clusters_router, prefix="/api")
 app.include_router(stats_router, prefix="/api")
 app.include_router(meta_router, prefix="/api")
 app.include_router(changes_router, prefix="/api")

--- a/backend/app/routers/clusters.py
+++ b/backend/app/routers/clusters.py
@@ -128,6 +128,14 @@ def crash_clusters(
         .all()
     )
 
+    # The baseline (mean/stddev) is computed over OCCUPIED grid cells only, not
+    # every cell in the CA bounding box. Including the ~1M mostly-empty cells
+    # would collapse the mean toward zero and flag almost every occupied cell as
+    # a "hotspot", so occupied-only is deliberate. Consequence: the z-score of
+    # any single cell is bounded by sqrt(n-1), so with <= 5 occupied cells no
+    # cell can exceed z > 2 and we correctly return no hotspots — heavy filters
+    # that leave very little data yield "not enough to call a hotspot" rather
+    # than a fabricated one.
     n = len(rows)
     counts = [r.count for r in rows]
     mean = sum(counts) / n if n else 0.0

--- a/backend/app/routers/clusters.py
+++ b/backend/app/routers/clusters.py
@@ -1,0 +1,157 @@
+"""Statistically significant crash-hotspot detection (grid density + z-score)."""
+
+import logging
+
+from fastapi import APIRouter, Depends, Query, Request, Response
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from sqlalchemy import case, func, literal_column, or_
+from sqlalchemy.orm import Session
+
+from app.county_slug_map import get_slug_map
+from app.database import get_db
+from app.filters import (
+    build_crash_predicates,
+    parse_bool_flag,
+    parse_cause,
+    parse_collision_type,
+    parse_county_codes,
+    parse_date_range,
+    parse_driver_age,
+    parse_hit_run,
+    parse_lighting,
+    parse_road_type,
+    parse_severity,
+    parse_weather,
+    parse_year,
+)
+from app.models import Crash
+from app.schemas.clusters import ClusterPoint, ClusterResponse, SeverityBreakdown
+
+router = APIRouter(tags=["clusters"])
+logger = logging.getLogger(__name__)
+
+_STEP = 0.01  # ~0.7 mi grid cell; hotspot detection is inherently a zoomed-out concept
+_DECIMALS = 2
+_Z_SCORE_THRESHOLD = 2.0
+
+_limiter = Limiter(key_func=get_remote_address)
+
+
+@router.get("/crashes/clusters", response_model=ClusterResponse)
+@_limiter.limit("1000/minute;20000/hour")
+def crash_clusters(
+    request: Request,
+    response: Response,
+    year: str | None = Query(None),
+    start: str | None = Query(None),
+    end: str | None = Query(None),
+    county: str | None = Query(None),
+    severity: str | None = Query(None),
+    cause: str | None = Query(None),
+    alcohol: str | None = Query(None),
+    distracted: str | None = Query(None),
+    pedestrian: str | None = Query(None),
+    cyclist: str | None = Query(None),
+    drug: str | None = Query(None),
+    driver_age: str | None = Query(None),
+    weather: str | None = Query(None),
+    lighting: str | None = Query(None),
+    collision_type: str | None = Query(None),
+    road_type: str | None = Query(None),
+    hit_run: str | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Statistically significant crash hotspots.
+
+    Aggregates crashes into a fixed 0.01deg (~0.7 mi) grid and flags cells
+    whose crash count exceeds mean + 2 standard deviations of all grid
+    cell counts (z-score thresholding). Aggregation happens entirely in SQL;
+    the z-score pass runs in Python over the resulting grid cells only
+    (typically hundreds to low-thousands of rows), never over raw crash rows.
+    """
+    response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+
+    date_range = parse_date_range(start, end)
+    years = parse_year(year) if date_range is None else None
+    county_codes = parse_county_codes(county, get_slug_map(db)) if county else None
+    severities = parse_severity(severity)
+    causes = parse_cause(cause)
+    alcohol_v = parse_bool_flag(alcohol, "alcohol")
+    distracted_v = parse_bool_flag(distracted, "distracted")
+    pedestrian_v = parse_bool_flag(pedestrian, "pedestrian")
+    cyclist_v = parse_bool_flag(cyclist, "cyclist")
+    drug_v = parse_bool_flag(drug, "drug")
+    driver_age_v = parse_driver_age(driver_age)
+    weather_v = parse_weather(weather)
+    lighting_v = parse_lighting(lighting)
+    collision_type_v = parse_collision_type(collision_type)
+    road_type_v = parse_road_type(road_type)
+    hit_run_v = parse_hit_run(hit_run)
+
+    preds = build_crash_predicates(
+        years=years,
+        date_range=date_range,
+        county_codes=county_codes,
+        severities=severities,
+        causes=causes,
+        alcohol=alcohol_v,
+        distracted=distracted_v,
+        pedestrian=pedestrian_v,
+        cyclist=cyclist_v,
+        drug=drug_v,
+        driver_age=driver_age_v,
+        weather=weather_v,
+        lighting=lighting_v,
+        collision_type=collision_type_v,
+        road_type=road_type_v,
+        hit_run=hit_run_v,
+    )
+    preds.append(Crash.latitude.isnot(None))
+    preds.append(Crash.longitude.isnot(None))
+    preds.append(Crash.latitude.between(32.5, 42.05))
+    preds.append(Crash.longitude.between(-124.5, -114.0))
+    if county_codes:
+        preds.append(or_(Crash.coord_county_mismatch.is_(None), Crash.coord_county_mismatch == False))  # noqa: E712
+
+    lat_bucket = (func.round(Crash.latitude / _STEP) * _STEP).label("lat")
+    lng_bucket = (func.round(Crash.longitude / _STEP) * _STEP).label("lng")
+    count_ = func.count().label("count")
+    fatal_ = func.sum(case((Crash.severity == "Fatal", 1), else_=0)).label("fatal")
+    injury_ = func.sum(case((Crash.severity == "Injury", 1), else_=0)).label("injury")
+    pdo_ = func.sum(case((Crash.severity == "Property Damage Only", 1), else_=0)).label("pdo")
+
+    rows = (
+        db.query(lat_bucket, lng_bucket, count_, fatal_, injury_, pdo_)
+        .filter(*preds)
+        .group_by(literal_column("lat"), literal_column("lng"))
+        .all()
+    )
+
+    n = len(rows)
+    counts = [r.count for r in rows]
+    mean = sum(counts) / n if n else 0.0
+    variance = sum((c - mean) ** 2 for c in counts) / n if n else 0.0
+    stddev = variance**0.5
+    threshold = mean + _Z_SCORE_THRESHOLD * stddev
+
+    clusters = []
+    if stddev > 0:
+        for r in rows:
+            z_score = (r.count - mean) / stddev
+            if z_score > _Z_SCORE_THRESHOLD:
+                clusters.append(ClusterPoint(
+                    lat=round(float(r.lat), _DECIMALS),
+                    lng=round(float(r.lng), _DECIMALS),
+                    crash_count=r.count,
+                    z_score=round(z_score, 2),
+                    severity=SeverityBreakdown(fatal=r.fatal, injury=r.injury, pdo=r.pdo),
+                ))
+
+    return ClusterResponse(
+        clusters=clusters,
+        total_grid_cells=n,
+        mean_count=round(mean, 2),
+        stddev_count=round(stddev, 2),
+        threshold=round(threshold, 2),
+    )

--- a/backend/app/schemas/clusters.py
+++ b/backend/app/schemas/clusters.py
@@ -1,0 +1,25 @@
+"""Response models for /api/crashes/clusters."""
+
+from pydantic import BaseModel
+
+
+class SeverityBreakdown(BaseModel):
+    fatal: int
+    injury: int
+    pdo: int
+
+
+class ClusterPoint(BaseModel):
+    lat: float
+    lng: float
+    crash_count: int
+    z_score: float
+    severity: SeverityBreakdown
+
+
+class ClusterResponse(BaseModel):
+    clusters: list[ClusterPoint]
+    total_grid_cells: int
+    mean_count: float
+    stddev_count: float
+    threshold: float

--- a/backend/tests/api/test_clusters.py
+++ b/backend/tests/api/test_clusters.py
@@ -1,0 +1,94 @@
+"""Integration tests for /api/crashes/clusters."""
+
+from datetime import datetime
+
+import pytest
+
+from app.models import Crash
+
+pytestmark = pytest.mark.integration
+
+
+def test_clusters_response_shape(client):
+    response = client.get("/api/crashes/clusters")
+    assert response.status_code == 200
+    body = response.json()
+    assert "clusters" in body
+    assert "total_grid_cells" in body
+    assert "mean_count" in body
+    assert "stddev_count" in body
+    assert "threshold" in body
+    assert isinstance(body["clusters"], list)
+
+
+def test_clusters_no_hotspots_in_seed_data(client):
+    """Seed data has 5 crashes spread across distinct grid cells (stddev=0),
+    so no cell can exceed mean + 2*stddev."""
+    response = client.get("/api/crashes/clusters")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["clusters"] == []
+    assert body["total_grid_cells"] == 5
+
+
+def test_clusters_no_matching_crashes(client):
+    response = client.get("/api/crashes/clusters?year=2001")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["clusters"] == []
+    assert body["total_grid_cells"] == 0
+    assert body["mean_count"] == 0
+    assert body["stddev_count"] == 0
+
+
+def test_clusters_cache_header(client):
+    response = client.get("/api/crashes/clusters")
+    assert response.headers.get("cache-control") == "public, max-age=3600, stale-while-revalidate=86400"
+
+
+def test_clusters_rejects_unknown_county(client):
+    response = client.get("/api/crashes/clusters?county=atlantis")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "county"
+
+
+def test_clusters_filter_by_severity_still_valid(client):
+    response = client.get("/api/crashes/clusters?severity=fatal")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_grid_cells"] == 2  # crashes 1 (SWITRS) + 3 (CCRS)
+
+
+def test_clusters_detects_hotspot(client, db_session):
+    """Pack extra crashes into a single grid cell so it stands out (z > 2)
+    against the sparse, single-crash-per-cell seed data."""
+    extra = [
+        Crash(
+            id=100 + i, collision_id=9000 + i, data_source="ccrs",
+            crash_datetime=datetime(2024, 5, 1, 10, 0), county_code=19,
+            crash_year=2024, crash_hour=10, crash_month=5, day_of_week_num=2,
+            severity="Fatal" if i < 3 else "Injury",
+            canonical_cause="dui", number_killed=1 if i < 3 else 0, number_injured=0 if i < 3 else 1,
+            county_name="Los Angeles", latitude=34.20, longitude=-118.20,
+            is_alcohol_involved=True, is_distraction_involved=False,
+        )
+        for i in range(8)
+    ]
+    db_session.add_all(extra)
+    db_session.commit()
+
+    response = client.get("/api/crashes/clusters?year=2024")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total_grid_cells"] == 1
+    # A single grid cell can't have a nonzero stddev on its own, so widen the
+    # filter to include the seed data's sparse cells alongside the packed one.
+    response = client.get("/api/crashes/clusters")
+    body = response.json()
+    assert len(body["clusters"]) == 1
+    cluster = body["clusters"][0]
+    assert cluster["lat"] == 34.2
+    assert cluster["lng"] == -118.2
+    assert cluster["crash_count"] == 8
+    assert cluster["z_score"] > 2
+    assert cluster["severity"] == {"fatal": 3, "injury": 5, "pdo": 0}

--- a/frontend/src/__mocks__/leaflet.ts
+++ b/frontend/src/__mocks__/leaflet.ts
@@ -95,6 +95,7 @@ export interface CircleMarkerInstance {
   opts: Record<string, unknown>;
   bindPopup: ReturnType<typeof vi.fn>;
   addTo: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
 }
 export const circleMarkerInstances: CircleMarkerInstance[] = [];
 
@@ -108,6 +109,7 @@ const L = {
       opts,
       bindPopup: vi.fn().mockReturnThis(),
       addTo: vi.fn().mockReturnThis(),
+      on: vi.fn().mockReturnThis(),
     };
     circleMarkerInstances.push(inst);
     return inst;

--- a/frontend/src/components/map/ClusterLayer.test.tsx
+++ b/frontend/src/components/map/ClusterLayer.test.tsx
@@ -1,0 +1,101 @@
+import { useEffect, type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import L from "leaflet";
+
+vi.mock("leaflet", () => import("../../__mocks__/leaflet"));
+vi.mock("react-leaflet", () => import("../../__mocks__/react-leaflet"));
+
+import { circleMarkerInstances } from "../../__mocks__/leaflet";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { LayersStateProvider, useLayersState } from "../../hooks/useLayersState";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { MemoryRouter } from "react-router-dom";
+import ClusterLayer from "./ClusterLayer";
+import type { ClusterPoint } from "../../hooks/useClusterHotspots";
+
+function Providers({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MemoryRouter>
+      <ThemeProvider>
+        <CustomThemeProvider>
+          <QueryClientProvider client={qc}>
+            <LayersStateProvider>{children}</LayersStateProvider>
+          </QueryClientProvider>
+        </CustomThemeProvider>
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+}
+
+function EnableClusterLayer() {
+  const { setOtherLayer } = useLayersState();
+  useEffect(() => setOtherLayer("crashClusters", true), [setOtherLayer]);
+  return null;
+}
+
+const CLUSTERS: ClusterPoint[] = [
+  { lat: 34.2, lng: -118.2, crash_count: 8, z_score: 3.1, severity: { fatal: 3, injury: 5, pdo: 0 } },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  circleMarkerInstances.length = 0;
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/crashes/clusters")) {
+      return {
+        ok: true,
+        json: async () => ({
+          clusters: CLUSTERS,
+          total_grid_cells: 5,
+          mean_count: 1,
+          stddev_count: 2.5,
+          threshold: 6,
+        }),
+      } as Response;
+    }
+    return { ok: true, json: async () => ({}) } as Response;
+  });
+});
+
+describe("ClusterLayer", () => {
+  it("does not fetch or draw markers when the layer is off (default)", async () => {
+    render(
+      <Providers>
+        <ClusterLayer onSelectCluster={() => {}} />
+      </Providers>,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(L.circleMarker).not.toHaveBeenCalled();
+  });
+
+  it("draws one pulsing marker per cluster when enabled", async () => {
+    render(
+      <Providers>
+        <EnableClusterLayer />
+        <ClusterLayer onSelectCluster={() => {}} />
+      </Providers>,
+    );
+    await waitFor(() => expect(circleMarkerInstances.length).toBe(1));
+    expect(circleMarkerInstances[0].latlng).toEqual([34.2, -118.2]);
+    expect(circleMarkerInstances[0].opts.className).toBe("cluster-pulse-marker");
+  });
+
+  it("invokes onSelectCluster with the cluster's stats when its marker is clicked", async () => {
+    const onSelectCluster = vi.fn();
+    render(
+      <Providers>
+        <EnableClusterLayer />
+        <ClusterLayer onSelectCluster={onSelectCluster} />
+      </Providers>,
+    );
+    await waitFor(() => expect(circleMarkerInstances.length).toBe(1));
+    const clickHandler = circleMarkerInstances[0].on.mock.calls.find(([event]) => event === "click")?.[1] as () => void;
+    clickHandler();
+    expect(onSelectCluster).toHaveBeenCalledWith(CLUSTERS[0]);
+  });
+});

--- a/frontend/src/components/map/ClusterLayer.test.tsx
+++ b/frontend/src/components/map/ClusterLayer.test.tsx
@@ -85,6 +85,23 @@ describe("ClusterLayer", () => {
     expect(circleMarkerInstances[0].opts.className).toBe("cluster-pulse-marker");
   });
 
+  it("omits involvement flags from the request when their toggles are off (default)", async () => {
+    render(
+      <Providers>
+        <EnableClusterLayer />
+        <ClusterLayer onSelectCluster={() => {}} />
+      </Providers>,
+    );
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    const url = String((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    // A default (off) toggle must NOT serialize `flag=false` — that would make
+    // the backend apply IS FALSE and drop pre-2016 SWITRS + flag-positive rows.
+    for (const flag of ["alcohol", "distracted", "pedestrian", "cyclist", "drug"]) {
+      expect(url).not.toContain(`${flag}=false`);
+      expect(url).not.toContain(`${flag}=`);
+    }
+  });
+
   it("invokes onSelectCluster with the cluster's stats when its marker is clicked", async () => {
     const onSelectCluster = vi.fn();
     render(

--- a/frontend/src/components/map/ClusterLayer.tsx
+++ b/frontend/src/components/map/ClusterLayer.tsx
@@ -45,11 +45,16 @@ export default memo(function ClusterLayer({ onSelectCluster }: ClusterLayerProps
     dateRange: fp.selectedDateRange,
     severities: [...fp.selectedSeverities],
     causes: [...fp.selectedCauses],
-    alcohol: fp.selectedAlcohol,
-    distracted: fp.selectedDistracted,
-    pedestrian: fp.selectedPedestrian,
-    cyclist: fp.selectedCyclist,
-    drug: fp.selectedDrug,
+    // Coerce the default `false` (toggle off) to undefined so buildUrl omits
+    // the param entirely. Sending `alcohol=false` makes the backend apply an
+    // `IS FALSE` predicate, which silently drops pre-2016 SWITRS rows (flag is
+    // NULL) and every flag-positive crash — corrupting the default hotspot set.
+    // Mirrors MapPage's involvementFilters.
+    alcohol: fp.selectedAlcohol || undefined,
+    distracted: fp.selectedDistracted || undefined,
+    pedestrian: fp.selectedPedestrian || undefined,
+    cyclist: fp.selectedCyclist || undefined,
+    drug: fp.selectedDrug || undefined,
     driverAge: fp.selectedDriverAge,
     weather: [...fp.selectedWeather],
     lighting: [...fp.selectedLighting],

--- a/frontend/src/components/map/ClusterLayer.tsx
+++ b/frontend/src/components/map/ClusterLayer.tsx
@@ -1,0 +1,106 @@
+import { memo, useEffect, useRef } from "react";
+import { useMap } from "react-leaflet";
+import L from "leaflet";
+import { useLayersState } from "../../hooks/useLayersState";
+import { useFilterParams } from "../../hooks/useFilterParams";
+import { useClusterHotspots, type ClusterPoint } from "../../hooks/useClusterHotspots";
+
+// Dedicated pane so cluster markers draw above the crash dot layer (625) but
+// below the label tiles (650) / popups (700).
+const CLUSTER_PANE = "clusterPane";
+
+const MARKER_COLOR = "#b91c1c";
+const MARKER_FILL = "#ef4444";
+const MIN_RADIUS = 8;
+const MAX_RADIUS = 16;
+const MAX_Z_SCORE_FOR_SCALE = 6;
+
+interface ClusterLayerProps {
+  onSelectCluster: (cluster: ClusterPoint) => void;
+}
+
+function radiusFor(zScore: number): number {
+  const frac = Math.max(0, Math.min(1, zScore / MAX_Z_SCORE_FOR_SCALE));
+  return MIN_RADIUS + frac * (MAX_RADIUS - MIN_RADIUS);
+}
+
+/**
+ * Plots statistically significant crash hotspots (grid density + z-score > 2σ,
+ * see /api/crashes/clusters) as pulsing circle markers. Clicking a marker
+ * hands the cluster's stats up to the side panel via onSelectCluster.
+ * Renders nothing when the layer is toggled off. Imperative Leaflet layer
+ * management mirrors TopIntersectionsLayer / HighwayDangerLayer.
+ */
+export default memo(function ClusterLayer({ onSelectCluster }: ClusterLayerProps) {
+  const map = useMap();
+  const fp = useFilterParams();
+  const { otherLayers } = useLayersState();
+  const enabled = otherLayers.crashClusters;
+
+  const { clusters } = useClusterHotspots({
+    enabled,
+    county: fp.selectedCounties.size > 0
+      ? [...fp.selectedCounties].map((c) => c.toLowerCase().replace(/ /g, "-")).join(",")
+      : null,
+    dateRange: fp.selectedDateRange,
+    severities: [...fp.selectedSeverities],
+    causes: [...fp.selectedCauses],
+    alcohol: fp.selectedAlcohol,
+    distracted: fp.selectedDistracted,
+    pedestrian: fp.selectedPedestrian,
+    cyclist: fp.selectedCyclist,
+    drug: fp.selectedDrug,
+    driverAge: fp.selectedDriverAge,
+    weather: [...fp.selectedWeather],
+    lighting: [...fp.selectedLighting],
+    collisionType: [...fp.selectedCollisionType],
+    roadType: fp.selectedRoadType,
+    hitRun: fp.selectedHitRun,
+  });
+
+  const onSelectRef = useRef(onSelectCluster);
+  onSelectRef.current = onSelectCluster;
+
+  const layerRef = useRef<L.LayerGroup | null>(null);
+
+  useEffect(() => {
+    if (layerRef.current) {
+      map.removeLayer(layerRef.current);
+      layerRef.current = null;
+    }
+    if (!enabled || clusters.length === 0) return;
+
+    if (!map.getPane(CLUSTER_PANE)) {
+      map.createPane(CLUSTER_PANE);
+      const pane = map.getPane(CLUSTER_PANE);
+      if (pane) pane.style.zIndex = "640";
+    }
+
+    const markers = clusters.map((cluster) => {
+      const marker = L.circleMarker([cluster.lat, cluster.lng], {
+        radius: radiusFor(cluster.z_score),
+        color: MARKER_COLOR,
+        fillColor: MARKER_FILL,
+        fillOpacity: 0.55,
+        weight: 2,
+        pane: CLUSTER_PANE,
+        className: "cluster-pulse-marker",
+      });
+      marker.on("click", () => onSelectRef.current(cluster));
+      return marker;
+    });
+
+    const group = L.layerGroup(markers);
+    group.addTo(map);
+    layerRef.current = group;
+
+    return () => {
+      if (layerRef.current) {
+        map.removeLayer(layerRef.current);
+        layerRef.current = null;
+      }
+    };
+  }, [map, enabled, clusters]);
+
+  return null;
+});

--- a/frontend/src/components/map/ClusterSidePanelContent.tsx
+++ b/frontend/src/components/map/ClusterSidePanelContent.tsx
@@ -1,0 +1,41 @@
+import type { ClusterPoint } from "../../hooks/useClusterHotspots";
+
+interface ClusterSidePanelContentProps {
+  cluster: ClusterPoint;
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between items-baseline">
+      <span className="text-sm text-on-surface-variant">{label}</span>
+      <span className="text-sm font-semibold text-on-surface tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Presentational summary of a single crash hotspot, shown in the side panel
+ * when a cluster marker is clicked on the map.
+ */
+export default function ClusterSidePanelContent({ cluster }: ClusterSidePanelContentProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <span className="font-headline text-2xl font-bold tracking-tight text-on-surface">
+          Crash Hotspot
+        </span>
+        <p className="text-[10px] uppercase tracking-widest text-on-surface-variant font-medium">
+          {cluster.lat.toFixed(2)}, {cluster.lng.toFixed(2)}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <Stat label="Crashes" value={cluster.crash_count.toLocaleString()} />
+        <Stat label="Z-score" value={cluster.z_score.toFixed(2)} />
+        <Stat label="Fatal" value={cluster.severity.fatal.toLocaleString()} />
+        <Stat label="Injury" value={cluster.severity.injury.toLocaleString()} />
+        <Stat label="Property damage only" value={cluster.severity.pdo.toLocaleString()} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/map/LayersPanel.tsx
+++ b/frontend/src/components/map/LayersPanel.tsx
@@ -300,6 +300,28 @@ export default function LayersPanel() {
         </div>
       </div>
 
+      {/* Crash Clusters */}
+      <div className="space-y-4">
+        <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">
+          Crash Clusters
+        </span>
+        <div className="space-y-3">
+          <div className="flex justify-between items-center">
+            <span className={`text-sm font-medium ${otherLayers.crashClusters ? "text-on-surface" : "text-on-surface-variant"}`}>
+              Hotspot detection
+            </span>
+            <Toggle
+              enabled={otherLayers.crashClusters}
+              onToggle={() => toggleOtherLayer("crashClusters")}
+              label="Hotspot detection"
+            />
+          </div>
+          <p className="text-[10px] text-on-surface-variant leading-tight pl-1">
+            Highlights statistically significant crash hotspots (z-score &gt; 2σ). Click a cluster for details.
+          </p>
+        </div>
+      </div>
+
       {/* Measure */}
       <div className="space-y-4">
         <span className="text-[10px] font-bold uppercase tracking-widest text-on-surface-variant font-body">

--- a/frontend/src/components/map/MapCanvas.test.tsx
+++ b/frontend/src/components/map/MapCanvas.test.tsx
@@ -11,6 +11,9 @@ vi.mock("./CountyBoundaries", () => ({
 vi.mock("./HighwayDangerLayer", () => ({
   default: () => null,
 }));
+vi.mock("./ClusterLayer", () => ({
+  default: () => null,
+}));
 vi.mock("./CrashHeatmap", () => ({
   default: () => null,
 }));
@@ -39,6 +42,7 @@ const defaultHeatmapProps = {
   heatmapResolution: "low" as const,
   heatmapPalette: "default" as const,
   onSelectHighway: vi.fn(),
+  onSelectCluster: vi.fn(),
 };
 
 function renderWithTheme(ui: React.ReactElement) {

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -20,7 +20,9 @@ import CoordMismatchLayer from "./CoordMismatchLayer";
 import CaliforniaMask from "./CaliforniaMask";
 import OverlayMarkers from "./OverlayMarkers";
 import CrashDotLayer from "./CrashDotLayer";
+import ClusterLayer from "./ClusterLayer";
 import type { HeatmapPoint } from "../../hooks/useCrashHeatmap";
+import type { ClusterPoint } from "../../hooks/useClusterHotspots";
 import type { HighwayRow } from "../../hooks/useHighwayRankings";
 import type { ViewportSeed } from "../../hooks/useViewportParams";
 import { useLayersState, type HeatmapResolution } from "../../hooks/useLayersState";
@@ -105,6 +107,7 @@ interface MapCanvasProps {
   onFocusCounty: (name: string | null) => void;
   onSelectCounty: (name: string) => void;
   onSelectHighway: (row: HighwayRow) => void;
+  onSelectCluster: (cluster: ClusterPoint) => void;
   onMapReady: (map: LeafletMap) => void;
   heatmapPoints: HeatmapPoint[];
   heatmapActive: boolean;
@@ -132,6 +135,7 @@ function MapInternals({
   onFocusCounty,
   onSelectCounty,
   onSelectHighway,
+  onSelectCluster,
   onMapReady,
   heatmapPoints,
   heatmapActive,
@@ -183,6 +187,7 @@ function MapInternals({
         onSelectCounty={onSelectCounty}
       />
       <HighwayDangerLayer onSelectHighway={onSelectHighway} />
+      <ClusterLayer onSelectCluster={onSelectCluster} />
       <TopIntersectionsLayer county={focusedCounty ? focusedCounty.toLowerCase().replace(/\s+/g, "-") : null} />
       {heatmapActive && (
         <CrashHeatmap
@@ -216,6 +221,7 @@ export default function MapCanvas({
   onFocusCounty,
   onSelectCounty,
   onSelectHighway,
+  onSelectCluster,
   onMapReady,
   heatmapPoints,
   heatmapActive,
@@ -295,6 +301,7 @@ export default function MapCanvas({
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onSelectHighway={onSelectHighway}
+        onSelectCluster={onSelectCluster}
         onMapReady={onMapReady}
         heatmapPoints={heatmapPoints}
         heatmapActive={heatmapActive}

--- a/frontend/src/hooks/useClusterHotspots.ts
+++ b/frontend/src/hooks/useClusterHotspots.ts
@@ -1,0 +1,116 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+import { slugify, formatYearMonth, type DateRangeFilter } from "./useFilterParams";
+
+export interface ClusterSeverityBreakdown {
+  fatal: number;
+  injury: number;
+  pdo: number;
+}
+
+export interface ClusterPoint {
+  lat: number;
+  lng: number;
+  crash_count: number;
+  z_score: number;
+  severity: ClusterSeverityBreakdown;
+}
+
+interface ClusterHotspotsParams {
+  enabled: boolean;
+  county: string | null;
+  dateRange: DateRangeFilter | null;
+  severities: string[];
+  causes: string[];
+  alcohol?: boolean | null;
+  distracted?: boolean | null;
+  pedestrian?: boolean | null;
+  cyclist?: boolean | null;
+  drug?: boolean | null;
+  driverAge?: string | null;
+  weather?: string[];
+  lighting?: string[];
+  collisionType?: string[];
+  roadType?: string | null;
+  hitRun?: boolean;
+}
+
+interface ClusterHotspotsApiResponse {
+  clusters: ClusterPoint[];
+  total_grid_cells: number;
+  mean_count: number;
+  stddev_count: number;
+  threshold: number;
+}
+
+function dateRangeKey(dr: DateRangeFilter | null): string {
+  if (!dr) return "";
+  return `${dr.start ? formatYearMonth(dr.start) : ""}|${dr.end ? formatYearMonth(dr.end) : ""}`;
+}
+
+function buildUrl(params: ClusterHotspotsParams): string {
+  const sp = new URLSearchParams();
+  if (params.county) sp.set("county", params.county);
+  if (params.dateRange?.start) sp.set("start", formatYearMonth(params.dateRange.start));
+  if (params.dateRange?.end) sp.set("end", formatYearMonth(params.dateRange.end));
+  if (params.severities.length) sp.set("severity", params.severities.map(slugify).join(","));
+  if (params.causes.length) sp.set("cause", params.causes.join(","));
+  if (params.alcohol != null) sp.set("alcohol", String(params.alcohol));
+  if (params.distracted != null) sp.set("distracted", String(params.distracted));
+  if (params.pedestrian != null) sp.set("pedestrian", String(params.pedestrian));
+  if (params.cyclist != null) sp.set("cyclist", String(params.cyclist));
+  if (params.drug != null) sp.set("drug", String(params.drug));
+  if (params.driverAge) sp.set("driver_age", params.driverAge);
+  if (params.weather?.length) sp.set("weather", params.weather.join(","));
+  if (params.lighting?.length) sp.set("lighting", params.lighting.join(","));
+  if (params.collisionType?.length) sp.set("collision_type", params.collisionType.join(","));
+  if (params.roadType) sp.set("road_type", params.roadType);
+  if (params.hitRun) sp.set("hit_run", "true");
+  return `${API_BASE}/api/crashes/clusters?${sp.toString()}`;
+}
+
+export const FETCH_TIMEOUT_MS = 15_000;
+
+async function fetchClusterHotspots(params: ClusterHotspotsParams): Promise<ClusterHotspotsApiResponse> {
+  const res = await fetch(buildUrl(params), {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`clusters ${res.status}`);
+  return res.json();
+}
+
+export function useClusterHotspots(params: ClusterHotspotsParams) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [
+      "crashClusters",
+      params.county,
+      dateRangeKey(params.dateRange),
+      params.severities,
+      params.causes,
+      params.alcohol,
+      params.distracted,
+      params.pedestrian,
+      params.cyclist,
+      params.drug,
+      params.driverAge,
+      params.weather ?? [],
+      params.lighting ?? [],
+      params.collisionType ?? [],
+      params.roadType ?? null,
+      params.hitRun ?? false,
+    ],
+    queryFn: () => fetchClusterHotspots(params),
+    enabled: params.enabled,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    clusters: data?.clusters ?? [],
+    totalGridCells: data?.total_grid_cells ?? 0,
+    meanCount: data?.mean_count ?? 0,
+    stddevCount: data?.stddev_count ?? 0,
+    threshold: data?.threshold ?? 0,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/src/hooks/useLayersState.tsx
+++ b/frontend/src/hooks/useLayersState.tsx
@@ -18,7 +18,7 @@ const THEME_TO_MAP_PALETTE: Record<ChartPaletteKey, PaletteKey> = {
   custom: "default",
 };
 
-export type OtherLayerKey = "heatmapStatewide" | "heatmapCounty" | "coordMismatches" | "coordIncludeRivers" | "incidents" | "countyBoundaries" | "roadTypes" | "schools" | "hospitals" | "highwayDanger" | "topIntersections";
+export type OtherLayerKey = "heatmapStatewide" | "heatmapCounty" | "coordMismatches" | "coordIncludeRivers" | "incidents" | "countyBoundaries" | "roadTypes" | "schools" | "hospitals" | "highwayDanger" | "topIntersections" | "crashClusters";
 export type HeatmapResolution = "raw" | "low" | "medium" | "high";
 
 /** The shareable subset of layer state that round-trips through the URL. See useLayerParams. */
@@ -43,6 +43,7 @@ const OTHER_LAYER_DEFAULTS: Record<OtherLayerKey, boolean> = {
   hospitals: false,
   highwayDanger: false,
   topIntersections: false,
+  crashClusters: false,
 };
 
 const STORAGE_KEY = "calsight-layers";

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -471,6 +471,15 @@
   50% { opacity: 0.6; }
 }
 
+.cluster-pulse-marker {
+  animation: clusterPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes clusterPulse {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 0.45; }
+}
+
 /* ══════════════════════════════════════════════════════════════════════════════
  * PRINT-PERFECT LAYOUT SYSTEM
  * ══════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -27,6 +27,8 @@ import DataExportPanel, {
 } from "../components/map/DataExportPanel";
 import MapCanvas from "../components/map/MapCanvas";
 import HighwaySidePanelContent from "../components/map/HighwaySidePanelContent";
+import ClusterSidePanelContent from "../components/map/ClusterSidePanelContent";
+import type { ClusterPoint } from "../hooks/useClusterHotspots";
 import type { HighwayRow } from "../hooks/useHighwayRankings";
 import { snapshotFilters } from "../lib/ai/contextBuilders";
 import AiInsightCard from "../components/map/AiInsightCard";
@@ -95,6 +97,7 @@ function MapPageInner() {
 
   const [activePanel, setActivePanel] = useState<string | null>(null);
   const [selectedHighway, setSelectedHighway] = useState<HighwayRow | null>(null);
+  const [selectedCluster, setSelectedCluster] = useState<ClusterPoint | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleIntroStart = useCallback((_mode: "simple" | "advanced") => {
     const isMobile = window.innerWidth < 768;
@@ -323,6 +326,11 @@ function MapPageInner() {
     setActivePanel("highway");
   }, []);
 
+  const handleSelectCluster = useCallback((cluster: ClusterPoint) => {
+    setSelectedCluster(cluster);
+    setActivePanel("cluster");
+  }, []);
+
   const handleSelectPlace = useCallback((lat: number, lng: number) => {
     setTempMarker([lat, lng]);
     mapRef.current?.setView([lat, lng], 14, { animate: true, duration: 0.5 });
@@ -464,6 +472,8 @@ function MapPageInner() {
 
   const meta = activePanel === "highway"
     ? { title: selectedHighway?.route_number ?? "Highway", subtitle: "Highway Danger" }
+    : activePanel === "cluster"
+    ? { title: "Crash Hotspot", subtitle: "Cluster Detection" }
     : activePanel ? PANEL_META[activePanel] : null;
 
   // Filter snapshot threaded into the highway side-panel AI deep-dive contexts.
@@ -557,6 +567,8 @@ function MapPageInner() {
         return <DataExportPanel />;
       case "highway":
         return selectedHighway ? <HighwaySidePanelContent row={selectedHighway} filters={highwayFilterSnapshot} /> : null;
+      case "cluster":
+        return selectedCluster ? <ClusterSidePanelContent cluster={selectedCluster} /> : null;
       default:
         return null;
     }
@@ -620,6 +632,7 @@ function MapPageInner() {
           onFocusCounty={handleFocusCounty}
           onSelectCounty={handleSelectCounty}
           onSelectHighway={handleSelectHighway}
+          onSelectCluster={handleSelectCluster}
           onMapReady={handleMapReady}
           heatmapPoints={heatmap.points}
           heatmapActive={heatmapEnabled}


### PR DESCRIPTION
**What**
Adds `/api/crashes/clusters` and a new map layer that detects and displays statistically significant crash hotspots (grid density + z-score > 2σ over a 0.01° grid) as pulsing markers, clickable for a stats side panel showing crash count, z-score, and severity breakdown. Closes [[#280](https://github.com/JeffreySardella/CalSight/issues/280)](https://github.com/JeffreySardella/CalSight/issues/280).

**Dependencies**
None new.

**How to test**
- `docker-compose up --build`, open the map
- Toggle "Crash Clusters → Hotspot detection" in the Layers panel
- Confirm pulsing markers appear over dense crash corridors (e.g. LA, Bakersfield, San Bernardino/Riverside, Oceanside/San Diego border)
- Click a marker to confirm the side panel shows crash count, z-score, and fatal/injury/PDO breakdown
- Toggle off to confirm the layer and its pane clean up correctly

**Checklist**
- [x] Backend integration tests added (`backend/tests/api/test_clusters.py`) — 7 tests, verified passing against real Postgres
- [x] Frontend tests added (`ClusterLayer.test.tsx`)
- [x] `ruff check` clean
- [x] `tsc --noEmit` clean (pre-existing unrelated `@sentry/react` module errors excluded)
- [x] `npm run lint` clean
- [x] Manually verified end-to-end in browser (layer toggle, network request, rendering, click-to-detail panel)