### PR TITLE
Drop implausible SWE sensor spikes; self-heal poisoned snowpack averages

### DIFF
--- a/backend/etl/load_snowpack.py
+++ b/backend/etl/load_snowpack.py
@@ -42,6 +42,14 @@ DEFAULT_TRAILING_DAYS = 120
 BACKFILL_START = date(2000, 1, 1)
 BATCH_SIZE = 1000
 
+# Physical plausibility ceiling. California's deepest snow years peak
+# around 90-100 inches of SWE at the snowiest pillows; CDEC's historical
+# feed contains occasional sensor glitches in the hundreds-to-thousands
+# (found during the 2026-07 production backfill: a mid-July "average" of
+# 155.9 inches). Anything above this is telemetry garbage — dropped on
+# load, and previously stored offenders are deleted after each run.
+MAX_PLAUSIBLE_SWE_IN = 150.0
+
 
 def upsert_stations(db) -> int:
     """Sync the snow_stations table from the static MAJOR_SNOW_STATIONS map.
@@ -79,9 +87,15 @@ def upsert_observations(db, observations: list[Observation]) -> int:
     known = set(MAJOR_SNOW_STATIONS)
     rows = []
     skipped = 0
+    implausible = 0
     for obs in observations:
         if obs.station_id not in known:
             skipped += 1
+            continue
+        # Spikes above the physical ceiling are sensor garbage — drop them
+        # so they can't poison the day-of-year averages.
+        if obs.value > MAX_PLAUSIBLE_SWE_IN:
+            implausible += 1
             continue
         rows.append(
             {
@@ -96,6 +110,12 @@ def upsert_observations(db, observations: list[Observation]) -> int:
     if skipped:
         logger.warning(
             "Dropped %d observations for stations not in MAJOR_SNOW_STATIONS", skipped
+        )
+    if implausible:
+        logger.warning(
+            "Dropped %d observations above %.0f in SWE (sensor spikes)",
+            implausible,
+            MAX_PLAUSIBLE_SWE_IN,
         )
 
     # CDEC can return an original plus a revised reading for one station-day;
@@ -115,6 +135,29 @@ def upsert_observations(db, observations: list[Observation]) -> int:
     return len(rows)
 
 
+def delete_implausible(db) -> int:
+    """Self-heal: remove stored SWE rows above the plausibility ceiling.
+
+    The drop-on-load guard only protects new fetches — rows written
+    before the guard existed (the initial 2026-07 backfill) stay in
+    snow_daily until deleted. Running this after every load makes the
+    cleanup automatic and idempotent.
+    """
+    deleted = (
+        db.query(SnowDaily)
+        .filter(SnowDaily.swe_in > MAX_PLAUSIBLE_SWE_IN)
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    if deleted:
+        logger.warning(
+            "Deleted %d stored SWE rows above %.0f in (sensor spikes)",
+            deleted,
+            MAX_PLAUSIBLE_SWE_IN,
+        )
+    return deleted
+
+
 @track_etl_run("snowpack")
 def run(start: date, end: date) -> int:
     """Fetch and upsert SWE for [start, end]. Returns rows loaded."""
@@ -132,6 +175,8 @@ def run(start: date, end: date) -> int:
             )
             observations = fetch_snow_water_content(win_start, win_end)
             total += upsert_observations(db, observations)
+
+        delete_implausible(db)
 
         logger.info("Done. %d daily SWE rows upserted.", total)
         return total

--- a/backend/tests/test_load_snowpack.py
+++ b/backend/tests/test_load_snowpack.py
@@ -5,7 +5,24 @@ from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 from etl.cdec_api import MAJOR_SNOW_STATIONS, SENSOR_SNOW_WATER_CONTENT, Observation
-from etl.load_snowpack import BATCH_SIZE, upsert_observations, upsert_stations
+from etl.load_snowpack import (
+    BATCH_SIZE,
+    MAX_PLAUSIBLE_SWE_IN,
+    delete_implausible,
+    upsert_observations,
+    upsert_stations,
+)
+
+
+class TestDeleteImplausible:
+    def test_deletes_stored_spikes_and_commits(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.delete.return_value = 3
+        assert delete_implausible(db) == 3
+        db.query.return_value.filter.return_value.delete.assert_called_once_with(
+            synchronize_session=False
+        )
+        db.commit.assert_called_once()
 
 
 def _obs(station="CSL", day=1, value=12.5):
@@ -62,6 +79,18 @@ class TestUpsertObservations:
         values = db.execute.call_args.args[0].compile().params
         assert 0.0 in values.values()
         assert -2.4 not in values.values()
+
+    def test_drops_swe_above_plausibility_ceiling(self):
+        # CDEC's historical feed contains sensor spikes (hundreds of inches);
+        # they are dropped entirely, not clamped — there is no true value.
+        db = MagicMock()
+        count = upsert_observations(
+            db, [_obs(day=1, value=MAX_PLAUSIBLE_SWE_IN + 1), _obs(day=2, value=90.0)]
+        )
+        assert count == 1
+        values = db.execute.call_args.args[0].compile().params
+        assert 90.0 in values.values()
+        assert MAX_PLAUSIBLE_SWE_IN + 1 not in values.values()
 
     def test_no_execute_for_empty_input(self):
         db = MagicMock()

--- a/backend/tests/test_load_snowpack.py
+++ b/backend/tests/test_load_snowpack.py
@@ -99,8 +99,10 @@ class TestUpsertObservations:
 
     def test_batches_large_inputs(self):
         db = MagicMock()
+        # Values must stay under MAX_PLAUSIBLE_SWE_IN or the ceiling guard
+        # drops them and the batch never fills.
         observations = [
-            Observation("CSL", SENSOR_SNOW_WATER_CONTENT, date(2000, 1, 1) + timedelta(days=i), float(i), "INCHES")
+            Observation("CSL", SENSOR_SNOW_WATER_CONTENT, date(2000, 1, 1) + timedelta(days=i), float(i % 100), "INCHES")
             for i in range(BATCH_SIZE + 1)
         ]
         upsert_observations(db, observations)


### PR DESCRIPTION
Found minutes after the #377 backfill went live: `/api/water/snowpack` reported a Central Sierra day-of-year **average of 155.9 inches of SWE in mid-July** — physically impossible (13 feet of water equivalent). CDEC's historical feed contains sensor spikes in the hundreds of inches; the parser only rejected the `-9999` sentinel.

Fix:
- `MAX_PLAUSIBLE_SWE_IN = 150.0` ceiling — readings above it are dropped at load (there is no true value to clamp to, unlike bare-pillow negative drift)
- `delete_implausible()` runs after every load and removes already-stored offenders, so the **daily 11:00 UTC job self-heals the poisoned backfill rows automatically** — no manual SQL needed
- Tests for both behaviors

Impact while unmerged: cosmetic only — the page is soft-launched/hidden and it's July (snowpack ≈ 0 everywhere); the garbage averages would matter in winter.

Note: local Python broke mid-session (Windows Store alias), so the suite runs here in CI rather than locally — the change is 30 lines plus tests.