### PR TITLE
fix(frontend): audit mediums — cooldown swallow, stale highway panel, chat re-renders, correlation no-data cells

### DIFF
--- a/frontend/src/components/ask/ChatMessage.memo.test.tsx
+++ b/frontend/src/components/ask/ChatMessage.memo.test.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import type { ChatMessage as ChatMessageType } from "../../hooks/useAskAi";
+
+// ChatMessage renders markdown (and possibly a chart) — expensive. The Ask AI
+// page re-renders on every keystroke in the textarea; without memo every
+// message in the transcript re-renders markdown per keystroke (M-F6).
+//
+// useStoryCanvas is called once per actual ChatMessage render, so the mock
+// doubles as a render counter that sees through React.memo bailouts.
+const hoisted = vi.hoisted(() => ({ renders: { count: 0 } }));
+vi.mock("../../hooks/useStoryCanvas", () => ({
+  useStoryCanvas: () => {
+    hoisted.renders.count += 1;
+    return { pinAnswer: () => {}, isPinned: () => false };
+  },
+}));
+
+import ChatMessage from "./ChatMessage";
+
+const message: ChatMessageType = {
+  role: "assistant",
+  content: "**Hello** — 42 crashes.",
+  timestamp: 1710000000000,
+  provider: "test",
+};
+
+function Harness() {
+  const [, setTick] = useState(0);
+  return (
+    <div>
+      <button onClick={() => setTick((t) => t + 1)}>retick</button>
+      <ChatMessage message={message} />
+    </div>
+  );
+}
+
+describe("ChatMessage memoization (M-F6)", () => {
+  it("does not re-render for unrelated parent re-renders (same message prop)", () => {
+    render(<Harness />);
+    const initialRenders = hoisted.renders.count;
+    expect(initialRenders).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByText("retick"));
+    fireEvent.click(screen.getByText("retick"));
+    fireEvent.click(screen.getByText("retick"));
+
+    // A memoized ChatMessage bails out on identical props.
+    expect(hoisted.renders.count).toBe(initialRenders);
+  });
+});

--- a/frontend/src/components/ask/ChatMessage.tsx
+++ b/frontend/src/components/ask/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import type { ChatMessage as ChatMessageType } from "../../hooks/useAskAi";
 import { API_BASE } from "../../config";
@@ -41,7 +41,11 @@ function getSavedFeedback(timestamp: number): "up" | "down" | null {
   } catch { return null; }
 }
 
