### PR TITLE
Snowpack: DWR April-1 convention + honest reservoir count

### DIFF
--- a/backend/app/routers/water.py
+++ b/backend/app/routers/water.py
@@ -334,6 +334,39 @@ _MIN_MEANINGFUL_SWE = 0.5
 _SNOW_RECENCY_DAYS = 14
 
 
+def _april1_stats(db, station_ids, newest: date):
+    """This season's April-1 SWE and the historical April-1 average per
+    station — the inputs for DWR's season-defining "% of April 1 average".
+
+    Returns (apr1_date, {sid: swe}, {sid: (avg, years)}). The historical
+    average uses the full period of record (like DWR's), so the current
+    season's own reading contributes ~1/N of its average.
+    """
+    apr1 = date(newest.year, 4, 1)
+    if newest < apr1:
+        apr1 = date(newest.year - 1, 4, 1)
+
+    readings = dict(
+        db.query(SnowDaily.station_id, SnowDaily.swe_in)
+        .filter(SnowDaily.station_id.in_(station_ids), SnowDaily.date == apr1)
+        .all()
+    )
+    averages = {
+        sid: (float(avg), years)
+        for sid, avg, years in (
+            db.query(SnowDaily.station_id, func.avg(SnowDaily.swe_in), func.count())
+            .filter(
+                SnowDaily.station_id.in_(station_ids),
+                func.extract("month", SnowDaily.date) == 4,
+                func.extract("day", SnowDaily.date) == 1,
+            )
+            .group_by(SnowDaily.station_id)
+            .all()
+        )
+    }
+    return apr1, readings, averages
+
+
 @router.get("/water/snowpack", response_model=SnowpackOut)
 @_limiter.limit("1000/minute;20000/hour")
 def snowpack(
@@ -341,8 +374,9 @@ def snowpack(
     response: Response,
     db: Session = Depends(get_db),
 ):
-    """Latest snow water equivalent by DWR region and statewide, each as a
-    percent of the same-day-of-year historical average across stations."""
+    """Latest snow water equivalent by DWR region and statewide, as a
+    percent of the same-day-of-year historical average across stations,
+    plus the season-defining percent of the April-1 average."""
     response.headers["Cache-Control"] = _ONE_HOUR
 
     conditions = latest_with_doy_average(db, SnowDaily, SnowDaily.swe_in)
@@ -366,14 +400,40 @@ def snowpack(
     def mean(values: list[float]) -> float:
         return sum(values) / len(values)
 
+    apr1_date, apr1_readings, apr1_averages = _april1_stats(
+        db, [c.station_id for c in current], newest
+    )
+
+    def apr1_comparable(cs: list[StationCondition]) -> list[str]:
+        # A station counts toward the April-1 percent when it reported that
+        # April 1 AND has a usable multi-year April-1 baseline.
+        return [
+            c.station_id
+            for c in cs
+            if c.station_id in apr1_readings
+            and c.station_id in apr1_averages
+            and apr1_averages[c.station_id][1] > 1
+            and apr1_averages[c.station_id][0] >= _MIN_MEANINGFUL_SWE
+        ]
+
+    def apr1_trio(cs: list[StationCondition]):
+        sids = apr1_comparable(cs)
+        if not sids:
+            return None, None, None
+        swe = mean([apr1_readings[s] for s in sids])
+        avg = mean([apr1_averages[s][0] for s in sids])
+        return round(swe, 1), round(avg, 1), round(swe / avg * 100, 1)
+
     # Every reported figure for a region comes from ONE station set, so
     # swe_in, avg_swe_in and pct_of_average always reconcile: when a percent
-    # is shown, swe_in IS that percent of avg_swe_in.
+    # is shown, swe_in IS that percent of avg_swe_in. (The apr1_* trio uses
+    # its own set and reconciles within itself the same way.)
     def summarize(region: str, cs: list[StationCondition]) -> RegionSnowpack:
         comparable = [c for c in cs if is_comparable(c)]
         used = comparable or cs
         swe = mean([c.value for c in used])
         avg = mean([c.avg for c in comparable]) if comparable else None
+        apr1_swe, apr1_avg, apr1_pct = apr1_trio(cs)
         return RegionSnowpack(
             region=region,
             station_count=len(used),
@@ -381,6 +441,9 @@ def snowpack(
             swe_in=round(swe, 1),
             avg_swe_in=round(avg, 1) if avg is not None else None,
             pct_of_average=round(swe / avg * 100, 1) if avg is not None else None,
+            apr1_swe_in=apr1_swe,
+            apr1_avg_swe_in=apr1_avg,
+            apr1_pct_of_average=apr1_pct,
         )
 
     by_region: dict[str, list[StationCondition]] = defaultdict(list)
@@ -403,8 +466,12 @@ def snowpack(
         else None
     )
 
+    _, _, statewide_apr1_pct = apr1_trio(current)
+
     return SnowpackOut(
         latest_date=newest,
         statewide_pct_of_average=statewide_pct,
+        apr1_date=apr1_date if statewide_apr1_pct is not None else None,
+        statewide_apr1_pct_of_average=statewide_apr1_pct,
         regions=regions,
     )

--- a/backend/app/schemas/snow.py
+++ b/backend/app/schemas/snow.py
@@ -21,6 +21,12 @@ class RegionSnowpack(BaseModel):
     swe_in: float                    # mean current SWE across the counted stations
     avg_swe_in: float | None = None  # mean same-day-of-year average (None until history)
     pct_of_average: float | None = None
+    # DWR's season-defining convention: this season's April-1 reading as a
+    # percent of the historical April-1 average. Its own trio — computed
+    # from one station set, so apr1_swe_in IS apr1_pct% of apr1_avg_swe_in.
+    apr1_swe_in: float | None = None
+    apr1_avg_swe_in: float | None = None
+    apr1_pct_of_average: float | None = None
 
 
 class SnowpackOut(BaseModel):
@@ -28,4 +34,8 @@ class SnowpackOut(BaseModel):
 
     latest_date: date
     statewide_pct_of_average: float | None = None
+    # The April 1 the apr1_* figures refer to (the most recent April 1 on
+    # or before latest_date — during Oct-Mar that is LAST season's April 1).
+    apr1_date: date | None = None
+    statewide_apr1_pct_of_average: float | None = None
     regions: list[RegionSnowpack]

--- a/backend/tests/api/test_snowpack.py
+++ b/backend/tests/api/test_snowpack.py
@@ -65,6 +65,59 @@ def test_snowpack_404_without_data(client):
     assert client.get("/api/water/snowpack").status_code == 404
 
 
+def test_snowpack_april1_uses_last_seasons_april_during_accumulation(
+    client, snow_data, db_session
+):
+    # newest reading is 2026-03-01, before this year's April 1 — so the
+    # apr1 figures refer to 2025-04-01 (last season's April 1).
+    db_session.add_all([
+        SnowDaily(station_id="CSL", date=date(2024, 4, 1), swe_in=8.0),
+        SnowDaily(station_id="CSL", date=date(2025, 4, 1), swe_in=12.0),
+    ])
+    db_session.commit()
+
+    body = client.get("/api/water/snowpack").json()
+    assert body["apr1_date"] == "2025-04-01"
+    # avg over {8, 12} = 10; 2025 reading 12 → 120%.
+    assert body["statewide_apr1_pct_of_average"] == pytest.approx(120.0)
+    central = next(r for r in body["regions"] if r["region"] == "Central Sierra")
+    assert central["apr1_swe_in"] == pytest.approx(12.0)
+    assert central["apr1_avg_swe_in"] == pytest.approx(10.0)
+    assert central["apr1_pct_of_average"] == pytest.approx(120.0)
+    # BSH has no April-1 history at all.
+    south = next(r for r in body["regions"] if r["region"] == "Southern Sierra")
+    assert south["apr1_pct_of_average"] is None
+
+
+def test_snowpack_april1_in_melt_season_uses_this_years_april(client, db_session):
+    # Newest reading is June — the season-defining number is THIS year's
+    # April 1 vs the April-1 average, even though current SWE is ~0.
+    db_session.add(
+        SnowStation(station_id="CSL", name="Central Sierra Snow Lab", elevation_ft=6900, region="Central Sierra")
+    )
+    db_session.flush()
+    db_session.add_all([
+        SnowDaily(station_id="CSL", date=date(2024, 4, 1), swe_in=8.0),
+        SnowDaily(station_id="CSL", date=date(2025, 4, 1), swe_in=12.0),
+        SnowDaily(station_id="CSL", date=date(2026, 4, 1), swe_in=6.0),
+        SnowDaily(station_id="CSL", date=date(2026, 6, 15), swe_in=0.5),  # newest
+    ])
+    db_session.commit()
+
+    body = client.get("/api/water/snowpack").json()
+    assert body["apr1_date"] == "2026-04-01"
+    # avg over {8, 12, 6} = 8.667 (period of record incl. this year);
+    # this year's 6.0 → 69.2%.
+    assert body["statewide_apr1_pct_of_average"] == pytest.approx(69.2, abs=0.1)
+
+
+def test_snowpack_april1_absent_without_april_history(client, snow_data):
+    # The base fixture has no April-1 rows at all — apr1 fields stay null.
+    body = client.get("/api/water/snowpack").json()
+    assert body["apr1_date"] is None
+    assert body["statewide_apr1_pct_of_average"] is None
+
+
 def test_snowpack_excludes_stale_offline_stations(client, db_session):
     """A station offline for years must not contribute its last-ever
     reading to the current snowpack total."""

--- a/frontend/src/components/water/SnowpackSection.test.tsx
+++ b/frontend/src/components/water/SnowpackSection.test.tsx
@@ -5,13 +5,30 @@ import type { ReactNode } from "react";
 import SnowpackSection from "./SnowpackSection";
 import type { Snowpack } from "../../hooks/useSnowpackData";
 
+const NO_APR1 = { apr1_swe_in: null, apr1_avg_swe_in: null, apr1_pct_of_average: null };
+
 const SNOWPACK: Snowpack = {
   latest_date: "2026-03-01",
   statewide_pct_of_average: 112,
+  apr1_date: null,
+  statewide_apr1_pct_of_average: null,
   regions: [
-    { region: "Central Sierra", station_count: 5, latest_date: "2026-03-01", swe_in: 24.6, avg_swe_in: 22.0, pct_of_average: 112 },
-    { region: "Northern Sierra / Trinity", station_count: 5, latest_date: "2026-03-01", swe_in: 30.1, avg_swe_in: 24.0, pct_of_average: 125 },
-    { region: "Southern Sierra", station_count: 5, latest_date: "2026-03-01", swe_in: 18.0, avg_swe_in: null, pct_of_average: null },
+    { region: "Central Sierra", station_count: 5, latest_date: "2026-03-01", swe_in: 24.6, avg_swe_in: 22.0, pct_of_average: 112, ...NO_APR1 },
+    { region: "Northern Sierra / Trinity", station_count: 5, latest_date: "2026-03-01", swe_in: 30.1, avg_swe_in: 24.0, pct_of_average: 125, ...NO_APR1 },
+    { region: "Southern Sierra", station_count: 5, latest_date: "2026-03-01", swe_in: 18.0, avg_swe_in: null, pct_of_average: null, ...NO_APR1 },
+  ],
+};
+
+// July response: same-date percents are melt-season noise; April-1 figures
+// carry the story.
+const SNOWPACK_MELT: Snowpack = {
+  latest_date: "2026-07-16",
+  statewide_pct_of_average: 9,
+  apr1_date: "2026-04-01",
+  statewide_apr1_pct_of_average: 69,
+  regions: [
+    { region: "Central Sierra", station_count: 3, latest_date: "2026-07-16", swe_in: 0.2, avg_swe_in: 1.8, pct_of_average: 9.5, apr1_swe_in: 6.0, apr1_avg_swe_in: 8.7, apr1_pct_of_average: 69.2 },
+    { region: "Southern Sierra", station_count: 2, latest_date: "2026-07-16", swe_in: 0.1, avg_swe_in: null, pct_of_average: null, ...NO_APR1 },
   ],
 };
 
@@ -93,6 +110,30 @@ describe("SnowpackSection", () => {
     renderSection();
     expect(
       await screen.findByRole("heading", { name: /Sierra snowpack by region/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("switches to the April-1 convention during the melt season", async () => {
+    mockApi(SNOWPACK_MELT);
+    renderSection();
+    // Headline is the season-defining April-1 number, not the noisy
+    // same-date percent.
+    expect(
+      await screen.findByRole("heading", { name: /April 1 snowpack was 69% of average/ }),
+    ).toBeInTheDocument();
+    const central = screen.getByRole("progressbar", { name: /Central Sierra/ });
+    expect(central).toHaveAttribute("aria-valuenow", "69");
+    expect(screen.getByText(/April 1: 6.0″ SWE · now 0.2″/)).toBeInTheDocument();
+    // A region without April-1 history still shows its dash.
+    const south = screen.getByRole("progressbar", { name: /Southern Sierra.*no comparison/i });
+    expect(south).not.toHaveAttribute("aria-valuenow");
+  });
+
+  it("keeps the same-date presentation in melt season when April-1 data is absent", async () => {
+    mockApi({ ...SNOWPACK, latest_date: "2026-07-16" });
+    renderSection();
+    expect(
+      await screen.findByRole("heading", { name: /Statewide snowpack is 112% of average/ }),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/water/SnowpackSection.tsx
+++ b/frontend/src/components/water/SnowpackSection.tsx
@@ -6,15 +6,28 @@ function barFraction(pct: number): number {
   return Math.min(pct, 200) / 200;
 }
 
-function RegionRow({ region }: { region: RegionSnowpack }) {
-  const pct = region.pct_of_average;
+/** DWR convention: during the melt season (April–September) the number
+ * that matters is how this season's April 1 snapshot compared to the
+ * April-1 average — the same-date percent degenerates as the denominator
+ * melts toward zero (a July "9% of a 1.8-inch average" is noise). */
+function isMeltSeason(latestDate: string): boolean {
+  const month = Number(latestDate.slice(5, 7));
+  return month >= 4 && month <= 9;
+}
+
+function RegionRow({ region, melt }: { region: RegionSnowpack; melt: boolean }) {
+  const pct = melt ? region.apr1_pct_of_average : region.pct_of_average;
+  const detail = melt
+    ? region.apr1_swe_in != null
+      ? `April 1: ${region.apr1_swe_in.toFixed(1)}″ SWE · now ${region.swe_in.toFixed(1)}″`
+      : `now ${region.swe_in.toFixed(1)}″ SWE · ${region.station_count} station${region.station_count === 1 ? "" : "s"}`
+    : `${region.swe_in.toFixed(1)}″ SWE · ${region.station_count} station${region.station_count === 1 ? "" : "s"}`;
+  const pctLabel = melt ? "% of April 1 average" : "% of average";
   return (
     <div className="grid grid-cols-[10rem_1fr_4rem] items-center gap-3">
       <div className="min-w-0">
         <p className="text-sm text-on-surface truncate">{region.region}</p>
-        <p className="text-[10px] text-on-surface-variant">
-          {region.swe_in.toFixed(1)}″ SWE · {region.station_count} stations
-        </p>
+        <p className="text-[10px] text-on-surface-variant">{detail}</p>
       </div>
       <div
         className="relative h-2 bg-surface-container-high rounded-full overflow-hidden"
@@ -22,7 +35,7 @@ function RegionRow({ region }: { region: RegionSnowpack }) {
         aria-valuenow={pct != null ? Math.round(pct) : undefined}
         aria-valuemin={0}
         aria-valuemax={200}
-        aria-label={`${region.region}: ${pct != null ? `${pct.toFixed(0)}% of average` : "no comparison available"}`}
+        aria-label={`${region.region}: ${pct != null ? `${pct.toFixed(0)}${pctLabel}` : "no comparison available"}`}
       >
         {pct != null && (
           <div
@@ -46,9 +59,11 @@ function RegionRow({ region }: { region: RegionSnowpack }) {
 }
 
 /**
- * Sierra snowpack by region — current snow water equivalent as a percent
- * of the same-day-of-year average. Self-contained fetch; renders nothing
- * until CDEC snow data is loaded.
+ * Sierra snowpack by region. In the accumulation season (Oct–Mar) this is
+ * current SWE as a percent of the same-day-of-year average — DWR's
+ * in-season headline. In the melt season (Apr–Sep) it switches to the
+ * season-defining "% of April 1 average". Self-contained fetch; renders
+ * nothing until CDEC snow data is loaded.
  */
 export default function SnowpackSection() {
   const { data, isError } = useSnowpack();
@@ -67,34 +82,41 @@ export default function SnowpackSection() {
 
   if (!data) return null;
 
-  const statewide = data.statewide_pct_of_average;
+  // Melt-season display needs the April-1 figures to exist; fall back to
+  // the same-date presentation when they don't (e.g. sparse history).
+  const melt = isMeltSeason(data.latest_date) && data.statewide_apr1_pct_of_average != null;
+  const statewide = melt
+    ? data.statewide_apr1_pct_of_average
+    : data.statewide_pct_of_average;
 
   return (
     <section aria-label="Snowpack conditions" className="mt-20 max-w-2xl mx-auto">
       <span className="font-label text-xs uppercase tracking-[0.3em] text-on-surface-variant block text-center">
-        Sierra snowpack · {data.latest_date}
+        Sierra snowpack · {melt && data.apr1_date ? `April 1 (${data.apr1_date.slice(0, 4)}) snapshot` : data.latest_date}
       </span>
       <h2 className="font-headline text-3xl md:text-4xl font-bold tracking-tighter text-on-surface text-center mt-4">
         {statewide != null
-          ? `Statewide snowpack is ${statewide.toFixed(0)}% of average`
+          ? melt
+            ? `April 1 snowpack was ${statewide.toFixed(0)}% of average`
+            : `Statewide snowpack is ${statewide.toFixed(0)}% of average`
           : "Sierra snowpack by region"}
       </h2>
       <p className="text-on-surface-variant text-center mt-3">
-        Snow water equivalent vs. the average for this day of year, by DWR
-        region. The tick marks 100% of average.
+        {melt
+          ? "How this season's April 1 snowpack — the typical peak — compared to the April 1 average, by DWR region. The tick marks 100%."
+          : "Snow water equivalent vs. the average for this day of year, by DWR region. The tick marks 100% of average."}
       </p>
 
       <div className="mt-8 space-y-4">
         {data.regions.map((r) => (
-          <RegionRow key={r.region} region={r} />
+          <RegionRow key={r.region} region={r} melt={melt} />
         ))}
       </div>
 
       <p className="text-xs text-on-surface-variant text-center mt-8">
         Source: California Department of Water Resources, California Data
         Exchange Center (CDEC) snow sensors. Snow water equivalent in inches;
-        percent of average is relative to the mean for this calendar day
-        across all loaded years.
+        averages are computed per calendar day across all loaded years.
       </p>
     </section>
   );

--- a/frontend/src/hooks/useSnowpackData.ts
+++ b/frontend/src/hooks/useSnowpackData.ts
@@ -8,11 +8,16 @@ export interface RegionSnowpack {
   swe_in: number;
   avg_swe_in: number | null;
   pct_of_average: number | null;
+  apr1_swe_in: number | null;
+  apr1_avg_swe_in: number | null;
+  apr1_pct_of_average: number | null;
 }
 
 export interface Snowpack {
   latest_date: string;
   statewide_pct_of_average: number | null;
+  apr1_date: string | null;
+  statewide_apr1_pct_of_average: number | null;
   regions: RegionSnowpack[];
 }
 

--- a/frontend/src/pages/WaterPage.tsx
+++ b/frontend/src/pages/WaterPage.tsx
@@ -80,6 +80,14 @@ export default function WaterPage() {
               of historical average
             </p>
           </div>
+          {/* Stale feeds are dropped from the totals (recency cutoff), so
+              the station count is the honest disclosure of what the
+              numbers above are built from. */}
+          {data && (
+            <p className="sm:col-span-3 text-[10px] text-on-surface-variant uppercase tracking-widest">
+              Based on {data.length} reservoir{data.length === 1 ? "" : "s"} reporting
+            </p>
+          )}
         </section>
       )}
 


### PR DESCRIPTION
Implements the top presentation-convention fix from the water ecosystem gap research (report delivered 2026-07-16).

**The problem:** DWR uses two denominators for snowpack. In season, press releases quote "% of average **for this date**" — which is what we shipped. But after April 1 that denominator melts toward zero and the percent becomes garbage; prod's July readout was "9% of a 1.8-inch average." DWR's own products switch to "% of the **April 1 average**" (the typical peak) — the season-defining number every April news cycle quotes.

**Backend:** `/api/water/snowpack` adds an April-1 trio per region + statewide (this season's April-1 reading, the historical April-1 average, the percent) plus `apr1_date` stating exactly which April 1 is meant (during Oct–Mar it's last season's). Data-driven like everything else — no external constants; the historical average uses the full period of record.

**Frontend:** seasonal presentation. Oct–Mar: unchanged (same-date %, matching DWR in-season headlines). Apr–Sep: headline becomes "April 1 snowpack was X% of average" with per-region April-1 bars and current SWE as fine print. Falls back to the same-date view when April-1 history doesn't exist. On today's prod data this turns the noise readout into "April 1 snowpack was N% of average" — the number that actually describes 2026's snow drought.

Also: the statewide reservoir strip now discloses "Based on N reservoirs reporting" — the recency cutoff silently drops dead feeds from the totals, and this makes the denominator honest.

Tests: backend 1094 (3 new — accumulation-season April-1 semantics, melt-season semantics, absent-history), frontend 987 (melt-season presentation + fallback), lint/build clean.