### PR TITLE
Pre-launch tidy: SW error callback, useStagedFilters tests, rotation runbook, healthcheck start_period

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+      # Cold start (imports + DB pool warmup) can exceed one interval;
+      # don't count those probes as failures.
+      start_period: 30s
 
   tunnel:
     image: cloudflare/cloudflared:2026.6.1

--- a/docs/OPERATOR_SETUP.md
+++ b/docs/OPERATOR_SETUP.md
@@ -68,6 +68,23 @@ Confirm how backups actually run on LXC 100:
 
 ---
 
+## 7. Secrets rotation runbook
+
+Rotate on a schedule (yearly is fine for a solo project) or immediately on any suspected leak. Order matters: create the new secret first, deploy it, verify, then revoke the old one — never revoke first.
+
+| Secret | Where it lives | Rotate by |
+|--------|----------------|-----------|
+| `ETL_API_KEY` (admin/run-etl auth) | GitHub repo secret + backend `.env` on LXC 100 | Generate a new random value (`openssl rand -hex 32`), update backend `.env`, `docker compose up -d backend`, then update the GitHub secret. Old key dies with the restart. |
+| Postgres `calsight` / `calsight_api_ro` passwords | LXC 100 Postgres + backend `.env` (`DATABASE_URL`, `ETL_DATABASE_URL`) | `ALTER USER … WITH PASSWORD …` in psql, update both URLs in `.env`, restart backend + pipeline containers. Do the RO role first (read-only traffic degrades gracefully), the writer second. |
+| Groq / OpenRouter / Cerebras / Gemini API keys | backend `.env` on LXC 100 | Create the new key in the provider console, swap in `.env`, restart backend, then delete the old key in the console. The multi-provider fallback keeps Ask AI alive if one provider's swap goes wrong. |
+| R2 access keys (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`) | LXC 100 `.env` | Cloudflare dashboard → R2 → Manage API tokens: create the new token, swap `.env`, run one manual `python -m etl.backup` to prove offsite upload works, then revoke the old token. |
+| `CLOUDFLARED_TOKEN` (tunnel) | VM 101 compose env | Cloudflare Zero Trust → refresh the tunnel token, update env, `docker compose up -d tunnel`. Site goes unreachable if this is botched — do it while watching `curl https://calsight.org/api/health`. |
+| `SENTRY_DSN` / `VITE_SENTRY_DSN`, `ALERT_WEBHOOK_URL`, `HEARTBEAT_URL` | per the table below | Low-sensitivity (write-only endpoints): regenerate in the respective dashboard and swap. Losing one costs observability, not availability. |
+
+After any rotation, confirm: `/api/health` 200, a manual run-etl dispatch succeeds (proves `ETL_API_KEY` + DB creds), and the next nightly Discord alert arrives (proves webhook).
+
+---
+
 ## Quick env-var reference by host
 
 | Host | Vars |

--- a/frontend/src/hooks/useStagedFilters.test.ts
+++ b/frontend/src/hooks/useStagedFilters.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useStagedFilters, type StagedFilters } from "./useStagedFilters";
+
+const empty: StagedFilters = {
+  selectedYears: new Set(),
+  dateRange: null,
+  severities: new Set(),
+  causes: new Set(),
+  alcohol: false,
+  distracted: false,
+  pedestrian: false,
+  cyclist: false,
+  drug: false,
+  driverAge: null,
+  weather: new Set(),
+  lighting: new Set(),
+  collisionType: new Set(),
+  roadType: null,
+  hitRun: false,
+};
+
+describe("useStagedFilters", () => {
+  it("starts from the initial value with no filters active", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    expect(result.current.staged).toEqual(empty);
+    expect(result.current.hasAnyFilter).toBe(false);
+  });
+
+  it("toggles a year on and off", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    act(() => result.current.toggleYear(2022));
+    expect(result.current.staged.selectedYears).toEqual(new Set([2022]));
+    expect(result.current.hasAnyFilter).toBe(true);
+    act(() => result.current.toggleYear(2022));
+    expect(result.current.staged.selectedYears.size).toBe(0);
+  });
+
+  it("setAllYears clears the year selection (empty set = all years)", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    act(() => result.current.toggleYear(2019));
+    act(() => result.current.setAllYears());
+    expect(result.current.staged.selectedYears.size).toBe(0);
+  });
+
+  it("toggles severities and causes independently and clears each", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    act(() => result.current.toggleSeverity("Fatal"));
+    act(() => result.current.toggleCause("dui"));
+    expect(result.current.staged.severities).toEqual(new Set(["Fatal"]));
+    expect(result.current.staged.causes).toEqual(new Set(["dui"]));
+    act(() => result.current.clearSeverities());
+    expect(result.current.staged.severities.size).toBe(0);
+    expect(result.current.staged.causes.size).toBe(1);
+    act(() => result.current.clearCauses());
+    expect(result.current.staged.causes.size).toBe(0);
+  });
+
+  it("toggles involvement flags by key", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    act(() => result.current.toggleInvolvement("alcohol"));
+    expect(result.current.staged.alcohol).toBe(true);
+    expect(result.current.staged.pedestrian).toBe(false);
+    act(() => result.current.toggleInvolvement("alcohol"));
+    expect(result.current.staged.alcohol).toBe(false);
+  });
+
+  it("sets and clears a date range", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    act(() =>
+      result.current.setDateRange({ year: 2020, month: 1 }, { year: 2021, month: 6 }),
+    );
+    expect(result.current.staged.dateRange).toEqual({
+      start: { year: 2020, month: 1 },
+      end: { year: 2021, month: 6 },
+    });
+    act(() => result.current.setDateRange(null, null));
+    expect(result.current.staged.dateRange).toBeNull();
+  });
+
+  it("clearAll wipes every staged filter", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    act(() => {
+      result.current.toggleYear(2020);
+      result.current.toggleSeverity("Fatal");
+      result.current.toggleInvolvement("cyclist");
+      result.current.setRoadType("highway");
+      result.current.toggleHitRun();
+    });
+    expect(result.current.hasAnyFilter).toBe(true);
+    act(() => result.current.clearAll());
+    expect(result.current.staged).toEqual(empty);
+    expect(result.current.hasAnyFilter).toBe(false);
+  });
+
+  it("reset replaces staged state wholesale", () => {
+    const { result } = renderHook(() => useStagedFilters(empty));
+    const target = { ...empty, selectedYears: new Set([2018]), alcohol: true };
+    act(() => result.current.reset(target));
+    expect(result.current.staged).toEqual(target);
+  });
+
+  it("re-syncs when the initial value identity changes (applied filters updated elsewhere)", () => {
+    const first = { ...empty, selectedYears: new Set([2017]) };
+    const second = { ...empty, selectedYears: new Set([2023]) };
+    const { result, rerender } = renderHook(
+      ({ initial }) => useStagedFilters(initial),
+      { initialProps: { initial: first } },
+    );
+    // Local edits survive rerenders with the SAME initial object…
+    act(() => result.current.toggleSeverity("Fatal"));
+    rerender({ initial: first });
+    expect(result.current.staged.severities).toEqual(new Set(["Fatal"]));
+    // …but a NEW initial object replaces the staged state.
+    rerender({ initial: second });
+    expect(result.current.staged.selectedYears).toEqual(new Set([2023]));
+    expect(result.current.staged.severities.size).toBe(0);
+  });
+
+  describe("has2016Plus", () => {
+    it("is true with no year filters at all", () => {
+      const { result } = renderHook(() => useStagedFilters(empty));
+      expect(result.current.has2016Plus).toBe(true);
+    });
+
+    it("is false when only pre-2016 years are selected", () => {
+      const { result } = renderHook(() => useStagedFilters(empty));
+      act(() => result.current.toggleYear(2012));
+      expect(result.current.has2016Plus).toBe(false);
+      act(() => result.current.toggleYear(2019));
+      expect(result.current.has2016Plus).toBe(true);
+    });
+
+    it("uses the date-range end year when a range is set", () => {
+      const { result } = renderHook(() => useStagedFilters(empty));
+      act(() =>
+        result.current.setDateRange({ year: 2010, month: 1 }, { year: 2014, month: 12 }),
+      );
+      expect(result.current.has2016Plus).toBe(false);
+      // An open-ended range (no end) runs to the present → includes 2016+.
+      act(() => result.current.setDateRange({ year: 2010, month: 1 }, null));
+      expect(result.current.has2016Plus).toBe(true);
+    });
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,14 +2,22 @@ import './instrument' // must be first — initializes Sentry before app code
 
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { reactErrorHandler } from '@sentry/react'
+import { captureException, reactErrorHandler } from '@sentry/react'
 import { registerSW } from 'virtual:pwa-register'
 import '@fontsource-variable/public-sans'
 import '@fontsource-variable/inter'
 import App from './App'
 import './index.css'
 
-registerSW({ immediate: true })
+registerSW({
+  immediate: true,
+  // A failed registration means updates stop arriving silently — surface
+  // it. captureException is a no-op when Sentry isn't initialized.
+  onRegisterError(error: unknown) {
+    console.error('Service worker registration failed', error)
+    captureException(error)
+  },
+})
 
 // React 19 root-level error hooks route uncaught render errors to Sentry
 // (no-ops when Sentry is not initialized).


### PR DESCRIPTION
The tracker-reconciliation audit (2026-07-16) verified every unticked checkbox in the open MEGA issues against main: **~68% were already shipped**. This PR knocks out the small genuine survivors so three trackers can close:

- **#292** (last item): `registerSW` now has `onRegisterError` — a failed service-worker registration logs and reaches Sentry (no-op without DSN) instead of failing silently.
- **#303** (last named gap): `useStagedFilters` hook test suite — 12 cases covering toggles, clearAll/reset, the initial-identity resync effect, and the `has2016Plus` party-data gate (year sets, date-range end year, open-ended ranges).
- **#300** (last item): secrets-rotation runbook in `docs/OPERATOR_SETUP.md` — per-secret procedure (ETL_API_KEY, DB roles, LLM providers, R2, tunnel token, DSNs/webhooks), create-deploy-verify-revoke ordering, and post-rotation checks.
- Backend healthcheck gets `start_period: 30s` so cold-start probes don't count toward failure retries.

Deliberately skipped from the audit's suggestion list: a PrivacyPage retention *period* — the page already states the actual policy (indefinite retention, anonymous records, deletion-on-request path); promising a specific period nothing enforces would be worse than the current honest text.

After merge, #292, #300, and #303 can be closed (reconciliation report has ready-to-paste closing comments with evidence).

Frontend: 974 passed (12 new), lint clean, production build clean. Backend untouched.