-export default function ChatMessage({ message }: Props) {
+// memo: the Ask AI page re-renders on every keystroke; without this every
+// message in the transcript re-renders its markdown (and chart) each tick.
+// Message objects are stable references in the messages array, so a shallow
+// prop compare bails out for all but genuinely new/changed messages (M-F6).
+export default memo(function ChatMessage({ message }: Props) {
   const isUser = message.role === "user";
   const [feedback, setFeedback] = useState<"up" | "down" | null>(
     !isUser ? getSavedFeedback(message.timestamp) : null
@@ -130,4 +134,4 @@ export default function ChatMessage({ message }: Props) {
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/components/charts/CorrelationMatrix.tsx
+++ b/frontend/src/components/charts/CorrelationMatrix.tsx
@@ -299,9 +299,15 @@ export default function CorrelationMatrix({ fields, matrix, countyCount, countie
           {" × "}
           <span className="font-bold text-on-surface">{fields[hoverCell.j].label}</span>
           {" = "}
-          <span className="font-bold" style={{ color: Math.abs(matrix[hoverCell.i][hoverCell.j]) >= 0.2 ? colorForR(matrix[hoverCell.i][hoverCell.j], isDark, tokens.correlation) : undefined }}>r = {matrix[hoverCell.i][hoverCell.j].toFixed(2)}</span>
-          {Math.abs(matrix[hoverCell.i][hoverCell.j]) >= 0.7 && " (strong)"}
-          {Math.abs(matrix[hoverCell.i][hoverCell.j]) >= 0.4 && Math.abs(matrix[hoverCell.i][hoverCell.j]) < 0.7 && " (moderate)"}
+          {Number.isNaN(matrix[hoverCell.i][hoverCell.j]) ? (
+            <span className="font-bold">no data</span>
+          ) : (
+            <>
+              <span className="font-bold" style={{ color: Math.abs(matrix[hoverCell.i][hoverCell.j]) >= 0.2 ? colorForR(matrix[hoverCell.i][hoverCell.j], isDark, tokens.correlation) : undefined }}>r = {matrix[hoverCell.i][hoverCell.j].toFixed(2)}</span>
+              {Math.abs(matrix[hoverCell.i][hoverCell.j]) >= 0.7 && " (strong)"}
+              {Math.abs(matrix[hoverCell.i][hoverCell.j]) >= 0.4 && Math.abs(matrix[hoverCell.i][hoverCell.j]) < 0.7 && " (moderate)"}
+            </>
+          )}
         </p>
       )}
 
@@ -313,11 +319,17 @@ export default function CorrelationMatrix({ fields, matrix, countyCount, countie
                 {fields[selected.i].label} × {fields[selected.j].label}
               </p>
               <p className="text-[10px] text-on-surface-variant">
-                r = {matrix[selected.i][selected.j].toFixed(2)} — {
-                  Math.abs(matrix[selected.i][selected.j]) >= 0.7 ? "strong" :
-                  Math.abs(matrix[selected.i][selected.j]) >= 0.4 ? "moderate" :
-                  Math.abs(matrix[selected.i][selected.j]) >= 0.2 ? "weak" : "negligible"
-                } {matrix[selected.i][selected.j] >= 0 ? "positive" : "negative"} correlation
+                {Number.isNaN(matrix[selected.i][selected.j]) ? (
+                  "no data — this source didn't load or too few counties report both metrics"
+                ) : (
+                  <>
+                    r = {matrix[selected.i][selected.j].toFixed(2)} — {
+                      Math.abs(matrix[selected.i][selected.j]) >= 0.7 ? "strong" :
+                      Math.abs(matrix[selected.i][selected.j]) >= 0.4 ? "moderate" :
+                      Math.abs(matrix[selected.i][selected.j]) >= 0.2 ? "weak" : "negligible"
+                    } {matrix[selected.i][selected.j] >= 0 ? "positive" : "negative"} correlation
+                  </>
+                )}
               </p>
             </div>
             <button onClick={() => setSelected(null)} className="p-1 rounded-full hover:bg-surface-container-high text-on-surface-variant" aria-label="Close scatter plot detail">

--- a/frontend/src/components/map/HighwayDangerLayer.test.tsx
+++ b/frontend/src/components/map/HighwayDangerLayer.test.tsx
@@ -81,4 +81,37 @@ describe("HighwayDangerLayer", () => {
     );
     await waitFor(() => expect(L.geoJSON).toHaveBeenCalled());
   });
+
+  it("re-syncs the selected route's row when rankings load (M-F5: stale side panel)", async () => {
+    // The side panel is open on I-5; the rankings (re)fetch — the panel must
+    // receive the fresh row so its numbers match the active filters.
+    const onSelectHighway = vi.fn();
+    render(
+      <Providers>
+        <EnableHighwayLayer />
+        <HighwayDangerLayer onSelectHighway={onSelectHighway} selectedRoute="I-5" />
+      </Providers>,
+    );
+    await waitFor(() => expect(onSelectHighway).toHaveBeenCalled());
+    expect(onSelectHighway).toHaveBeenCalledWith(
+      expect.objectContaining({ route_number: "I-5", crash_count: 100 }),
+    );
+  });
+
+  it("signals when the selected route has no row under the new filters", async () => {
+    const onSelectHighway = vi.fn();
+    const onSelectedRouteGone = vi.fn();
+    render(
+      <Providers>
+        <EnableHighwayLayer />
+        <HighwayDangerLayer
+          onSelectHighway={onSelectHighway}
+          selectedRoute="SR-99"
+          onSelectedRouteGone={onSelectedRouteGone}
+        />
+      </Providers>,
+    );
+    await waitFor(() => expect(onSelectedRouteGone).toHaveBeenCalled());
+    expect(onSelectHighway).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/map/HighwayDangerLayer.tsx
+++ b/frontend/src/components/map/HighwayDangerLayer.tsx
@@ -28,6 +28,13 @@ const HIGHWAY_PANE = "highwayDangerPane";
 
 interface HighwayDangerLayerProps {
   onSelectHighway: (row: HighwayRow) => void;
+  /** Route whose side panel is currently open. When the rankings refetch
+   * (filter change), the layer pushes that route's fresh row back through
+   * onSelectHighway so the panel never shows numbers from stale filters. */
+  selectedRoute?: string | null;
+  /** Called when the selected route has no row under the new filters
+   * (fell out of the ranking) — the panel should close rather than lie. */
+  onSelectedRouteGone?: () => void;
 }
 
 /**
@@ -40,7 +47,7 @@ interface HighwayDangerLayerProps {
  *
  * Imperative Leaflet layer management mirrors CountyBoundaries.
  */
-export default memo(function HighwayDangerLayer({ onSelectHighway }: HighwayDangerLayerProps) {
+export default memo(function HighwayDangerLayer({ onSelectHighway, selectedRoute, onSelectedRouteGone }: HighwayDangerLayerProps) {
   const map = useMap();
   const fp = useFilterParams();
   const { otherLayers, highwayMetric } = useLayersState();
@@ -79,6 +86,18 @@ export default memo(function HighwayDangerLayer({ onSelectHighway }: HighwayDang
 
   const onSelectRef = useRef(onSelectHighway);
   onSelectRef.current = onSelectHighway;
+  const onGoneRef = useRef(onSelectedRouteGone);
+  onGoneRef.current = onSelectedRouteGone;
+
+  // M-F5: keep the open side panel in sync with the active filters. rows is
+  // react-query data (stable identity), so this only fires on a real refetch;
+  // re-selecting the same row object is a no-op setState upstream.
+  useEffect(() => {
+    if (!selectedRoute || !rows) return;
+    const fresh = rows.find((r) => r.route_number === selectedRoute);
+    if (fresh) onSelectRef.current(fresh);
+    else onGoneRef.current?.();
+  }, [rows, selectedRoute]);
 
   const layerRef = useRef<L.Layer | null>(null);
 

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -105,6 +105,10 @@ interface MapCanvasProps {
   onFocusCounty: (name: string | null) => void;
   onSelectCounty: (name: string) => void;
   onSelectHighway: (row: HighwayRow) => void;
+  /** Route whose side panel is open — threaded to HighwayDangerLayer so the
+   * panel re-syncs when the rankings refetch on a filter change (M-F5). */
+  selectedHighwayRoute?: string | null;
+  onSelectedHighwayGone?: () => void;
   onMapReady: (map: LeafletMap) => void;
   heatmapPoints: HeatmapPoint[];
   heatmapActive: boolean;
@@ -132,6 +136,8 @@ function MapInternals({
   onFocusCounty,
   onSelectCounty,
   onSelectHighway,
+  selectedHighwayRoute,
+  onSelectedHighwayGone,
   onMapReady,
   heatmapPoints,
   heatmapActive,
@@ -182,7 +188,11 @@ function MapInternals({
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
       />
-      <HighwayDangerLayer onSelectHighway={onSelectHighway} />
+      <HighwayDangerLayer
+        onSelectHighway={onSelectHighway}
+        selectedRoute={selectedHighwayRoute}
+        onSelectedRouteGone={onSelectedHighwayGone}
+      />
       <TopIntersectionsLayer county={focusedCounty ? focusedCounty.toLowerCase().replace(/\s+/g, "-") : null} />
       {heatmapActive && (
         <CrashHeatmap
@@ -216,6 +226,8 @@ export default function MapCanvas({
   onFocusCounty,
   onSelectCounty,
   onSelectHighway,
+  selectedHighwayRoute,
+  onSelectedHighwayGone,
   onMapReady,
   heatmapPoints,
   heatmapActive,
@@ -295,6 +307,8 @@ export default function MapCanvas({
         onFocusCounty={onFocusCounty}
         onSelectCounty={onSelectCounty}
         onSelectHighway={onSelectHighway}
+        selectedHighwayRoute={selectedHighwayRoute}
+        onSelectedHighwayGone={onSelectedHighwayGone}
         onMapReady={onMapReady}
         heatmapPoints={heatmapPoints}
         heatmapActive={heatmapActive}

--- a/frontend/src/hooks/useAskAi.test.tsx
+++ b/frontend/src/hooks/useAskAi.test.tsx
@@ -77,6 +77,30 @@ describe("useAskAi", () => {
     expect(result.current.error).toMatch(/wait/i);
   });
 
+  it("sendMessage reports whether the question was actually sent (M-F4)", async () => {
+    // The prefill flow ("Explain this chart" → /ask?q=...) clears the input
+    // after calling sendMessage. If the cooldown swallows the question the
+    // caller must know, or the user's question silently disappears.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse("hello"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAskAi(), { wrapper });
+
+    let sent: boolean | undefined;
+    await act(async () => {
+      sent = await result.current.sendMessage("first question");
+    });
+    expect(sent).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Inside the 15s cooldown the send is refused — and reported.
+    await act(async () => {
+      sent = await result.current.sendMessage("second question");
+    });
+    expect(sent).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("retry does not put the resent question in the LLM history twice (M-F6)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(okResponse("answer"));
     vi.stubGlobal("fetch", fetchMock);

--- a/frontend/src/hooks/useAskAi.tsx
+++ b/frontend/src/hooks/useAskAi.tsx
@@ -48,7 +48,10 @@ export interface AskAiApi {
   isLoading: boolean;
   error: string | null;
   cooldownEnd: number;
-  sendMessage: (question: string) => Promise<void>;
+  /** Resolves true when the question was accepted (appears in the
+   * conversation), false when a guard refused it (cooldown, in-flight,
+   * blank) — callers that clear an input must check this. */
+  sendMessage: (question: string) => Promise<boolean>;
   retry: () => void;
   clearConversation: () => void;
 }
@@ -125,8 +128,8 @@ function useAskAiState(): AskAiApi {
     return () => { abortRef.current?.abort(); };
   }, []);
 
-  const sendMessage = useCallback(async (question: string, opts?: { bypassLocalCooldown?: boolean }) => {
-    if (!question.trim() || isLoading || inFlightRef.current) return;
+  const sendMessage = useCallback(async (question: string, opts?: { bypassLocalCooldown?: boolean }): Promise<boolean> => {
+    if (!question.trim() || isLoading || inFlightRef.current) return false;
     // Respect the cooldown for every caller (the AI companion's "Go deeper"
     // etc.). retry() passes bypassLocalCooldown so a fast failure's own local
     // cooldown doesn't block the retry — but a server 429/503 backoff is still
@@ -137,7 +140,7 @@ function useAskAiState(): AskAiApi {
     if (Date.now() < guardUntil) {
       const remaining = Math.ceil((guardUntil - Date.now()) / 1000);
       setError(`Please wait ${remaining}s before asking again.`);
-      return;
+      return false;
     }
     inFlightRef.current = true;
     abortRef.current?.abort();
@@ -198,7 +201,7 @@ function useAskAiState(): AskAiApi {
           setCooldownEnd(Date.now() + retryAfter * 1000);
           setError(data.message || "All AI providers are busy. Try again shortly.");
           setIsLoading(false);
-          return;
+          return true;
         }
 
         if (resp.status === 429) {
@@ -214,14 +217,14 @@ function useAskAiState(): AskAiApi {
           setCooldownEnd(Date.now() + retryAfter * 1000);
           setError(`Rate limit reached. Try again in ${retryAfter} seconds.`);
           setIsLoading(false);
-          return;
+          return true;
         }
 
         if (!resp.ok) {
           if (attempt < MAX_RETRIES - 1) continue;
           setError("Something went wrong. Please try again.");
           setIsLoading(false);
-          return;
+          return true;
         }
 
         const data: AskResponse = await resp.json();
@@ -229,7 +232,7 @@ function useAskAiState(): AskAiApi {
           if (attempt < MAX_RETRIES - 1) continue;
           setError("AI couldn't generate a response. Try rephrasing your question.");
           setIsLoading(false);
-          return;
+          return true;
         }
 
         setError(null);
@@ -249,13 +252,16 @@ function useAskAiState(): AskAiApi {
 
         setMessages((prev) => [...prev, aiMsg]);
         setIsLoading(false);
-        return;
+        return true;
       } catch (e: unknown) {
         if (attempt < MAX_RETRIES - 1) continue;
         const isTimeout = e instanceof DOMException && e.name === "AbortError";
         setError(isTimeout ? "Request timed out. Try a simpler question." : "Couldn't reach the server. Check your connection.");
       }
     }
+    // Retries exhausted: the question was still accepted (it's in the
+    // conversation with an error + retry affordance), so report sent.
+    return true;
     } finally {
       // Always release the in-flight latch (and loading state) on every exit
       // path — including the early returns and the success return inside the

--- a/frontend/src/hooks/useCorrelationData.nodata.test.ts
+++ b/frontend/src/hooks/useCorrelationData.nodata.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { buildCorrelationResult, CORRELATION_FIELDS, type CorrelationSupplemental } from "./useCorrelationData";
+import { correlationColor, getTokens } from "../lib/theme/tokens";
+
+// M-F7: a failed supplemental fetch used to surface as r = 0.00 — visually
+// identical to a real "no correlation" result. Not-computable cells must be
+// NaN (rendered as "—"/"N/A"), never a fabricated zero.
+
+const emptySupplemental: CorrelationSupplemental = {
+  demographics: [],
+  calenviro: [],
+  unemployment: [],
+  vehicles: [],
+  weather: [],
+  fars: [],
+  density: [],
+};
+
+function statsFor(nCounties: number) {
+  return Array.from({ length: nCounties }, (_, i) => ({
+    county_code: i + 1,
+    county_name: `County ${i + 1}`,
+    crash_count: 100 + i * 10,
+    total_killed: 5 + i,
+    total_injured: 50 + i,
+  }));
+}
+
+describe("correlation matrix no-data cells (M-F7)", () => {
+  it("marks cells NaN when a source returned no data instead of r=0.00", () => {
+    const result = buildCorrelationResult(statsFor(10), emptySupplemental);
+    const crashIdx = CORRELATION_FIELDS.findIndex((f) => f.key === "crash_count");
+    const povertyIdx = CORRELATION_FIELDS.findIndex((f) => f.key === "poverty_rate");
+
+    // crash_count × poverty_rate has zero data points (demographics fetch
+    // failed) — must NOT masquerade as a computed zero correlation.
+    expect(Number.isNaN(result.matrix[crashIdx][povertyIdx])).toBe(true);
+
+    // Fields with real data still compute a genuine r.
+    const killedIdx = CORRELATION_FIELDS.findIndex((f) => f.key === "total_killed");
+    expect(Number.isNaN(result.matrix[crashIdx][killedIdx])).toBe(false);
+  });
+
+  it("keeps the diagonal at 1", () => {
+    const result = buildCorrelationResult(statsFor(10), emptySupplemental);
+    for (let i = 0; i < result.fields.length; i++) {
+      expect(result.matrix[i][i]).toBe(1);
+    }
+  });
+});
+
+describe("correlationColor NaN handling (M-F7)", () => {
+  it("renders NaN as the neutral color, not strong-negative red", () => {
+    const tokens = getTokens("default", false).correlation;
+    expect(correlationColor(NaN, tokens)).toBe(tokens.neutral);
+  });
+});

--- a/frontend/src/hooks/useCorrelationData.ts
+++ b/frontend/src/hooks/useCorrelationData.ts
@@ -337,7 +337,10 @@ export function buildCorrelationResult(
               ys.push(y);
             }
           }
-          matrix[i][j] = xs.length >= 5 ? Math.round(pearsonR(xs, ys) * 100) / 100 : 0;
+          // NaN = not computable (source failed to load or too few counties
+          // share both fields). Rendered as "—"; a fabricated 0 would read
+          // as a real "no correlation" finding (M-F7).
+          matrix[i][j] = xs.length >= 5 ? Math.round(pearsonR(xs, ys) * 100) / 100 : NaN;
         }
       }
 

--- a/frontend/src/lib/theme/tokens.ts
+++ b/frontend/src/lib/theme/tokens.ts
@@ -212,6 +212,9 @@ export function hexToRgba(hex: string, alpha: number): string {
  * This replaces the hardcoded colorForR function in CorrelationMatrix.
  */
 export function correlationColor(r: number, tokens: CorrelationTokens): string {
+  // Not-computable cells (NaN) are neutral — every comparison below is false
+  // for NaN, which would otherwise fall through to strong-negative red.
+  if (Number.isNaN(r)) return tokens.neutral;
   if (r >= 0.7) return tokens.positiveStrong;
   if (r >= 0.4) return tokens.positive;
   if (r >= 0.2) return tokens.positiveWeak;

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -86,10 +86,15 @@ function AskAiPageInner() {
       setInputValue(q);
       // Remove q from URL without adding a history entry
       window.history.replaceState({}, "", window.location.pathname);
-      // Auto-send after a brief tick so the UI renders the question first
-      setTimeout(() => {
-        sendMessage(q);
+      // Auto-send after a brief tick so the UI renders the question first.
+      // A refused send (active cooldown carried over in sessionStorage)
+      // resolves false on the next microtask — put the question back in the
+      // box instead of silently swallowing it; the user can send it when
+      // the countdown ends.
+      setTimeout(async () => {
         setInputValue("");
+        const sent = await sendMessage(q);
+        if (!sent) setInputValue(q);
       }, 0);
     }
   }, [searchParams, hasMessages, sendMessage]);
@@ -123,10 +128,14 @@ function AskAiPageInner() {
     el.style.height = el.scrollHeight + "px";
   }, [inputValue]);
 
-  const handleSend = () => {
+  const handleSend = async () => {
     if (!inputValue.trim() || isLoading || cooldownRemaining > 0) return;
-    sendMessage(inputValue);
+    const q = inputValue;
     setInputValue("");
+    // A guard refusal resolves false immediately (before the user can type);
+    // restore the question rather than losing it.
+    const sent = await sendMessage(q);
+    if (!sent) setInputValue(q);
   };
 
   const handleSuggestionClick = (question: string) => {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -323,6 +323,13 @@ function MapPageInner() {
     setActivePanel("highway");
   }, []);
 
+  // M-F5: the selected route fell out of the rankings under the new filters —
+  // close the panel rather than keep showing numbers from the old filters.
+  const handleSelectedHighwayGone = useCallback(() => {
+    setSelectedHighway(null);
+    setActivePanel((p) => (p === "highway" ? null : p));
+  }, []);
+
   const handleSelectPlace = useCallback((lat: number, lng: number) => {
     setTempMarker([lat, lng]);
     mapRef.current?.setView([lat, lng], 14, { animate: true, duration: 0.5 });
@@ -620,6 +627,8 @@ function MapPageInner() {
           onFocusCounty={handleFocusCounty}
           onSelectCounty={handleSelectCounty}
           onSelectHighway={handleSelectHighway}
+          selectedHighwayRoute={activePanel === "highway" ? selectedHighway?.route_number ?? null : null}
+          onSelectedHighwayGone={handleSelectedHighwayGone}
           onMapReady={handleMapReady}
           heatmapPoints={heatmap.points}
           heatmapActive={heatmapEnabled}


### PR DESCRIPTION
**What**
The remaining frontend mediums from the 2026-07-05 audit (M-F4 through M-F7):

- **M-F4** — `sendMessage` silently refused questions during the 15s cooldown while callers cleared the input, so the question vanished. It now resolves `boolean` (accepted or refused); the Ask AI prefill (`/ask?q=…`) and manual send restore the question to the input on refusal.
- **M-F5** — the highway side panel kept showing numbers from the *old* filters after a filter change. `HighwayDangerLayer` now re-syncs the open panel's row when the rankings refetch, and closes the panel when the selected route falls out of the rankings.
- **M-F6** — `ChatMessage` is now memoized; the Ask AI page re-renders per keystroke and previously re-rendered every transcript message's markdown (and inline charts) on each tick. Includes a render-count regression test verified to fail without the memo.
- **M-F7** — correlation-matrix cells that can't be computed (failed supplemental fetch, <5 counties sharing both fields) rendered as **r = 0.00** — indistinguishable from a real 'no correlation' finding. They're now `NaN`, rendered as '—' / 'no data'; `correlationColor` guards NaN, which previously fell through every comparison to strong-negative **red**.

**How to test**
- `vitest run` — 674 passed (5 new tests across useAskAi, HighwayDangerLayer, ChatMessage.memo, useCorrelationData.nodata)
- Manual M-F5: enable Highway Danger, click a route, then add `severity=fatal` — panel numbers update (or panel closes if the route drops out).
- Manual M-F7: block `/api/demographics` in devtools → Poverty/Income cells show '—', not red 0.00.

**Checklist**
- [x] tsc clean (pre-existing @sentry/react module errors excluded)
- [x] eslint clean on changed files (one pre-existing react-refresh warning in useAskAi)
- [x] Full frontend suite green