### PR TITLE
Upgrade CalEnviroScreen correlation source from CES 4.0 to CES 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ frontend/
 
 - [CCRS](https://data.ca.gov/dataset/ccrs) — California crash records (State of California)
 - [ACS](https://www.census.gov/programs-surveys/acs) — Demographics (Census Bureau)
-- [CalEnviroScreen 4.0](https://oehha.ca.gov/calenviroscreen) — Environmental justice scores
+- [CalEnviroScreen 5.0](https://oehha.ca.gov/calenviroscreen) — Environmental justice scores
 - [NOAA Storm Events](https://www.ncdc.noaa.gov/stormevents/) — Weather data
 - [HPMS](https://www.fhwa.dot.gov/policyinformation/hpms.cfm) — Road miles and traffic volumes
 - [CDEC](https://cdec.water.ca.gov) — Reservoir storage (CA Dept. of Water Resources)

--- a/backend/DATA_DICTIONARY.md
+++ b/backend/DATA_DICTIONARY.md
@@ -406,17 +406,17 @@ See DATA_GAPS.md for coverage gaps: education fields are NULL before 2012, and s
 
 ## 15. `calenviroscreen`
 
-**Purpose:** CalEnviroScreen 4.0 environmental justice scores per county. Enables equity analysis.  
+**Purpose:** CalEnviroScreen 5.0 environmental justice scores per county. Enables equity analysis.  
 **Grain:** One row per county (all 58).  
-**Source:** CA OEHHA (Office of Environmental Health Hazard Assessment) via ArcGIS, aggregated from ~8,000 census tracts using population-weighted averaging.  
+**Source:** CA OEHHA (Office of Environmental Health Hazard Assessment) via ArcGIS, aggregated from ~9,100 census tracts (2020 census geography) using population-weighted averaging.  
 **Loaded by:** `etl.load_calenviroscreen`  
-**Caveat:** Single snapshot based on 2021 data. Not a time series.
+**Caveat:** Single snapshot (CES 5.0, published 2026-07-01). Not a time series.
 
 | Column | Type | Null | Description |
 |---|---|---|---|
 | `id` | Integer | N | **PK** |
 | `county_code` | SmallInteger | N | **FK → counties.code.** Unique |
-| `ces_score` | Float | Y | Overall CES 4.0 score (pollution burden × population characteristics) |
+| `ces_score` | Float | Y | Overall CES 5.0 score (pollution burden × population characteristics) |
 | `ces_percentile` | Float | Y | Overall percentile (0–100). Higher = more burdened |
 | `pollution_burden` | Float | Y | Pollution burden sub-score |
 | `pop_characteristics` | Float | Y | Population characteristics sub-score |

--- a/backend/DATA_GAPS.md
+++ b/backend/DATA_GAPS.md
@@ -77,9 +77,9 @@ Good enough for trend analysis ("rainy months have more crashes") but not for in
 
 ## CalEnviroScreen
 
-**Single snapshot.** Version 4.0 is based on 2021 data. It's not a time series — we can't show how environmental burden changed over the years. When OEHHA releases version 5.0 we can update it but for now it's one point in time.
+**Single snapshot.** Version 5.0 was published July 2026. It's not a time series — we can't show how environmental burden changed over the years. Each major CES release replaces the previous snapshot, so it's one point in time.
 
-**County averages from tract data.** The raw data is at the census tract level (~8,000 tracts). We averaged up to 58 counties using population weighting. That hides a lot of variation within counties — LA County for example has tracts ranging from very low to very high environmental burden.
+**County averages from tract data.** The raw data is at the census tract level (~9,100 tracts on 2020 census geography). We averaged up to 58 counties using population weighting. That hides a lot of variation within counties — LA County for example has tracts ranging from very low to very high environmental burden.
 
 ## Unemployment
 

--- a/backend/app/ai_prompt.py
+++ b/backend/app/ai_prompt.py
@@ -27,7 +27,7 @@ Data limitations (DO NOT query what doesn't exist):
 - Party/victim data ONLY exists for 2016+ (CCRS). Pre-2016 SWITRS crashes have no party or victim records.
 - is_alcohol_involved / is_distraction_involved are NULL for all pre-2016 crashes.
 - Weather table has monthly NOAA data — NOT per-crash weather. The crashes table has a per-crash 'weather' field which IS queryable via query_crashes.
-- CalEnviroScreen is a single snapshot (CES 4.0) — not year-over-year.
+- CalEnviroScreen is a single snapshot (CES 5.0) — not year-over-year.
 - Some rural counties have sparse data in early years (< 50 crashes/year).
 - Traffic volumes (AADT) are aggregate per county — not per-road-segment.
 - You have NO tools for water conditions (reservoir storage, snowpack, drought). If asked, say the crash explorer doesn't cover water data — never guess or invent water figures. (When the Water page launches publicly, point users to /water here.)

--- a/backend/app/ai_tools.py
+++ b/backend/app/ai_tools.py
@@ -550,7 +550,7 @@ def get_road_info(db: Session, county: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def get_environmental(db: Session, county: str) -> dict:
-    """CalEnviroScreen 4.0 scores for a county."""
+    """CalEnviroScreen 5.0 scores for a county."""
     code = _county_code(db, county)
     if code is None:
         return {"error": f"County not found: {county}"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -748,19 +748,20 @@ class UnemploymentRate(Base):
 
 
 class CalenviroScreen(Base):
-    """CalEnviroScreen 4.0 — California's environmental justice scores.
+    """CalEnviroScreen 5.0 — California's environmental justice scores.
 
     OEHHA (Office of Environmental Health Hazard Assessment) scores every
     census tract in California based on pollution exposure and population
     vulnerability. Higher score = more burdened community.
 
-    The raw data is at the census tract level (~8,000 tracts) but we
-    average it up to county level using population weighting. So this
-    table has one row per county with averaged scores.
+    The raw data is at the census tract level (~9,100 tracts on 2020
+    census geography) but we average it up to county level using
+    population weighting. So this table has one row per county with
+    averaged scores.
 
     Good for equity analysis — "do high-pollution, high-poverty counties
-    also have worse crash outcomes?" Merced County has the highest score
-    (lots of agricultural pollution + 46% poverty). Marin has the lowest.
+    also have worse crash outcomes?" Central Valley agricultural counties
+    score highest; wealthy coastal counties like Marin score lowest.
     """
 
     __tablename__ = "calenviroscreen"
@@ -769,7 +770,7 @@ class CalenviroScreen(Base):
     county_code = Column(
         SmallInteger, ForeignKey("counties.code"), nullable=False, unique=True
     )
-    ces_score = Column(Float)              # overall CES 4.0 score
+    ces_score = Column(Float)              # overall CES 5.0 score
     ces_percentile = Column(Float)         # overall percentile (0-100)
     pollution_burden = Column(Float)       # pollution burden score
     pop_characteristics = Column(Float)    # population characteristics score

--- a/backend/app/routers/reference.py
+++ b/backend/app/routers/reference.py
@@ -160,7 +160,7 @@ def list_calenviroscreen(
     county: str | None = Query(None),
     db: Session = Depends(get_db),
 ):
-    """County-level CalEnviroScreen 4.0 scores (population-weighted averages)."""
+    """County-level CalEnviroScreen 5.0 scores (population-weighted averages)."""
     response.headers["Cache-Control"] = _ONE_HOUR
     q = db.query(CalenviroScreen)
     if county:

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -149,7 +149,7 @@ def build_default_registry() -> JobRegistry:
         table_name="calenviroscreen",
         max_drop_pct=20,
         source_type="arcgis",
-        freshness_url="https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services/CalEnviroScreen_4_0_Results_/FeatureServer/0/query",
+        freshness_url="https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services/calenviroscreen50results_F_070126_gdb/FeatureServer/0/query",
     ))
     registry.register(Job(
         name="licensed_drivers",

--- a/backend/etl/load_calenviroscreen.py
+++ b/backend/etl/load_calenviroscreen.py
@@ -1,10 +1,10 @@
-"""Pull CalEnviroScreen 4.0 environmental justice scores from OEHHA.
+"""Pull CalEnviroScreen 5.0 environmental justice scores from OEHHA.
 
 CalEnviroScreen is California's tool for identifying communities that
 are most affected by pollution and poverty. The raw data is at the
-census tract level (~8,000 tracts) so we average it up to county level
-using population weighting. That way we can compare environmental
-burden across counties alongside crash data.
+census tract level (~9,100 tracts on 2020 census geography) so we
+average it up to county level using population weighting. That way we
+can compare environmental burden across counties alongside crash data.
 
 The data lives on an ArcGIS server. We page through it 2,000 tracts
 at a time, then do the aggregation in Python.
@@ -33,38 +33,45 @@ logger = logging.getLogger(__name__)
 # The CalEnviroScreen data lives on an ArcGIS server run by OEHHA.
 # We hit it like a REST API — query with "where 1=1" (give me everything)
 # and page through in batches of 2,000 records.
+# This is the final CES 5.0 results layer published 2026-07-01
+# ("_F_070126" = Final, July 1 2026).
 ARCGIS_BASE = (
     "https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services"
-    "/CalEnviroScreen_4_0_Results_/FeatureServer/0/query"
+    "/calenviroscreen50results_F_070126_gdb/FeatureServer/0/query"
 )
 
-# Fields we need from the ArcGIS response
+# The census population field used for weighting. CES 4.0 called this
+# "ACS2019TotalPop"; CES 5.0 renamed it to "Population" (ACS 2024).
+POPULATION_FIELD = "Population"
+
+# Fields we need from the ArcGIS response. CES 5.0 renamed most of the
+# cryptic 4.0 short names (pm, diesel, pov, ...) to fuller ones.
 OUT_FIELDS = ",".join([
-    "tract", "ACS2019TotalPop",
+    "tract", POPULATION_FIELD,
     "CIscore", "CIscoreP",
     "PollutionScore", "PopCharScore",
-    "pm", "ozone", "diesel", "pest", "traffic",
-    "pov", "unemp", "edu", "ling", "housingB",
+    "PM2_5", "ozone", "Diesel_PM", "Pesticides", "traffic",
+    "Poverty", "Unemployment", "Education", "Linguistic_Isol", "HousBurd",
 ])
 
-# Maps the short ArcGIS field names to our database column names.
-# OEHHA uses pretty cryptic names — "pm" is PM2.5 particulate matter,
-# "ling" is linguistic isolation, "housingB" is housing burden, etc.
+# Maps the ArcGIS field names to our database column names.
+# "PM2_5" is PM2.5 particulate matter, "Linguistic_Isol" is linguistic
+# isolation, "HousBurd" is housing burden, etc.
 FIELD_MAP = {
     "CIscore": "ces_score",
     "CIscoreP": "ces_percentile",
     "PollutionScore": "pollution_burden",
     "PopCharScore": "pop_characteristics",
-    "pm": "pm25_score",
+    "PM2_5": "pm25_score",
     "ozone": "ozone_score",
-    "diesel": "diesel_pm_score",
-    "pest": "pesticide_score",
+    "Diesel_PM": "diesel_pm_score",
+    "Pesticides": "pesticide_score",
     "traffic": "traffic_score",
-    "pov": "poverty_pct",
-    "unemp": "unemployment_pct",
-    "edu": "education_pct",
-    "ling": "linguistic_isolation_pct",
-    "housingB": "housing_burden_pct",
+    "Poverty": "poverty_pct",
+    "Unemployment": "unemployment_pct",
+    "Education": "education_pct",
+    "Linguistic_Isol": "linguistic_isolation_pct",
+    "HousBurd": "housing_burden_pct",
 }
 
 
@@ -79,7 +86,7 @@ def _safe_float(value):
 
 
 def fetch_tracts() -> list[dict]:
-    """Download all ~8,000 census tract records from the ArcGIS server.
+    """Download all ~9,100 census tract records from the ArcGIS server.
 
     ArcGIS caps you at about 2,000 records per request, so we page
     through using resultOffset. Usually takes 4-5 requests to get
@@ -119,7 +126,7 @@ def fetch_tracts() -> list[dict]:
 
 
 def aggregate_to_counties(tracts: list[dict], fips_to_code: dict[str, int]) -> dict:
-    """Average ~8,000 census tracts up to 58 counties.
+    """Average ~9,100 census tracts up to 58 counties.
 
     Each tract has scores for pollution, poverty, etc. We want county-level
     numbers, but you can't just take a simple average because tracts have
@@ -154,7 +161,7 @@ def aggregate_to_counties(tracts: list[dict], fips_to_code: dict[str, int]) -> d
         if county_code is None:
             continue
 
-        pop = _safe_float(tract.get("ACS2019TotalPop"))
+        pop = _safe_float(tract.get(POPULATION_FIELD))
         if pop is None or pop <= 0:
             continue
 

--- a/backend/run_all_etl.sh
+++ b/backend/run_all_etl.sh
@@ -71,7 +71,7 @@ python -m etl.bls_unemployment
 echo "=== Unemployment done ==="
 
 echo ""
-echo "=== 12/20CalEnviroScreen 4.0 ==="
+echo "=== 12/20CalEnviroScreen 5.0 ==="
 python -m etl.load_calenviroscreen
 echo "=== CalEnviroScreen done ==="
 

--- a/backend/tests/test_load_calenviroscreen.py
+++ b/backend/tests/test_load_calenviroscreen.py
@@ -1,4 +1,4 @@
-"""Tests for the CalEnviroScreen ETL."""
+"""Tests for the CalEnviroScreen ETL (CES 5.0 field names)."""
 
 from etl.load_calenviroscreen import aggregate_to_counties, _safe_float
 
@@ -26,27 +26,27 @@ class TestAggregateToCounties:
         tracts = [
             {
                 "tract": 6001400100,  # Alameda tract
-                "ACS2019TotalPop": 5000,
+                "Population": 5000,
                 "CIscore": 30.0,
                 "CIscoreP": 50.0,
                 "PollutionScore": 5.0,
                 "PopCharScore": 4.0,
-                "pm": 10.0, "ozone": 0.04, "diesel": 0.5,
-                "pest": 0.0, "traffic": 1000.0,
-                "pov": 20.0, "unemp": 5.0, "edu": 15.0,
-                "ling": 10.0, "housingB": 30.0,
+                "PM2_5": 10.0, "ozone": 0.04, "Diesel_PM": 0.5,
+                "Pesticides": 0.0, "traffic": 1000.0,
+                "Poverty": 20.0, "Unemployment": 5.0, "Education": 15.0,
+                "Linguistic_Isol": 10.0, "HousBurd": 30.0,
             },
             {
                 "tract": 6001400200,  # Another Alameda tract
-                "ACS2019TotalPop": 3000,
+                "Population": 3000,
                 "CIscore": 20.0,
                 "CIscoreP": 30.0,
                 "PollutionScore": 3.0,
                 "PopCharScore": 2.0,
-                "pm": 8.0, "ozone": 0.03, "diesel": 0.3,
-                "pest": 0.0, "traffic": 800.0,
-                "pov": 10.0, "unemp": 3.0, "edu": 10.0,
-                "ling": 5.0, "housingB": 20.0,
+                "PM2_5": 8.0, "ozone": 0.03, "Diesel_PM": 0.3,
+                "Pesticides": 0.0, "traffic": 800.0,
+                "Poverty": 10.0, "Unemployment": 3.0, "Education": 10.0,
+                "Linguistic_Isol": 5.0, "HousBurd": 20.0,
             },
         ]
         fips_to_code = {"06001": 1}
@@ -62,7 +62,7 @@ class TestAggregateToCounties:
 
     def test_skips_zero_population_tracts(self):
         tracts = [
-            {"tract": 6001400100, "ACS2019TotalPop": 0, "CIscore": 50.0},
+            {"tract": 6001400100, "Population": 0, "CIscore": 50.0},
         ]
         fips_to_code = {"06001": 1}
 
@@ -71,7 +71,7 @@ class TestAggregateToCounties:
 
     def test_skips_unknown_counties(self):
         tracts = [
-            {"tract": 9999900100, "ACS2019TotalPop": 1000, "CIscore": 50.0},
+            {"tract": 9999900100, "Population": 1000, "CIscore": 50.0},
         ]
         fips_to_code = {"06001": 1}
 
@@ -80,7 +80,7 @@ class TestAggregateToCounties:
 
     def test_handles_missing_fields_gracefully(self):
         tracts = [
-            {"tract": 6001400100, "ACS2019TotalPop": 1000},
+            {"tract": 6001400100, "Population": 1000},
         ]
         fips_to_code = {"06001": 1}
 

--- a/docs/DATA_METHODOLOGY.md
+++ b/docs/DATA_METHODOLOGY.md
@@ -300,23 +300,23 @@ CDS Code (County-District-School), school name, county, city, latitude, longitud
 
 **Filter Criteria:** Only records with `Status = "Active"` are retained. Enables "crashes near schools" spatial analysis and school-zone safety metrics.
 
-### 2.15 CalEnviroScreen 4.0
+### 2.15 CalEnviroScreen 5.0
 
 | Attribute | Value |
 |---|---|
-| **Official Name** | CalEnviroScreen 4.0 |
+| **Official Name** | CalEnviroScreen 5.0 |
 | **Source Agency** | California Office of Environmental Health Hazard Assessment (OEHHA) |
 | **Legal Authority** | California Public Records Act; SB 535 (Disadvantaged Communities); AB 1550 |
 | **URL** | https://oehha.ca.gov/calenviroscreen |
-| **API Endpoint** | `https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services/CalEnviroScreen_4_0_Results_/FeatureServer` |
-| **Coverage** | Point-in-time (based on ACS 2019 population data) |
-| **Update Frequency** | Updated with each major CES version release (CES 4.0 published 2021) |
-| **Row Count** | 58 county records (aggregated from ~8,000 census tracts) |
+| **API Endpoint** | `https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services/calenviroscreen50results_F_070126_gdb/FeatureServer` |
+| **Coverage** | Point-in-time (based on ACS 2024 population data, 2020 census tract geography) |
+| **Update Frequency** | Updated with each major CES version release (CES 5.0 published 2026-07-01) |
+| **Row Count** | 58 county records (aggregated from ~9,100 census tracts) |
 
 **Fields Extracted:**
 CES composite score, CES percentile, pollution burden score, population characteristics score, PM2.5, ozone, diesel particulate matter, pesticide use, traffic proximity, poverty rate, unemployment rate, education (% without HS diploma), linguistic isolation, housing burden.
 
-**Aggregation Method:** The raw data is at census tract level (~8,000 tracts in California). CalSight aggregates to county level using **population-weighted averaging**:
+**Aggregation Method:** The raw data is at census tract level (~9,100 tracts in California, on 2020 census geography). CalSight aggregates to county level using **population-weighted averaging**:
 
 ```
 county_score = SUM(tract_score * tract_population) / SUM(tract_population)
@@ -560,9 +560,9 @@ The correlation matrix computes all 325 unique pairwise Pearson correlations amo
 | No Vehicle %, Drive Alone %, Bike % | Census ACS demographics |
 | Disability % | Census ACS demographics |
 | Unemployment Rate | BLS LAUS |
-| CES Score, CES Percentile | CalEnviroScreen 4.0 |
-| Traffic Score, Pollution Burden, Diesel PM | CalEnviroScreen 4.0 |
-| Linguistic Isolation %, Housing Burden %, No Diploma % | CalEnviroScreen 4.0 |
+| CES Score, CES Percentile | CalEnviroScreen 5.0 |
+| Traffic Score, Pollution Burden, Diesel PM | CalEnviroScreen 5.0 |
+| Linguistic Isolation %, Housing Burden %, No Diploma % | CalEnviroScreen 5.0 |
 | EV %, Vehicles per Capita | DMV vehicle registrations |
 | Average Temperature, Total Rainfall | NOAA weather |
 
@@ -803,7 +803,7 @@ All other data sources (data.ca.gov CKAN, Caltrans ArcGIS, FHWA ArcGIS, OEHHA Ar
 
 12. California Department of Education. *California Public Schools*. https://data.ca.gov/dataset/california-public-schools
 
-13. California Office of Environmental Health Hazard Assessment. *CalEnviroScreen 4.0*. https://oehha.ca.gov/calenviroscreen
+13. California Office of Environmental Health Hazard Assessment. *CalEnviroScreen 5.0*. https://oehha.ca.gov/calenviroscreen
 
 ### Statistical Methods
 

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -139,10 +139,10 @@ export default function AboutPage() {
 
           <div className="bg-surface-container-lowest p-8 rounded-lg ambient-shadow flex flex-col justify-between">
             <div>
-              <h2 className="font-headline text-xl font-bold text-on-surface">CalEnviroScreen 4.0</h2>
+              <h2 className="font-headline text-xl font-bold text-on-surface">CalEnviroScreen 5.0</h2>
               <p className="text-sm text-on-surface-variant mt-1">Environmental Justice Scores — OEHHA</p>
               <p className="text-xs text-on-surface-variant mt-3 leading-relaxed">
-                Population-weighted county scores aggregated from ~8,000 census tracts. Includes <JargonTerm term="CES">CES</JargonTerm> composite score, pollution burden, PM2.5, ozone, diesel particulate matter, traffic proximity, poverty, unemployment, linguistic isolation, and housing burden.
+                Population-weighted county scores aggregated from ~9,100 census tracts. Includes <JargonTerm term="CES">CES</JargonTerm> composite score, pollution burden, PM2.5, ozone, diesel particulate matter, traffic proximity, poverty, unemployment, linguistic isolation, and housing burden.
               </p>
             </div>
             <div className="flex items-center justify-between mt-6">

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -823,7 +823,7 @@ function StatsPageInner() {
               System (SWITRS, 2001&ndash;2015) and the California Crash Records
               System (CCRS, 2016&ndash;present), maintained by the California
               Highway Patrol. Demographics from U.S. Census ACS 5-year
-              estimates. Environmental data from CalEnviroScreen 4.0 (OEHHA).
+              estimates. Environmental data from CalEnviroScreen 5.0 (OEHHA).
               Employment from Bureau of Labor Statistics LAUS. Vehicle and
               driver data from California DMV.
             </p>


### PR DESCRIPTION
## Summary

OEHHA/CalEPA released [CalEnviroScreen 5.0 on 2026-07-01](https://calepa.ca.gov/2026/07/01/california-releases-calenviroscreen-5-0-to-identify-and-prioritize-pollution-burdened-communities-announces-preliminary-disadvantaged-communities-designation/). This PR points our correlation source at the final CES 5.0 results and updates every user-facing 4.0 reference.

**New source:** `https://services1.arcgis.com/PCHfdHz4GlDNAhBb/arcgis/rest/services/calenviroscreen50results_F_070126_gdb/FeatureServer/0` (same OEHHA ArcGIS org as 4.0; `_F_070126` = final results published July 1, 2026).

## Schema differences found (4.0 vs 5.0)

| Purpose | CES 4.0 field | CES 5.0 field |
|---|---|---|
| Population weight | `ACS2019TotalPop` | `Population` (ACS 2024) |
| Overall score / percentile | `CIscore` / `CIscoreP` | unchanged |
| Component scores | `PollutionScore` / `PopCharScore` | unchanged |
| PM2.5 | `pm` | `PM2_5` |
| Diesel PM | `diesel` | `Diesel_PM` |
| Pesticides | `pest` | `Pesticides` |
| Poverty | `pov` | `Poverty` |
| Unemployment | `unemp` | `Unemployment` |
| Education (no diploma) | `edu` | `Education` |
| Linguistic isolation | `ling` | `Linguistic_Isol` |
| Housing burden | `housingB` | `HousBurd` |
| Ozone / traffic / tract | `ozone` / `traffic` / `tract` | unchanged |

- **Census geography:** 5.0 moves from 2010 to 2020 census tracts (9,106 tracts vs ~8,035). Tract IDs keep the same 11-digit format with the county FIPS in the first 5 digits, so our county rollup logic is unchanged — verified all 58 counties aggregate with zero null fields in a live run.
- **New 5.0 indicators** (Diabetes Prevalence, Small Air Toxic Sites, refreshed drinking water methodology) exist in the layer but are not part of our 15 stored columns, so no migration is needed — **same table, refreshed in place**.

## Score shifts users will notice

CES 5.0 recomputes every indicator with newer data and recalculates all percentiles on the new tract set, so county-level values shift moderately (e.g. Alameda county-weighted `CIscore` is now 23.05 vs ~28 under 4.0). Rankings stay directionally similar (Central Valley high, wealthy coastal counties low). Values update when the monthly `calenviroscreen` ETL job next runs after deploy.

## Changes

- `backend/etl/load_calenviroscreen.py` — new endpoint, field map, population field constant
- `backend/etl/jobs.py` — freshness URL now checks the 5.0 layer
- `backend/tests/test_load_calenviroscreen.py` — fixtures use 5.0 field names
- Version strings: `ai_prompt.py`, `ai_tools.py`, `models.py`, `routers/reference.py`, `run_all_etl.sh`, `AboutPage.tsx`, `StatsPage.tsx`, `README.md`, `DATA_DICTIONARY.md`, `DATA_GAPS.md`, `DATA_METHODOLOGY.md`

## Validation

- Live smoke run against the real endpoint: 9,106 tracts fetched, 58/58 counties aggregated, 39.29M weighted population, no null fields
- Backend: 1091 passed
- Frontend: 985 passed (134 files)