### PR TITLE
fix(pipeline): stop ETL scheduler container crash-looping at startup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -361,6 +361,31 @@ jobs:
           echo "Checking tunnel..."
           docker compose -f docker-compose.prod.yml ps tunnel --format '{{.State}}' | grep -q running && echo "Tunnel is running" || { echo "Tunnel not running:"; docker compose -f docker-compose.prod.yml logs --tail=20 tunnel; exit 1; }
 
+      - name: Verify pipeline container is stable (not crash-looping)
+        # A pipeline container that dies at startup restarts forever and is
+        # only "running" a few seconds per minute — every scheduled ETL, backup
+        # and vacuum silently stops while `up -d` still reports success. This
+        # went unnoticed for weeks (2026-07-13 incident, 257 restarts) because
+        # nothing checked the container after start and the failure alert only
+        # ships backend logs. Require zero restarts AND a running state, and
+        # dump the pipeline's own logs when it fails.
+        env:
+          CLOUDFLARED_TOKEN: ${{ secrets.CLOUDFLARED_TOKEN }}
+        run: |
+          CID=$(docker compose -f docker-compose.prod.yml -f docker-compose.pipeline.yml ps -aq pipeline)
+          if [ -z "$CID" ]; then
+            echo "Pipeline container not found"; exit 1
+          fi
+          # The container has been up since the `up -d` step several minutes
+          # ago — a healthy scheduler has zero restarts by now.
+          STATE=$(docker inspect "$CID" --format '{{.State.Status}} restarts={{.RestartCount}}')
+          echo "Pipeline container: $STATE"
+          if [ "$(docker inspect "$CID" --format '{{.State.Status}}{{.RestartCount}}')" != "running0" ]; then
+            echo "Pipeline container is not stably running — recent logs:"
+            docker logs --tail=60 "$CID" 2>&1 || true
+            exit 1
+          fi
+
       - name: Verify pipeline can write backups
         # Scheduled pg_dump writes to the /backups bind mount as the `app`
         # user; catch a permissions regression at deploy time instead of at
@@ -371,7 +396,9 @@ jobs:
           docker compose -f docker-compose.prod.yml -f docker-compose.pipeline.yml \
             exec -T pipeline sh -c 'touch /backups/.write-test && rm /backups/.write-test' \
             && echo "Backup directory is writable" \
-            || { echo "Pipeline cannot write to /backups — backups would fail silently"; exit 1; }
+            || { echo "Pipeline cannot write to /backups — backups would fail silently"; \
+                 docker compose -f docker-compose.prod.yml -f docker-compose.pipeline.yml logs --tail=60 pipeline || true; \
+                 exit 1; }
 
       - name: Record last successfully deployed SHA
         # Read by check-backfill on the NEXT deploy so it diffs against the

