### PR TITLE
fix(frontend): retry transient query failures with backoff

### DIFF
--- a/frontend/src/lib/queryClient.test.ts
+++ b/frontend/src/lib/queryClient.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  statusFromError,
+  isRetryableError,
+  shouldRetry,
+  retryBackoff,
+  MAX_QUERY_RETRIES,
+} from "./queryClient";
+
+describe("statusFromError", () => {
+  it("extracts the trailing HTTP status from our fetch errors", () => {
+    expect(statusFromError(new Error("heatmap 503"))).toBe(503);
+    expect(statusFromError(new Error("dashboard batch 500"))).toBe(500);
+    expect(statusFromError(new Error("clusters 404"))).toBe(404);
+  });
+
+  it("returns null for messages with no recognizable status", () => {
+    expect(statusFromError(new Error("Failed to fetch"))).toBeNull();
+    expect(statusFromError(new Error("The operation timed out"))).toBeNull();
+    // A TimeoutError from AbortSignal.timeout has no status code.
+    expect(statusFromError(new DOMException("timeout", "TimeoutError"))).toBeNull();
+  });
+
+  it("returns null for non-Error values", () => {
+    expect(statusFromError("503")).toBeNull();
+    expect(statusFromError(null)).toBeNull();
+    expect(statusFromError(undefined)).toBeNull();
+  });
+
+  it("ignores out-of-range 3-digit numbers", () => {
+    expect(statusFromError(new Error("loaded 800 rows"))).toBeNull();
+  });
+});
+
+describe("isRetryableError", () => {
+  it("retries network/timeout errors (no status)", () => {
+    expect(isRetryableError(new Error("Failed to fetch"))).toBe(true);
+    expect(isRetryableError(new DOMException("timeout", "TimeoutError"))).toBe(true);
+  });
+
+  it("retries 5xx server errors", () => {
+    expect(isRetryableError(new Error("heatmap 500"))).toBe(true);
+    expect(isRetryableError(new Error("heatmap 503"))).toBe(true);
+  });
+
+  it("does NOT retry 4xx client errors — they won't recover", () => {
+    expect(isRetryableError(new Error("clusters 400"))).toBe(false);
+    expect(isRetryableError(new Error("clusters 404"))).toBe(false);
+    expect(isRetryableError(new Error("stats 422"))).toBe(false);
+  });
+});
+
+describe("shouldRetry", () => {
+  it("keeps retrying transient errors until the cap", () => {
+    expect(shouldRetry(0, new Error("heatmap 503"))).toBe(true);
+    expect(shouldRetry(MAX_QUERY_RETRIES - 1, new Error("heatmap 503"))).toBe(true);
+    expect(shouldRetry(MAX_QUERY_RETRIES, new Error("heatmap 503"))).toBe(false);
+  });
+
+  it("never retries a 4xx, even on the first failure", () => {
+    expect(shouldRetry(0, new Error("stats 422"))).toBe(false);
+  });
+});
+
+describe("retryBackoff", () => {
+  it("grows exponentially from ~1s", () => {
+    // Strip jitter (< 250ms) by flooring to the base.
+    expect(Math.floor(retryBackoff(0) / 1000)).toBe(1); // ~1s
+    expect(Math.floor(retryBackoff(1) / 1000)).toBe(2); // ~2s
+    expect(Math.floor(retryBackoff(2) / 1000)).toBe(4); // ~4s
+  });
+
+  it("caps at 15s so a long outage doesn't back off forever", () => {
+    expect(retryBackoff(20)).toBeLessThanOrEqual(15_000 + 250);
+    expect(retryBackoff(20)).toBeGreaterThanOrEqual(15_000);
+  });
+});

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,5 +1,54 @@
 import { QueryClient } from "@tanstack/react-query";
 
