### PR TITLE
feat(observability): initialize Sentry in the ETL scheduler process

### DIFF
--- a/backend/etl/pipeline.py
+++ b/backend/etl/pipeline.py
@@ -46,6 +46,36 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _init_sentry() -> None:
+    """Sentry for the scheduler process (no-op unless SENTRY_DSN is set).
+
+    The API initializes Sentry in app.main, but this process never imports
+    it — so the 2026-07 startup crash-loop (an AttributeError before
+    scheduler.start(), weeks of restarts) produced zero Sentry events.
+    Mirrors app.main's config: send_default_pii stays False.
+    """
+    try:
+        from app.settings import settings
+
+        if not settings.sentry_dsn:
+            return
+        import sentry_sdk
+
+        sentry_sdk.init(
+            dsn=settings.sentry_dsn,
+            environment=settings.sentry_environment,
+            traces_sample_rate=settings.sentry_traces_sample_rate,
+            send_default_pii=False,
+        )
+        logger.info(
+            "Sentry error monitoring enabled (environment=%s)",
+            settings.sentry_environment,
+        )
+    except Exception as exc:
+        # Monitoring must never stop the scheduler from starting.
+        logger.warning("Sentry init failed (continuing without it): %s", exc)
+
+
 # ---------------------------------------------------------------------------
 # Schedule Configuration
 # ---------------------------------------------------------------------------
@@ -360,6 +390,8 @@ def build_scheduler(no_backup: bool = False) -> BlockingScheduler:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    _init_sentry()
+
     parser = argparse.ArgumentParser(description="CalSight Automated Data Pipeline")
     parser.add_argument(
         "--no-backup",

--- a/backend/tests/test_pipeline_scheduler.py
+++ b/backend/tests/test_pipeline_scheduler.py
@@ -51,3 +51,14 @@ def test_weekly_runs_sunday_and_daily_skips_sunday():
     )
     next_daily = daily.get_next_fire_time(None, after_sat)
     assert next_daily == datetime(2026, 7, 20, 11, 0, tzinfo=timezone.utc)  # Monday
+
+
+def test_init_sentry_never_raises(monkeypatch):
+    import sys
+
+    # Monitoring must not stop the scheduler: no DSN → early return; a
+    # broken settings import → warning, not a crash.
+    pipeline._init_sentry()
+
+    monkeypatch.setitem(sys.modules, "app.settings", None)
+    pipeline._init_sentry()  # import failure path — must be swallowed


### PR DESCRIPTION
## What does this PR do?

Closes the last observability gap from the 2026-07-13 incident: the scheduler crash-looped for **weeks** with zero Sentry events, because `sentry_sdk.init` only lives in `app.main` and the pipeline process never imports it.

- `main()` now calls a guarded `_init_sentry()` first thing: mirrors the API's config (env, traces rate, `send_default_pii=False`), no-op without `SENTRY_DSN`, and any init failure logs a warning instead of stopping the scheduler.
- With this, an unhandled exception that kills the scheduler process is captured via the SDK's excepthook — the exact failure mode of the incident.

**Operator note (the other half):** `send_heartbeat` is already wired after every scheduled run — a dead-man's-switch that would have caught this in a day — but it's a no-op until `HEARTBEAT_URL` is set in prod `.env` (pending chore from June, now high-priority).

## Verification
- `pytest tests/test_pipeline_scheduler.py`: 5 passed (new test pins that `_init_sentry` never raises, with and without importable settings); `ruff` clean

## Dependencies
None (builds on #374).

## How to test
- [ ] `cd backend && pytest tests/test_pipeline_scheduler.py -q`
- [ ] After deploy with SENTRY_DSN set: pipeline log shows "Sentry error monitoring enabled"