--- a/backend/deploy/README.md
+++ b/backend/deploy/README.md
@@ -24,10 +24,25 @@ schedule:
   `etl.run_all` path.
 
 **Operator action still required on LXC 100** (cannot be verified from
-this repo): confirm the old unit is inert and remove it —
+this repo) — **ORDER MATTERS**. The 2026-07-13 incident showed the compose
+pipeline container had been crash-looping for weeks while a host-side
+runner (systemd/cron, firing 02:00 UTC) was the ONLY thing actually
+loading data. Disabling the host runner before the container is verified
+healthy would stop all ETL.
 
 ```bash
-systemctl status calsight-etl-scheduler   # expect: not-found / inactive
+# 1. FIRST verify the compose scheduler is genuinely alive:
+docker ps --filter name=pipeline          # expect: Up (not Restarting)
+docker inspect calsight-pipeline-1 --format '{{.State.Status}} restarts={{.RestartCount}}'
+docker logs --tail 30 calsight-pipeline-1 # expect the "Schedules:" banner, no traceback
+
+# 2. Identify what actually fires the 02:00 UTC nightly (issue #370):
+systemctl cat calsight-etl-scheduler 2>/dev/null || echo "no such unit"
+crontab -l | grep -i -e etl -e calsight
+
+# 3. ONLY after step 1 shows a stable scheduler AND at least one
+#    container-scheduled run has landed in etl_runs (daily fires 11:00 UTC),
+#    retire the host runner:
 systemctl disable --now calsight-etl-scheduler 2>/dev/null || true
 rm -f /etc/systemd/system/calsight-etl-scheduler.service && systemctl daemon-reload
 crontab -l | grep -v etl | crontab -      # drop any leftover ETL cron line

--- a/backend/etl/pipeline.py
+++ b/backend/etl/pipeline.py
@@ -276,6 +276,80 @@ def _job_listener(event):
 
 
 # ---------------------------------------------------------------------------
+# Scheduler construction
+# ---------------------------------------------------------------------------
+
+def build_scheduler(no_backup: bool = False) -> BlockingScheduler:
+    """Create the scheduler with all cron jobs registered and log the plan.
+
+    Kept separate from main() so tests can exercise the full startup path
+    without blocking: this exact code crash-looped the pipeline container in
+    production for weeks (2026-07 incident) because pending APScheduler jobs
+    have no `next_run_time` attribute until the scheduler starts, and nothing
+    in CI ever ran it.
+    """
+    scheduler = BlockingScheduler()
+    scheduler.add_listener(_job_listener, EVENT_JOB_EXECUTED | EVENT_JOB_ERROR)
+
+    # Daily crash pipeline
+    scheduler.add_job(
+        run_daily_pipeline,
+        CronTrigger.from_crontab(SCHEDULES["daily_crashes"]["cron"], timezone=ETL_TIMEZONE),
+        id="daily_crashes",
+        replace_existing=True,
+        misfire_grace_time=3600,
+    )
+
+    # Weekly full refresh
+    scheduler.add_job(
+        run_weekly_pipeline,
+        CronTrigger.from_crontab(SCHEDULES["weekly_full"]["cron"], timezone=ETL_TIMEZONE),
+        id="weekly_full",
+        replace_existing=True,
+        misfire_grace_time=3600,
+    )
+
+    # Database maintenance
+    scheduler.add_job(
+        lambda: run_pipeline(
+            build_default_registry(), triggered_by="schedule", only=["vacuum"]
+        ),
+        CronTrigger.from_crontab(SCHEDULES["maintenance"]["cron"], timezone=ETL_TIMEZONE),
+        id="maintenance",
+        replace_existing=True,
+    )
+
+    # Backup
+    if not no_backup:
+        scheduler.add_job(
+            run_backup,
+            CronTrigger.from_crontab(SCHEDULES["backup"]["cron"], timezone=ETL_TIMEZONE),
+            id="backup",
+            replace_existing=True,
+        )
+
+    logger.info("=" * 60)
+    logger.info("  CalSight Automated Data Pipeline — Started")
+    logger.info("=" * 60)
+    logger.info("Schedules:")
+    for name, config in SCHEDULES.items():
+        if name == "backup" and no_backup:
+            continue
+        job = scheduler.get_job(name)
+        # Jobs are "pending" until the scheduler starts and have no
+        # next_run_time attribute yet — attribute access here raised
+        # AttributeError and killed the container before start().
+        next_run = getattr(job, "next_run_time", None) if job else None
+        logger.info(
+            "  %-20s  cron=%-15s  next=%s",
+            name, config["cron"], next_run or "(computed at scheduler start)",
+        )
+    logger.info("=" * 60)
+
+    return scheduler
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -322,57 +396,7 @@ def main() -> int:
         return 1
 
     # --- Start the scheduler ---
-    scheduler = BlockingScheduler()
-    scheduler.add_listener(_job_listener, EVENT_JOB_EXECUTED | EVENT_JOB_ERROR)
-
-    # Daily crash pipeline
-    scheduler.add_job(
-        run_daily_pipeline,
-        CronTrigger.from_crontab(SCHEDULES["daily_crashes"]["cron"], timezone=ETL_TIMEZONE),
-        id="daily_crashes",
-        replace_existing=True,
-        misfire_grace_time=3600,
-    )
-
-    # Weekly full refresh
-    scheduler.add_job(
-        run_weekly_pipeline,
-        CronTrigger.from_crontab(SCHEDULES["weekly_full"]["cron"], timezone=ETL_TIMEZONE),
-        id="weekly_full",
-        replace_existing=True,
-        misfire_grace_time=3600,
-    )
-
-    # Database maintenance
-    scheduler.add_job(
-        lambda: run_pipeline(
-            build_default_registry(), triggered_by="schedule", only=["vacuum"]
-        ),
-        CronTrigger.from_crontab(SCHEDULES["maintenance"]["cron"], timezone=ETL_TIMEZONE),
-        id="maintenance",
-        replace_existing=True,
-    )
-
-    # Backup
-    if not args.no_backup:
-        scheduler.add_job(
-            run_backup,
-            CronTrigger.from_crontab(SCHEDULES["backup"]["cron"], timezone=ETL_TIMEZONE),
-            id="backup",
-            replace_existing=True,
-        )
-
-    logger.info("=" * 60)
-    logger.info("  CalSight Automated Data Pipeline — Started")
-    logger.info("=" * 60)
-    logger.info("Schedules:")
-    for name, config in SCHEDULES.items():
-        if name == "backup" and args.no_backup:
-            continue
-        job = scheduler.get_job(name)
-        next_run = job.next_run_time if job else "not scheduled"
-        logger.info("  %-20s  cron=%-15s  next=%s", name, config["cron"], next_run)
-    logger.info("=" * 60)
+    scheduler = build_scheduler(no_backup=args.no_backup)
 
     try:
         scheduler.start()

--- a/backend/tests/test_pipeline_scheduler.py
+++ b/backend/tests/test_pipeline_scheduler.py
@@ -1,0 +1,33 @@
+"""Regression: the scheduler must survive its own startup path.
+
+`python -m etl.pipeline` crash-looped in production for weeks (257 restarts,
+2026-07 incident) because the schedule-summary log accessed
+`job.next_run_time` on jobs that were still pending — APScheduler only sets
+that attribute once the scheduler starts, so attribute access raised
+AttributeError before start() was ever reached. CI stayed green the whole
+time because nothing exercised scheduler construction. These tests run the
+exact code path the container runs at boot (minus the blocking start()).
+"""
+
+import etl.pipeline as pipeline
+
+
+def test_build_scheduler_registers_all_jobs_without_raising():
+    scheduler = pipeline.build_scheduler()
+    ids = {job.id for job in scheduler.get_jobs()}
+    assert ids == {"daily_crashes", "weekly_full", "maintenance", "backup"}
+    assert not scheduler.running
+
+
+def test_build_scheduler_no_backup_skips_backup_job():
+    scheduler = pipeline.build_scheduler(no_backup=True)
+    ids = {job.id for job in scheduler.get_jobs()}
+    assert ids == {"daily_crashes", "weekly_full", "maintenance"}
+
+
+def test_schedule_crons_parse_and_match_registered_jobs():
+    # Every configured schedule (except backup, which has no jobs entry)
+    # must correspond to a registered scheduler job.
+    scheduler = pipeline.build_scheduler()
+    for name in pipeline.SCHEDULES:
+        assert scheduler.get_job(name) is not None, f"schedule {name} not registered"


### PR DESCRIPTION
## What does this PR do?

**Root-causes and fixes tonight's deploy failures (run 29220021298 + rerun) and a much older silent outage.**

### The bug
`python -m etl.pipeline` crashes at boot, before `scheduler.start()`:

```
AttributeError: 'Job' object has no attribute 'next_run_time'   (pipeline.py:369)
```

APScheduler jobs added before the scheduler starts are *pending* and don't have `next_run_time` yet; the schedule-summary log accessed it directly. The pipeline container has been restart-looping — **257 restarts** as of tonight's diagnostics run — and its crons (daily 11:00 UTC, weekly Sun 09:00, vacuum 15:00, backup 07:00) never fired. Prod ETL survived only because the host-side 02:00 UTC runner (issue #370's "legacy" scheduler) is still doing all the work.

Nobody noticed because:
- CI never exercises scheduler construction (import-only coverage)
- the deploy's backup-writability `exec` races the restart backoff — a crash-looping container is alive a few seconds per minute, so the check *usually* passed by luck (it lost twice tonight, which rolled back #372's deploy)
- the deploy failure alert only ships **backend** logs

### The fix
- `build_scheduler()` extracted from `main()`; `next_run_time` read via `getattr` with a clear "(computed at scheduler start)" fallback. Regression tests execute the exact boot path — verified they fail (3 failures) against the old code.
- **Deploy hardening:** new "Verify pipeline container is stable" step fails the deploy unless the container is `running` with **0 restarts**, and dumps the pipeline's own logs; the backup-writability check now dumps pipeline logs on failure too.
- **backend/deploy/README.md:** the #370 operator cleanup is reordered — verify the container scheduler is alive **before** retiring the host-side runner (following the previous instructions today would have stopped all ETL).

## Verification
- `pytest -m "not integration"`: **709 passed** (incl. 3 new regression tests); `ruff` clean
- Reverting the one-line fix makes the new tests fail with the exact production traceback

## Dependencies
None.

## How to test
- [ ] `cd backend && pytest tests/test_pipeline_scheduler.py -q`
- [ ] After deploy: `gh workflow run pipeline-diag.yml` → container `running`, restarts=0, log shows the "Schedules:" banner