+// Max attempts AFTER the initial request (so up to 4 total tries). Chosen to
+// ride out the couple-of-seconds dropouts you get on flaky cellular / wifi
+// handoffs without hammering the server when it's genuinely down.
+export const MAX_QUERY_RETRIES = 3;
+
+/**
+ * Pulls a trailing HTTP status out of our fetch errors. The data hooks throw
+ * `new Error("heatmap 503")` / `new Error("dashboard batch 500")`, so the code
+ * is the last 3-digit token in the message. Returns null when there's no
+ * recognizable status — a network drop, a timeout (AbortSignal.timeout throws a
+ * TimeoutError with no code), or an aborted request — which we treat as
+ * transient and therefore retryable.
+ */
+export function statusFromError(error: unknown): number | null {
+  if (!(error instanceof Error)) return null;
+  const match = error.message.match(/\b(\d{3})\b/);
+  if (!match) return null;
+  const code = Number(match[1]);
+  return code >= 100 && code < 600 ? code : null;
+}
+
+/**
+ * A 4xx won't succeed by trying again (bad filter, not found, unauthorized) —
+ * retrying just delays the error state the user needs to see. Only retry the
+ * things that plausibly recover on their own: network errors, timeouts, and
+ * 5xx server hiccups (and anything without a status, which is usually a dropped
+ * connection).
+ */
+export function isRetryableError(error: unknown): boolean {
+  const status = statusFromError(error);
+  if (status == null) return true;
+  return status >= 500;
+}
+
+export function shouldRetry(failureCount: number, error: unknown): boolean {
+  return failureCount < MAX_QUERY_RETRIES && isRetryableError(error);
+}
+
+/**
+ * Exponential backoff with a little jitter, capped at 15s. Spacing the retries
+ * out (~1s, ~2s, ~4s) gives a flaky signal time to actually come back and
+ * avoids a thundering-herd retry storm when the API is briefly overloaded.
+ * attemptIndex is 0-based for the first retry.
+ */
+export function retryBackoff(attemptIndex: number): number {
+  const base = Math.min(1000 * 2 ** attemptIndex, 15_000);
+  return base + Math.random() * 250;
+}
+
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -7,7 +56,12 @@ export const queryClient = new QueryClient({
       // 24h, matched to the offline-persistence maxAge in queryPersistence.ts —
       // a query must stay in-cache to keep being written to the persisted snapshot.
       gcTime: 24 * 60 * 60 * 1000,
-      retry: 1,
+      // Ride out transient network blips (flaky cellular) instead of failing to
+      // a blank panel after a single dropped request. Bails immediately on 4xx,
+      // which won't recover on retry. Panels still show their own "Couldn't
+      // load — Retry" state once these attempts are exhausted.
+      retry: shouldRetry,
+      retryDelay: retryBackoff,
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
## Why

Follow-up to a real prod scare: on flaky cellular signal, panels showed a silent blank / premature error because **every react-query fetch inherited `retry: 1` with no delay**. One dropped request on a weak signal → one immediate retry → give up. The backend was healthy the whole time.

The app already has good explicit error UI (map heatmap "Couldn't load" + Retry, dashboard "Unable to load" + Retry, correlation/stats error states). The missing piece was the **recovery policy** that keeps a transient blip from reaching those states in the first place.

## What

Centralized in `queryClient.ts` (so it applies to **every** panel — map, dashboard, stats, correlation — via the shared default):

- **Up to 3 retries** (4 total attempts) with **exponential backoff + jitter** (~1s / 2s / 4s, capped at 15s) — rides out multi-second signal dropouts and avoids a retry storm.
- **Bails immediately on 4xx** (bad filter, 404, 422) — those won't recover on retry, so the user still sees the real error fast.
- Network errors / timeouts (no status) and 5xx are treated as retryable.

Retry/backoff logic is extracted into pure, exported helpers (`statusFromError`, `isRetryableError`, `shouldRetry`, `retryBackoff`) and unit-tested.

## Testing
- New `queryClient.test.ts`: 11 tests covering status parsing, 4xx-vs-5xx/network retry policy, retry cap, and backoff growth/cap.
- Full frontend suite green (95 files / 691 tests).
- typecheck + eslint clean.

## Not in scope
Opt-in map overlay layers (clusters/intersections) still render nothing on their own fetch error — they benefit from the retry bump but lack an explicit error card. Noted as a low-priority follow-up.