### PR TITLE
Accessibility pass: keyboard navigation for all remaining chart types + page titles

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,7 +12,9 @@ const PAGE_TITLES: Record<string, string> = {
   "/stats": "Statistics Dashboard — CalSight",
   "/ask": "Ask AI — CalSight",
   "/about": "About — CalSight",
+  "/water": "Water — CalSight",
   "/privacy": "Privacy Policy — CalSight",
+  "/terms": "Terms of Service — CalSight",
   "/admin/etl": "ETL Admin — CalSight",
 };
 

--- a/frontend/src/components/charts/DualAxisLineChart.tsx
+++ b/frontend/src/components/charts/DualAxisLineChart.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { useChartAnimation } from "../../hooks/useChartAnimation";
 import { useTextScale } from "../../hooks/useTextScale";
 
@@ -54,6 +55,7 @@ export default function DualAxisLineChart({
 }: DualAxisLineChartProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const [svgWidth, setSvgWidth] = useState(400);
   const titleId = useId();
   const { progress } = useChartAnimation(svgRef);
@@ -73,7 +75,23 @@ export default function DualAxisLineChart({
 
   // Touch scrub: snap to the nearest data point on the x axis, mirroring
   // SimpleLineChart's touch handling.
-  const pointsRef = useRef<{ x: number }[]>([]);
+  const pointsRef = useRef<{ x: number; y: number }[]>([]);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the data
+  // points (crosshair + tooltip follow) and each point announces both series
+  // through the polite live region below the svg. Same convention as
+  // SimpleLineChart.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const p = pointsRef.current[next];
+    if (!rect || !p) return;
+    setHover({ idx: next, x: rect.left + p.x, y: rect.top + p.y });
+    const d = data[next];
+    setAnnounce(`${d.label}: ${primaryLabel} ${d.primary.toLocaleString()}, ${secondaryLabel} ${d.secondary.toLocaleString()}`);
+  }, [data, hover, primaryLabel, secondaryLabel]);
 
   const handleTouchScrub = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -150,6 +168,10 @@ export default function DualAxisLineChart({
         className="block"
         role="img"
         aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Dual-axis line chart. Use arrow keys to explore data points."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchMove={handleTouchScrub}
         onTouchEnd={() => setHover(null)}
       >
@@ -368,6 +390,8 @@ export default function DualAxisLineChart({
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && data[hover.idx] != null && renderTooltip?.(data[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused data point to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/SimpleDonutChart.tsx
+++ b/frontend/src/components/charts/SimpleDonutChart.tsx
@@ -1,5 +1,6 @@
 ﻿import { useState, useRef, useCallback, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { useChartAnimation } from "../../hooks/useChartAnimation";
 
 interface Segment {
@@ -45,6 +46,7 @@ export default function SimpleDonutChart({
 }: SimpleDonutChartProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const titleId = useId();
   const { progress } = useChartAnimation(svgRef);
 
@@ -53,6 +55,29 @@ export default function SimpleDonutChart({
   }, []);
 
   const segAnglesRef = useRef<{ start: number; end: number }[]>([]);
+  const segPosRef = useRef<{ x: number; y: number }[]>([]);
+  const segPctRef = useRef<number[]>([]);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the
+  // segments (tooltip follows), each announced through the polite live region
+  // below the svg; Enter/Space activates the same handler as click. Same
+  // convention as SimpleLineChart / SimpleBarChart.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    if ((e.key === "Enter" || e.key === " ") && hover !== null && data[hover.idx] && onSegmentClick) {
+      e.preventDefault();
+      onSegmentClick(data[hover.idx], hover.idx);
+      return;
+    }
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const p = segPosRef.current[next];
+    if (!rect || !p) return;
+    setHover({ idx: next, x: rect.left + p.x, y: rect.top + p.y });
+    const d = data[next];
+    setAnnounce(`${d.label}: ${d.value.toLocaleString()} (${segPctRef.current[next] ?? 0}%)`);
+  }, [data, hover, onSegmentClick]);
 
   const handleTouchScrub = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -126,10 +151,19 @@ export default function SimpleDonutChart({
   });
 
   const withPct = data.map((d) => ({ ...d, pct: Math.round((d.value / total) * 100) }));
+  // Mid-arc anchor for the keyboard-focus tooltip, at the ring's midline.
+  segPosRef.current = segments.map((seg) =>
+    polarToCartesian(cx, cy, (effectiveInner + effectiveOuter) / 2, seg.midAngle),
+  );
+  segPctRef.current = segments.map((seg) => seg.pct);
 
   return (
     <div className="w-full overflow-visible relative flex justify-center" style={{ height }}>
       <svg ref={svgRef} width={vw} height={height} className="block overflow-visible" role="img" aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Donut chart. Use arrow keys to explore segments."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={titleId}>{title}</title>}
         {segments.map((seg, i) => {
@@ -165,6 +199,8 @@ export default function SimpleDonutChart({
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && withPct[hover.idx] != null && renderTooltip?.(withPct[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused segment to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/SimpleLollipop.tsx
+++ b/frontend/src/components/charts/SimpleLollipop.tsx
@@ -1,5 +1,6 @@
 ﻿import { useState, useRef, useCallback, useEffect, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { useTextScale } from "../../hooks/useTextScale";
 
 interface LollipopItem {
@@ -37,6 +38,7 @@ export default function SimpleLollipop({
 }: SimpleLollipopProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const [svgWidth, setSvgWidth] = useState(300);
   const titleId = useId();
   const ts = useTextScale();
@@ -52,6 +54,29 @@ export default function SimpleLollipop({
   const handleMouseMove = useCallback((e: React.MouseEvent, idx: number) => {
     setHover({ idx, x: e.clientX, y: e.clientY });
   }, []);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the rows
+  // (tooltip follows), each announced through the polite live region below
+  // the svg; Enter/Space activates the same handler as click. Same convention
+  // as SimpleLineChart / SimpleBarChart.
+  const dotPosRef = useRef<{ x: number; y: number }[]>([]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    if ((e.key === "Enter" || e.key === " ") && hover !== null && data[hover.idx] && onItemClick) {
+      e.preventDefault();
+      onItemClick(data[hover.idx], hover.idx);
+      return;
+    }
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const p = dotPosRef.current[next];
+    if (!rect || !p) return;
+    setHover({ idx: next, x: rect.left + p.x, y: rect.top + p.y });
+    const d = data[next];
+    setAnnounce(`${d.label}: ${d.value.toLocaleString()}`);
+  }, [data, hover, onItemClick]);
 
   const handleTouchScrub = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -72,9 +97,18 @@ export default function SimpleLollipop({
   const rowH = Math.min(28, (height - 8) / data.length);
   const svgH = Math.max(height, data.length * rowH + 8);
 
+  dotPosRef.current = data.map((d, i) => ({
+    x: labelW + (maxVal > 0 ? (d.value / maxVal) * barArea : 0),
+    y: i * rowH + rowH / 2 + 4,
+  }));
+
   return (
     <div className="w-full overflow-visible relative" style={{ height: svgH }}>
       <svg ref={svgRef} width="100%" height={svgH} className="block overflow-visible" role="img" aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Lollipop chart. Use arrow keys to explore rows."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={titleId}>{title}</title>}
         {data.map((d, i) => {
@@ -151,6 +185,8 @@ export default function SimpleLollipop({
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && data[hover.idx] != null && renderTooltip?.(data[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused row to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/SimplePolarArea.tsx
+++ b/frontend/src/components/charts/SimplePolarArea.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { useDesignTokens } from "../../hooks/useDesignTokens";
 import { useTextScale } from "../../hooks/useTextScale";
 import { CHART_PALETTES, paletteColor } from "../../lib/theme/palettes";
@@ -21,6 +22,7 @@ interface SimplePolarAreaProps {
 export default function SimplePolarArea({ data, height = 220, renderTooltip, title }: SimplePolarAreaProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const titleId = useId();
   const tokens = useDesignTokens();
   const palette = tokens.chart.categorical.length > 0 ? tokens.chart.categorical : CHART_PALETTES.default;
@@ -29,6 +31,23 @@ export default function SimplePolarArea({ data, height = 220, renderTooltip, tit
   const handleMouseMove = useCallback((e: React.MouseEvent<SVGPathElement>, idx: number) => {
     setHover({ idx, x: e.clientX, y: e.clientY });
   }, []);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the
+  // slices (tooltip follows) and each slice is announced through the polite
+  // live region below the svg. Same convention as SimpleLineChart.
+  const slicePosRef = useRef<{ x: number; y: number }[]>([]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const p = slicePosRef.current[next];
+    if (!rect || !p) return;
+    setHover({ idx: next, x: rect.left + p.x, y: rect.top + p.y });
+    const d = data[next];
+    setAnnounce(`${d.label}: ${d.value.toLocaleString()}`);
+  }, [data, hover]);
 
   // Touch scrub: map the touch point's angle around the center to a slice,
   // mirroring the angular scrub in SimpleRadar.
@@ -57,9 +76,21 @@ export default function SimplePolarArea({ data, height = 220, renderTooltip, tit
   const maxR = cx - 12;
   const sliceAngle = (2 * Math.PI) / n;
 
+  // Mid-slice anchor for the keyboard-focus tooltip.
+  slicePosRef.current = data.map((d, i) => {
+    const r = maxVal > 0 ? (d.value / maxVal) * maxR : 0;
+    const midAngle = i * sliceAngle - Math.PI / 2 + sliceAngle / 2;
+    const anchorR = Math.max(r * 0.7, maxR * 0.3);
+    return { x: cx + anchorR * Math.cos(midAngle), y: cy + anchorR * Math.sin(midAngle) };
+  });
+
   return (
     <div className="w-full overflow-visible relative flex justify-center" style={{ height }}>
       <svg ref={svgRef} width={height} height={height} className="block" role="img" aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Polar area chart. Use arrow keys to explore slices."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchStart={handleTouchScrub} onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={titleId}>{title}</title>}
         {data.map((d, i) => {
@@ -117,6 +148,8 @@ export default function SimplePolarArea({ data, height = 220, renderTooltip, tit
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && data[hover.idx] != null && renderTooltip?.(data[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused slice to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/SimpleRadar.tsx
+++ b/frontend/src/components/charts/SimpleRadar.tsx
@@ -1,5 +1,6 @@
 ﻿import { useState, useRef, useCallback, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { useTextScale } from "../../hooks/useTextScale";
 
 interface RadarItem {
@@ -24,12 +25,30 @@ export default function SimpleRadar({
 }: SimpleRadarProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const titleId = useId();
   const ts = useTextScale();
 
   const handleMouseMove = useCallback((e: React.MouseEvent, idx: number) => {
     setHover({ idx, x: e.clientX, y: e.clientY });
   }, []);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the
+  // vertices (tooltip follows) and each is announced through the polite live
+  // region below the svg. Same convention as SimpleLineChart.
+  const pointsRef = useRef<{ x: number; y: number }[]>([]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const p = pointsRef.current[next];
+    if (!rect || !p) return;
+    setHover({ idx: next, x: rect.left + p.x, y: rect.top + p.y });
+    const d = data[next];
+    setAnnounce(`${d.label}: ${d.value.toLocaleString()}`);
+  }, [data, hover]);
 
   const handleTouchScrub = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -70,10 +89,15 @@ export default function SimpleRadar({
   });
 
   const polyPoints = points.map((p) => `${p.x},${p.y}`).join(" ");
+  pointsRef.current = points;
 
   return (
     <div className="w-full overflow-visible relative flex justify-center" style={{ height }}>
       <svg ref={svgRef} width={height} height={height} className="block" role="img" aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Radar chart. Use arrow keys to explore categories."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={titleId}>{title}</title>}
         {Array.from({ length: rings }).map((_, ring) => {
@@ -136,6 +160,8 @@ export default function SimpleRadar({
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && data[hover.idx] != null && renderTooltip?.(data[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused category to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/SimpleScatter.tsx
+++ b/frontend/src/components/charts/SimpleScatter.tsx
@@ -1,5 +1,6 @@
 ﻿import { useState, useRef, useCallback, useEffect, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { linearRegressionXY } from "../../lib/dashboard/stats";
 import { useDesignTokens } from "../../hooks/useDesignTokens";
 import { useTextScale } from "../../hooks/useTextScale";
@@ -40,6 +41,7 @@ export default function SimpleScatter({
 }: SimpleScatterProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const tokens = useDesignTokens();
   // Shared fallback: the canonical default chart palette (same as SimplePolarArea)
   const paletteColors = tokens.chart.categorical.length > 0 ? tokens.chart.categorical : CHART_PALETTES.default;
@@ -58,6 +60,23 @@ export default function SimpleScatter({
   const handleMouseMove = useCallback((e: React.MouseEvent, idx: number) => {
     setHover({ idx, x: e.clientX, y: e.clientY });
   }, []);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the data
+  // points (tooltip follows) and each point is announced through the polite
+  // live region below the svg. Same convention as SimpleLineChart.
+  const dotPosRef = useRef<{ x: number; y: number }[]>([]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const p = dotPosRef.current[next];
+    if (!rect || !p) return;
+    setHover({ idx: next, x: rect.left + p.x, y: rect.top + p.y });
+    const d = data[next];
+    setAnnounce(`${d.label}: ${xLabel} ${(d.x ?? d.value).toLocaleString()}, ${yLabel} ${(d.y ?? 0).toLocaleString()}`);
+  }, [data, hover, xLabel, yLabel]);
 
   const handleTouchScrub = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -98,6 +117,11 @@ export default function SimpleScatter({
   const xTicks = 4;
   const yTicks = 4;
 
+  dotPosRef.current = points.map((p) => ({
+    x: padding.left + (p.xVal / maxX) * chartW,
+    y: padding.top + chartH - (p.yVal / maxY) * chartH,
+  }));
+
   const scatterR2 = points.length >= 3 ? linearRegressionXY(points.map(p => ({ x: p.xVal, y: p.yVal }))).r2 : null;
 
   return (
@@ -108,6 +132,10 @@ export default function SimpleScatter({
         </span>
       )}
       <svg ref={svgRef} width="100%" height={height} className="block" role="img" aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Scatter plot. Use arrow keys to explore data points."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={titleId}>{title}</title>}
         {Array.from({ length: yTicks + 1 }).map((_, i) => {
@@ -204,6 +232,8 @@ export default function SimpleScatter({
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && data[hover.idx] != null && renderTooltip?.(data[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused data point to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/SimpleTreemap.tsx
+++ b/frontend/src/components/charts/SimpleTreemap.tsx
@@ -1,5 +1,6 @@
 ﻿import { useState, useRef, useEffect, useCallback, useId } from "react";
 import ChartTooltip from "./ChartTooltip";
+import { nextChartIndex } from "./chartKeyboardNav";
 import { useTextScale } from "../../hooks/useTextScale";
 import { textOnColor } from "./onColorText";
 
@@ -81,6 +82,7 @@ export default function SimpleTreemap({
 }: SimpleTreemapProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [hover, setHover] = useState<{ idx: number; x: number; y: number } | null>(null);
+  const [announce, setAnnounce] = useState("");
   const [svgWidth, setSvgWidth] = useState(300);
   const titleId = useId();
   const ts = useTextScale();
@@ -95,6 +97,23 @@ export default function SimpleTreemap({
   }, []);
 
   const rectsRef = useRef<{ x: number; y: number; w: number; h: number; idx: number }[]>([]);
+
+  // Keyboard access: the chart itself is focusable; arrow keys walk the tiles
+  // in data order (tooltip follows) and each tile is announced through the
+  // polite live region below the svg. Same convention as SimpleLineChart.
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<SVGSVGElement>) => {
+    const next = nextChartIndex(e.key, hover?.idx, data.length);
+    if (next === null) return;
+    e.preventDefault();
+    const rect = svgRef.current?.getBoundingClientRect();
+    const cell = rectsRef.current.find((r) => r.idx === next);
+    if (!rect || !cell) return;
+    setHover({ idx: next, x: rect.left + cell.x + cell.w / 2, y: rect.top + cell.y + cell.h / 2 });
+    const d = data[next];
+    const total = data.reduce((s, dd) => s + dd.value, 0);
+    const pct = total > 0 ? Math.round((d.value / total) * 100) : 0;
+    setAnnounce(`${d.label}: ${d.value.toLocaleString()} (${pct}%)`);
+  }, [data, hover]);
 
   const handleTouchScrub = useCallback((e: React.TouchEvent<SVGSVGElement>) => {
     const svg = svgRef.current;
@@ -147,6 +166,10 @@ export default function SimpleTreemap({
   return (
     <div className="w-full overflow-visible relative" style={{ height: effectiveH }}>
       <svg ref={svgRef} width="100%" height={effectiveH} className="block" role="img" aria-labelledby={title ? titleId : undefined}
+        aria-label={title ? undefined : "Treemap. Use arrow keys to explore tiles."}
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        onBlur={() => { setHover(null); setAnnounce(""); }}
         onTouchMove={handleTouchScrub} onTouchEnd={() => setHover(null)}>
         {title && <title id={titleId}>{title}</title>}
         {rects.map((r) => {
@@ -189,6 +212,8 @@ export default function SimpleTreemap({
       <ChartTooltip x={hover?.x ?? 0} y={hover?.y ?? 0} visible={hover !== null} containerRef={svgRef}>
         {hover !== null && data[hover.idx] && renderTooltip?.(data[hover.idx], hover.idx)}
       </ChartTooltip>
+      {/* Announces the keyboard-focused tile to screen readers */}
+      <div className="sr-only" role="status">{announce}</div>
     </div>
   );
 }

--- a/frontend/src/components/charts/chartKeyboardNav.ts
+++ b/frontend/src/components/charts/chartKeyboardNav.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared arrow-key stepping for keyboard-navigable charts.
+ *
+ * Mirrors the convention SimpleLineChart established: the chart's <svg> is
+ * focusable (tabIndex=0), arrow keys walk the data points (tooltip follows),
+ * Home/End jump to the first/last point, and each step is announced through a
+ * polite `role="status"` live region rendered next to the svg.
+ *
+ * Returns the next index to focus, or null when the key is not a navigation
+ * key (so callers can let other keys fall through untouched).
+ */
+export function nextChartIndex(
+  key: string,
+  current: number | null | undefined,
+  length: number,
+): number | null {
+  if (length <= 0) return null;
+  const cur = current ?? -1;
+  // ArrowDown/ArrowUp are accepted as aliases so vertical layouts
+  // (lollipops, stacked treemaps) and radial charts feel natural too.
+  if (key === "ArrowRight" || key === "ArrowDown") {
+    return cur === -1 ? 0 : Math.min(length - 1, cur + 1);
+  }
+  if (key === "ArrowLeft" || key === "ArrowUp") {
+    return cur === -1 ? length - 1 : Math.max(0, cur - 1);
+  }
+  if (key === "Home") return 0;
+  if (key === "End") return length - 1;
+  return null;
+}

--- a/frontend/src/components/charts/charts.keyboard.test.tsx
+++ b/frontend/src/components/charts/charts.keyboard.test.tsx
@@ -1,0 +1,230 @@
+import { type ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render as rtlRender, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CustomThemeProvider } from "../../context/CustomThemeContext";
+import { ThemeProvider } from "../../context/ThemeContext";
+import { nextChartIndex } from "./chartKeyboardNav";
+import DualAxisLineChart from "./DualAxisLineChart";
+import SimpleDonutChart from "./SimpleDonutChart";
+import SimpleLollipop from "./SimpleLollipop";
+import SimplePolarArea from "./SimplePolarArea";
+import SimpleRadar from "./SimpleRadar";
+import SimpleScatter from "./SimpleScatter";
+import SimpleTreemap from "./SimpleTreemap";
+
+const render = (ui: ReactNode) =>
+  rtlRender(
+    <ThemeProvider>
+      <CustomThemeProvider>{ui}</CustomThemeProvider>
+    </ThemeProvider>,
+  );
+
+// jsdom lacks these; charts read matchMedia (reduced-motion) and observe
+// their size/visibility on mount.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+class MockIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+  root = null;
+  rootMargin = "";
+  thresholds = [];
+}
+globalThis.IntersectionObserver =
+  MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+beforeEach(() => cleanup());
+
+describe("nextChartIndex", () => {
+  it("steps forward and backward with clamping", () => {
+    expect(nextChartIndex("ArrowRight", null, 3)).toBe(0);
+    expect(nextChartIndex("ArrowRight", 0, 3)).toBe(1);
+    expect(nextChartIndex("ArrowRight", 2, 3)).toBe(2);
+    expect(nextChartIndex("ArrowLeft", null, 3)).toBe(2);
+    expect(nextChartIndex("ArrowLeft", 1, 3)).toBe(0);
+    expect(nextChartIndex("ArrowLeft", 0, 3)).toBe(0);
+  });
+
+  it("treats ArrowDown/ArrowUp as aliases and supports Home/End", () => {
+    expect(nextChartIndex("ArrowDown", 0, 3)).toBe(1);
+    expect(nextChartIndex("ArrowUp", 1, 3)).toBe(0);
+    expect(nextChartIndex("Home", 2, 3)).toBe(0);
+    expect(nextChartIndex("End", 0, 3)).toBe(2);
+  });
+
+  it("ignores non-navigation keys and empty data", () => {
+    expect(nextChartIndex("Enter", 0, 3)).toBeNull();
+    expect(nextChartIndex("a", 0, 3)).toBeNull();
+    expect(nextChartIndex("ArrowRight", 0, 0)).toBeNull();
+  });
+});
+
+const items = [
+  { label: "Alpha", value: 10 },
+  { label: "Beta", value: 20 },
+  { label: "Gamma", value: 30 },
+];
+
+describe("chart keyboard accessibility (remaining chart types)", () => {
+  it("SimpleScatter walks points and announces x/y values", () => {
+    const { container } = render(
+      <SimpleScatter data={items} title="Scatter" xLabel="Crashes" yLabel="Deaths" />,
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+    expect(status).toBeEmptyDOMElement();
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("Alpha: Crashes 10, Deaths 0");
+
+    fireEvent.keyDown(svg, { key: "End" });
+    expect(status).toHaveTextContent("Gamma: Crashes 30, Deaths 0");
+
+    fireEvent.blur(svg);
+    expect(status).toBeEmptyDOMElement();
+  });
+
+  it("DualAxisLineChart announces both series and shows the tooltip", () => {
+    const dual = [
+      { label: "2021", primary: 100, secondary: 5 },
+      { label: "2022", primary: 200, secondary: 7 },
+    ];
+    const { container } = render(
+      <DualAxisLineChart
+        data={dual}
+        title="Dual"
+        primaryLabel="Crashes"
+        secondaryLabel="Rate"
+        renderTooltip={(item) => <span>tip-{item.label}</span>}
+      />,
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("2021: Crashes 100, Rate 5");
+    expect(screen.getByText("tip-2021")).toBeInTheDocument();
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("2022: Crashes 200, Rate 7");
+
+    fireEvent.blur(svg);
+    expect(screen.queryByText("tip-2021")).toBeNull();
+  });
+
+  it("SimpleDonutChart walks segments with percentages and activates on Enter", () => {
+    const onSegmentClick = vi.fn();
+    const withColor = items.map((d) => ({ ...d, color: "#123456" }));
+    const { container } = render(
+      <SimpleDonutChart data={withColor} title="Donut" onSegmentClick={onSegmentClick} />,
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("Alpha: 10 (17%)");
+
+    fireEvent.keyDown(svg, { key: "Enter" });
+    expect(onSegmentClick).toHaveBeenCalledWith(withColor[0], 0);
+  });
+
+  it("SimpleLollipop walks rows and activates on Space", () => {
+    const onItemClick = vi.fn();
+    const { container } = render(
+      <SimpleLollipop data={items} title="Lollipop" onItemClick={onItemClick} />,
+    );
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+
+    fireEvent.keyDown(svg, { key: "ArrowDown" });
+    expect(status).toHaveTextContent("Alpha: 10");
+    fireEvent.keyDown(svg, { key: "ArrowDown" });
+    expect(status).toHaveTextContent("Beta: 20");
+
+    fireEvent.keyDown(svg, { key: " " });
+    expect(onItemClick).toHaveBeenCalledWith(items[1], 1);
+  });
+
+  it("SimplePolarArea walks slices and announces values", () => {
+    const { container } = render(<SimplePolarArea data={items} title="Polar" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("Alpha: 10");
+    fireEvent.keyDown(svg, { key: "End" });
+    expect(status).toHaveTextContent("Gamma: 30");
+  });
+
+  it("SimpleRadar walks vertices and announces values", () => {
+    const { container } = render(<SimpleRadar data={items} title="Radar" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("Alpha: 10");
+    fireEvent.keyDown(svg, { key: "ArrowLeft" });
+    expect(status).toHaveTextContent("Alpha: 10");
+  });
+
+  it("SimpleTreemap walks tiles in data order with percentages", () => {
+    const { container } = render(<SimpleTreemap data={items} title="Treemap" />);
+    const svg = container.querySelector("svg")!;
+    expect(svg).toHaveAttribute("tabindex", "0");
+    const status = screen.getByRole("status");
+
+    fireEvent.keyDown(svg, { key: "ArrowRight" });
+    expect(status).toHaveTextContent("Alpha: 10 (17%)");
+    fireEvent.keyDown(svg, { key: "End" });
+    expect(status).toHaveTextContent("Gamma: 30 (50%)");
+  });
+
+  it("keeps the tooltip guarded when data shrinks under a keyboard-focused index", () => {
+    const tip = (item: { label: string; value: number }) => <span>tip-{item.label}</span>;
+    const { container, rerender } = rtlRender(
+      <ThemeProvider>
+        <CustomThemeProvider>
+          <SimpleLollipop data={items} renderTooltip={tip} />
+        </CustomThemeProvider>
+      </ThemeProvider>,
+    );
+    const svg = container.querySelector("svg")!;
+    fireEvent.keyDown(svg, { key: "End" });
+    expect(screen.getByText("tip-Gamma")).toBeInTheDocument();
+
+    expect(() =>
+      rerender(
+        <ThemeProvider>
+          <CustomThemeProvider>
+            <SimpleLollipop data={[items[0]]} renderTooltip={tip} />
+          </CustomThemeProvider>
+        </ThemeProvider>,
+      ),
+    ).not.toThrow();
+    expect(screen.queryByText("tip-Gamma")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes out the accessibility backlog from the MEGA trackers (#291 Accessibility section, #322 "Accessibility — WCAG 2.2 AA" tier, docs/DEFINITION_OF_DONE.md). Every unticked a11y item was verified against current main first — most were already shipped by PR #371; this PR implements what actually remained.

## Implemented

1. **Keyboard access for the 7 remaining interactive chart types** (#291 "SVG chart elements no keyboard access — bars/dots not focusable (all chart files)"; the one a11y item PR #371's closing comment explicitly left open). Extends the exact convention SimpleLineChart/SimpleBarChart established — focusable `<svg>` (`tabIndex=0`), ArrowLeft/Right (+Up/Down aliases) walk the data, Home/End jump, tooltip follows focus, each step announced via a polite `sr-only` `role="status"` live region, blur clears state — to:
   - `DualAxisLineChart` (announces both series: "2021: Crashes 100, Rate 5")
   - `SimpleScatter` (announces x/y pair)
   - `SimpleDonutChart` (announces value + percent; **Enter/Space activates `onSegmentClick`**)
   - `SimpleLollipop` (**Enter/Space activates `onItemClick`**)
   - `SimplePolarArea`, `SimpleRadar`, `SimpleTreemap`
   - Shared stepping helper `frontend/src/components/charts/chartKeyboardNav.ts`
2. **New test suite** `frontend/src/components/charts/charts.keyboard.test.tsx` — 13 tests: helper edge cases, per-chart arrow-key walking + live-region announcements, Enter/Space activation, blur cleanup, and the shrink-under-focus tooltip-bounds guard.
3. **Distinct document titles for `/water` and `/terms`** (WCAG 2.4.2, `Layout.tsx` PAGE_TITLES). Both routes fell back to the generic site title — Layout's title effect runs after the page's MetaTags effect and was overwriting the Water page's own title.

## Verified already done (no re-fix; file:line evidence)

| Tracker item | Evidence |
|---|---|
| #291 AdminGuard password input label | `AdminGuard.tsx:87` `aria-label="Admin key"` |
| #291 Leaflet popup `#666` text in dark mode | no `#666` remains in `OverlayMarkers.tsx` (grep clean) |
| #291 Chat feedback buttons < 44px | `ChatMessage.tsx:104,112,123` `min-w-[44px] min-h-[44px]` |
| #291 SimplePolarArea `#fff` labels contrast | `SimplePolarArea.tsx` uses `textOnColor()` from `charts/onColorText.ts` |
| #291 duplicate `aria-label="Main navigation"` | `NavBar.tsx:33` "Main navigation" vs `BottomTabBar.tsx:19` "Mobile navigation" |
| #291 3 charts missing touch support | touch scrub handlers present in `SimplePolarArea.tsx:35`, `SimpleGauge.tsx`, `DualAxisLineChart.tsx:78` |
| #291 DualAxisLineChart missing `useTextScale` | `DualAxisLineChart.tsx:4,61` |
| #291 tooltip bounds safety (stale `hover.idx`) | every hover chart guards `data[hover.idx] != null` before rendering the tooltip |
| DoD "Focus trap missing in ChartConfigSheet" | `ChartConfigSheet.tsx:2,35` uses `focus-trap-react` |
| Keyboard access on bar/line charts | `SimpleBarChart.tsx:88-119`, `SimpleLineChart.tsx:78-96` (PR #371) |
| Reduced motion | `context/AccessibilityContext.tsx`, `hooks/useChartAnimation.ts:27`, `index.css:401,1177` |
| Skip link | `Layout.tsx:41-46` "Skip to main content" |
| CorrelationMatrix screen-reader access | deliberate design: svg `aria-hidden`, accessible `<table>` alternative (`CorrelationMatrix.tsx:222-227`) |
| Water module (#377, new surface) | `ReservoirCard.tsx:63-67` progressbar + `:92` aria-expanded; `DroughtMap.tsx:141-142` labeled `role="img"` + text legend — already follows conventions |

## Deliberately skipped (with reasons)

- **Formal axe + Lighthouse audit across all pages** (#322): needs a real browser pass against the running app, not a code change; left as the tracker's remaining umbrella item.
- **SimpleGauge keyboard nav**: single-value chart whose value and legend are already visible text inside/below the svg — nothing to walk.
- **Sparkline keyboard nav**: decorative/no hover interactivity; already `role="img"` with a `label` prop.
- **CorrelationMatrix svg keyboard nav**: would duplicate the existing accessible table, which is the intentional AT representation.
- **WCAG 2.2-specific criteria** (focus-not-obscured 2.4.11, consistent help 3.2.6, redundant entry 3.3.7): product/design-level judgments that belong to the formal audit above, not spot code patches.

## Verification

- `npx vitest run`: **133 files / 973 tests passing** (960 before + 13 new)
- `npm run lint`: 0 errors; 31 warnings — byte-identical to the clean-main baseline (verified by stash/compare)
- `npm run build`: green (PWA precache builds)

Frontend-only; `backend/` untouched (PR #378 in flight there).
