### PR TITLE
fix(audit): driver_age silent-unfiltered 422, partial-year ETL resume, statement timeouts, Explain filter carry

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,5 +1,5 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import DeclarativeBase, sessionmaker
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from app.settings import settings
 
@@ -42,3 +42,14 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def apply_statement_timeout(db: Session, ms: int) -> None:
+    """Bound every query in this session's current transaction.
+
+    SET LOCAL resets when the transaction ends (commit/rollback/close), so
+    it can't leak the timeout onto the next user of a pooled connection.
+    Heavy endpoints call this so a pathological filter combination times out
+    instead of holding a pool connection indefinitely.
+    """
+    db.execute(text(f"SET LOCAL statement_timeout = {int(ms)}"))

--- a/backend/app/routers/ask.py
+++ b/backend/app/routers/ask.py
@@ -14,7 +14,6 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from slowapi import Limiter
 from slowapi.util import get_remote_address
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.ai_prompt import (
@@ -25,7 +24,7 @@ from app.ai_prompt import (
     build_quick_facts,
 )
 from app.ai_tools import TOOL_REGISTRY, query_crashes
-from app.database import SessionLocal, get_db
+from app.database import SessionLocal, apply_statement_timeout, get_db
 from app.llm_cache import get_ask_cache, make_cache_key
 from app.models import ChatFeedback
 from app.llm import (
@@ -50,10 +49,7 @@ _STATEMENT_TIMEOUT_MS = 50_000
 
 
 def _apply_statement_timeout(db: Session, ms: int = _STATEMENT_TIMEOUT_MS) -> None:
-    """Bound every query on this dedicated, short-lived ask session. SET LOCAL
-    resets when the session's transaction ends (on close), so it can't leak the
-    timeout onto the next user of a pooled connection."""
-    db.execute(text(f"SET LOCAL statement_timeout = {int(ms)}"))
+    apply_statement_timeout(db, ms)
 
 
 class _AskAbandoned(Exception):

--- a/backend/app/routers/intersections.py
+++ b/backend/app/routers/intersections.py
@@ -30,7 +30,7 @@ from sqlalchemy import Float, and_, case, cast, func, null, select
 from sqlalchemy.orm import Session
 
 from app.county_slug_map import get_code, get_slug_map
-from app.database import get_db
+from app.database import apply_statement_timeout, get_db
 from app.models import County, Crash
 
 router = APIRouter(tags=["intersections"])
@@ -38,6 +38,12 @@ router = APIRouter(tags=["intersections"])
 _limiter = Limiter(key_func=get_remote_address)
 
 _MAX_LIMIT = 200
+
+# Per-query backstop: these endpoints aggregate the full crashes table when no
+# county filter is given (the TTL cache only helps after a first successful
+# scan). Kill runaway queries so they release their pool connection instead of
+# piling up under load. Comfortably above the observed statewide scan time.
+_STATEMENT_TIMEOUT_MS = 30_000
 
 # Relative severity weights for the optional severity-weighted score
 # (EPDO-style — "equivalent property-damage-only"). These are a presentation
@@ -342,6 +348,7 @@ def get_intersections(
 ):
     """Crashes aggregated by (primary_road x secondary_road), ranked by count or severity-weighted score."""
     response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+    apply_statement_timeout(db, _STATEMENT_TIMEOUT_MS)
     code = _resolve_county(db, county)
     return _aggregate(
         db, by_secondary=True, county_code=code, year_start=year_start,
@@ -367,6 +374,7 @@ def get_corridors(
 ):
     """Crashes aggregated by primary_road (corridor), ranked by count or severity-weighted score."""
     response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+    apply_statement_timeout(db, _STATEMENT_TIMEOUT_MS)
     code = _resolve_county(db, county)
     return _aggregate(
         db, by_secondary=False, county_code=code, year_start=year_start,
@@ -394,6 +402,7 @@ def get_street_concentration(
     (see ConcentrationOut). Neutral: the numbers are reported without framing.
     """
     response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+    apply_statement_timeout(db, _STATEMENT_TIMEOUT_MS)
     code = _resolve_county(db, county)
     name = None
     if code is not None:

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.ca_highways import miles_for
 from app.county_slug_map import get_slug_map
-from app.database import get_db
+from app.database import apply_statement_timeout, get_db
 from app.filters import (
     FilterError,
     build_crash_predicates,
@@ -222,8 +222,16 @@ def _apply_wide_filters(stmt, years, county_codes, severities, causes,
         stmt = stmt.where(w.c.f_hit_run == (1 if hit_run_v else 0))
     if driver_age_v is not None:
         bracket = _AGE_BRACKET_MAP.get(driver_age_v)
-        if bracket is not None:
-            stmt = stmt.where(w.c.age_bracket == bracket)
+        if bracket is None:
+            # mv_crashes_wide only stores the five canonical brackets;
+            # silently dropping the filter would return unfiltered data
+            # presented as filtered.
+            raise FilterError(
+                "driver_age",
+                "Stats support only the canonical age brackets: "
+                "16-21, 22-34, 35-49, 50-64, 65+.",
+            )
+        stmt = stmt.where(w.c.age_bracket == bracket)
     return stmt
 
 
@@ -1137,6 +1145,9 @@ def stats_distribution(
         raise HTTPException(status_code=422, detail=f"invalid metric: {metric}")
 
     response.headers["Cache-Control"] = "public, max-age=3600, stale-while-revalidate=86400"
+    # Statewide raw-table aggregation with the full filter set — bound it so a
+    # pathological combination can't hold a pool connection indefinitely.
+    apply_statement_timeout(db, 30_000)
 
     date_range = parse_date_range(start, end)
     years = years_from_date_range(date_range) if date_range is not None else parse_year(year)

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -70,6 +70,11 @@ def determine_source(year: int) -> str:
     return "ccrs"
 
 
+# The smallest complete year in either source carries a few hundred thousand
+# crashes, so a year sitting far below this is a partial load, not a real one.
+_MIN_COMPLETE_YEAR_ROWS = 100_000
+
+
 def get_loaded_years(session) -> dict[int, int]:
     """Check which years already have crash data in the database.
 
@@ -228,10 +233,21 @@ def select_years_to_load(
     Without that exception, the daily job would no-op as soon as a year
     had a single batch loaded.
 
+    A year only counts as loaded above _MIN_COMPLETE_YEAR_ROWS: every
+    complete California year has hundreds of thousands of crashes, so a
+    count far below that means the load died partway (e.g. OOM) and the
+    year must be resumed, not skipped forever. The threshold is deliberately
+    conservative — a load that failed late can still be misclassified as
+    complete, but the common failure mode (dying in the first batches)
+    self-heals on the next run.
+
     Returns (switrs_years, ccrs_years, skipped_years).
     """
     if today_year is None:
         today_year = datetime.now(timezone.utc).year
+
+    def _is_loaded(year: int) -> bool:
+        return loaded.get(year, 0) >= _MIN_COMPLETE_YEAR_ROWS
 
     switrs_years = [
         y for y in range(start_year, end_year + 1)
@@ -248,12 +264,12 @@ def select_years_to_load(
     if not force:
         refresh_years = {today_year, today_year - 1}
         skipped = sorted(
-            [y for y in switrs_years if y in loaded]
-            + [y for y in ccrs_years if y in loaded and y not in refresh_years]
+            [y for y in switrs_years if _is_loaded(y)]
+            + [y for y in ccrs_years if _is_loaded(y) and y not in refresh_years]
         )
-        switrs_years = [y for y in switrs_years if y not in loaded]
+        switrs_years = [y for y in switrs_years if not _is_loaded(y)]
         ccrs_years = [
-            y for y in ccrs_years if y not in loaded or y in refresh_years
+            y for y in ccrs_years if not _is_loaded(y) or y in refresh_years
         ]
 
     return switrs_years, ccrs_years, skipped

--- a/backend/tests/api/test_stats.py
+++ b/backend/tests/api/test_stats.py
@@ -300,6 +300,39 @@ def test_stats_group_by_rate_rejects_cause_filter(client):
     assert response.json()["filter"] == "cause"
 
 
+# --- driver_age bracket handling (mv_crashes_wide) ---
+
+
+def test_stats_driver_age_canonical_bracket_ok(client):
+    """The five canonical brackets map onto mv_crashes_wide.age_bracket."""
+    # 65+ is sent URL-encoded (%2B) — a raw + decodes to a space.
+    for bracket in ["16-21", "22-34", "35-49", "50-64", "65%2B"]:
+        response = client.get(f"/api/stats?driver_age={bracket}")
+        assert response.status_code == 200, f"Bracket '{bracket}' rejected"
+
+
+def test_stats_driver_age_non_canonical_bracket_422(client):
+    """mv_crashes_wide only stores the five canonical age brackets — an
+    arbitrary range like 18-25 can't be honored there, so it must 422
+    rather than silently return unfiltered data presented as filtered."""
+    response = client.get("/api/stats?driver_age=18-25")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "driver_age"
+
+
+def test_stats_driver_age_non_canonical_422_with_group_by(client):
+    response = client.get("/api/stats?group_by=year&driver_age=30-40")
+    assert response.status_code == 422
+    assert response.json()["filter"] == "driver_age"
+
+
+def test_stats_highways_driver_age_arbitrary_range_ok(client):
+    """/stats/highways filters the raw crashes table with a real BETWEEN
+    predicate, so arbitrary ranges remain valid there."""
+    response = client.get("/api/stats/highways?driver_age=18-25")
+    assert response.status_code == 200
+
+
 # --- cause filter accepts new categories ---
 
 

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -110,6 +110,26 @@ class TestSelectYearsToLoad:
         assert switrs == []
         assert skipped == list(range(2001, 2016))
 
+    def test_partially_loaded_ccrs_year_resumes(self):
+        # A historical year that died mid-load (e.g. OOM after 12k of ~450k
+        # rows) must not count as loaded — otherwise it is skipped forever
+        # and the gap never heals. Reloading is safe (idempotent upsert).
+        loaded = {2018: 12_000, 2019: 480_000}
+        _, ccrs, skipped = select_years_to_load(
+            2016, 2026, loaded, source_filter="ccrs", today_year=2026,
+        )
+        assert 2018 in ccrs
+        assert 2018 not in skipped
+        assert 2019 in skipped
+
+    def test_partially_loaded_switrs_year_resumes(self):
+        loaded = {2010: 5_000}
+        switrs, _, skipped = select_years_to_load(
+            2001, 2015, loaded, source_filter="switrs", today_year=2026,
+        )
+        assert 2010 in switrs
+        assert 2010 not in skipped
+
     def test_year_rollover_shifts_refresh_window(self):
         # On Jan 1 2027 the refresh window becomes {2026, 2027}; 2025 retires.
         loaded = {2025: 400_000, 2026: 500_000}

--- a/backend/tests/test_statement_timeouts.py
+++ b/backend/tests/test_statement_timeouts.py
@@ -1,0 +1,50 @@
+"""Heavy endpoints must bound their queries with SET LOCAL statement_timeout.
+
+/api/intersections, /api/corridors, and /api/intersections/street-concentration
+aggregate the full crashes table when called statewide; /api/stats/distribution
+runs the full filter set against the raw table. Without a per-query timeout a
+pathological combination holds a pool connection indefinitely and requests
+pile up (same rationale as /ask and /crashes include_total).
+"""
+
+from types import SimpleNamespace
+
+from app.database import apply_statement_timeout
+
+
+def test_apply_statement_timeout_issues_set_local():
+    calls = []
+    db = SimpleNamespace(execute=lambda stmt, *a, **k: calls.append(str(stmt)))
+
+    apply_statement_timeout(db, 30_000)
+
+    assert len(calls) == 1
+    assert "set local statement_timeout" in calls[0].lower()
+    assert "30000" in calls[0]
+
+
+def test_apply_statement_timeout_coerces_ms_to_int():
+    """A float (or string) budget must not produce invalid SQL."""
+    calls = []
+    db = SimpleNamespace(execute=lambda stmt, *a, **k: calls.append(str(stmt)))
+
+    apply_statement_timeout(db, 1500.9)
+
+    assert "1500" in calls[0]
+
+
+def test_heavy_endpoints_call_the_timeout(monkeypatch):
+    """Source-level guard: the three intersections endpoints and
+    stats_distribution each apply the timeout before querying."""
+    import inspect
+
+    from app.routers import intersections, stats
+
+    for fn in (
+        intersections.get_intersections,
+        intersections.get_corridors,
+        intersections.get_street_concentration,
+        stats.stats_distribution,
+    ):
+        src = inspect.getsource(fn)
+        assert "apply_statement_timeout(" in src, fn.__name__

--- a/frontend/src/components/stats/ChartCard.test.tsx
+++ b/frontend/src/components/stats/ChartCard.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import ChartCard from "./ChartCard";
+import type { ChartSlot } from "../../lib/dashboard/types";
+
+// jsdom lacks matchMedia; ThemeProvider and chart components read it.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+const navigateSpy = vi.fn();
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+globalThis.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+const slot: ChartSlot = {
+  id: "c1",
+  dimension: "year",
+  measure: "count",
+  chartType: "bar",
+  order: 0,
+};
+
+const data = [
+  { label: "2022", value: 10 },
+  { label: "2023", value: 20 },
+];
+
+function renderCard(url: string) {
+  return render(
+    <ThemeProvider>
+      <CustomThemeProvider>
+        <MemoryRouter initialEntries={[url]}>
+          <ChartCard slot={slot} data={data} editing={false} />
+        </MemoryRouter>
+      </CustomThemeProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe("ChartCard Explain navigation", () => {
+  beforeEach(() => navigateSpy.mockClear());
+
+  it("carries the active filter query string to /ask so the AI explains the filtered chart", async () => {
+    renderCard("/stats?severity=fatal&cause=dui&year=2023&drill_county=fresno");
+    await userEvent.click(screen.getByRole("button", { name: /^explain crashes by year/i }));
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    const target = new URL(navigateSpy.mock.calls[0][0], "http://localhost");
+    expect(target.pathname).toBe("/ask");
+    expect(target.searchParams.get("q")).toMatch(/Crashes by Year/);
+    // Active filters carry over so useAskAi sends them with the question.
+    expect(target.searchParams.get("severity")).toBe("fatal");
+    expect(target.searchParams.get("cause")).toBe("dui");
+    expect(target.searchParams.get("year")).toBe("2023");
+    // Stats-internal params are not filters and must not leak.
+    expect(target.searchParams.get("drill_county")).toBeNull();
+  });
+
+  it("navigates with only q when no filters are active", async () => {
+    renderCard("/stats");
+    await userEvent.click(screen.getByRole("button", { name: /^explain crashes by year/i }));
+
+    const target = new URL(navigateSpy.mock.calls[0][0], "http://localhost");
+    expect(target.pathname).toBe("/ask");
+    expect(target.searchParams.get("q")).toMatch(/Crashes by Year/);
+    expect([...target.searchParams.keys()]).toEqual(["q"]);
+  });
+});

--- a/frontend/src/components/stats/ChartCard.tsx
+++ b/frontend/src/components/stats/ChartCard.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useMemo, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import SimpleBarChart from "../charts/SimpleBarChart";
 import SimpleDonutChart from "../charts/SimpleDonutChart";
 import SimpleLineChart from "../charts/SimpleLineChart";
@@ -19,7 +19,7 @@ import type { ChartNarrativeResult } from "../../hooks/useNarrativeInsights";
 import type { ChartSlot, Dimension } from "../../lib/dashboard/types";
 import { DIMENSION_LABELS, MEASURE_LABELS } from "../../lib/dashboard/types";
 import type { ChartDataItem } from "../../hooks/useDashboardData";
-import { useFilterParams } from "../../hooks/useFilterParams";
+import { useFilterParams, buildFilterQS } from "../../hooks/useFilterParams";
 import { useCustomTheme } from "../../context/CustomThemeContext";
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { exportChartPng, exportChartCsv } from "../../lib/export/chartExport";
@@ -254,6 +254,7 @@ function ChartCard({
   const [showTable, setShowTable] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { selectedCounties } = useFilterParams();
   const { chartColors } = useCustomTheme();
   const title = buildTitle(slot);
@@ -323,7 +324,11 @@ function ChartCard({
       ? ` in ${[...selectedCounties].join(", ")}`
       : "";
     const question = `Explain the "${title}" chart${countyPart}. What are the key takeaways?`;
-    navigate(`/ask?q=${encodeURIComponent(question)}`);
+    // Carry the active filters so useAskAi sends them with the question —
+    // otherwise the AI explains the unfiltered chart.
+    const params = new URLSearchParams(buildFilterQS(searchParams));
+    params.set("q", question);
+    navigate(`/ask?${params.toString()}`);
   };
 
   const handleExportPng = () => {

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -84,8 +84,11 @@ function AskAiPageInner() {
     if (q && !hasMessages) {
       prefillHandled.current = true;
       setInputValue(q);
-      // Remove q from URL without adding a history entry
-      window.history.replaceState({}, "", window.location.pathname);
+      // Remove q from URL without adding a history entry, keeping the
+      // filter params (severity, county, ...) that useAskAi reads per send.
+      const url = new URL(window.location.href);
+      url.searchParams.delete("q");
+      window.history.replaceState({}, "", url);
       // Auto-send after a brief tick so the UI renders the question first
       setTimeout(() => {
         sendMessage(q);


### PR DESCRIPTION
**What**
Knocks out the remaining backend mediums (M3/M4/M5) and frontend M3 from the 2026-07-05 audit:

- **Backend M3** — `/api/stats?driver_age=18-25` (any non-canonical bracket) silently returned **unfiltered** data presented as filtered; `mv_crashes_wide` only stores the 5 canonical brackets. Now 422s with the allowed brackets, mirroring the `group_by=rate`+`cause` precedent. `/stats/highways` still accepts arbitrary ranges (real `BETWEEN` on the raw table) — covered by a test.
- **Backend M4** — a historical year that died mid-load (e.g. OOM at 12k of ~450k rows) was skipped forever (`y in loaded`). `select_years_to_load` now requires ≥100k rows to count a year as loaded, so partial years resume on the next run (idempotent upsert makes reload safe).
- **Backend M5** — shared `apply_statement_timeout()` in `app.database` (ask.py now delegates to it); applied 30s budgets to `/api/intersections`, `/api/corridors`, `/api/intersections/street-concentration`, `/api/stats/distribution` — the remaining unbounded full-table scan paths.
- **Frontend M3** — ChartCard "Explain" navigated to `/ask?q=…` **dropping the filter query string**, so the AI explained the unfiltered chart while the user believed filters applied. Now carries `buildFilterQS(searchParams)`; AskAiPage strips only `q` from the URL instead of the entire query string.

**How to test**
- `pytest -m integration` — 248 passed (includes 4 new driver_age tests)
- `pytest tests/test_load_crashes.py tests/test_statement_timeouts.py` — new resume + timeout tests
- `vitest run` — 671 passed (includes new ChartCard Explain navigation tests)
- Manual: set severity=fatal on Stats, click a chart's ✨ Explain — the /ask request body now includes the filters.

**Checklist**
- [x] ruff clean, eslint clean, tsc clean
- [x] Full backend integration suite green against real Postgres
- [x] Full frontend suite green