### PR TITLE
feat(etl): alert when a data source drifts past its staleness threshold

### DIFF
--- a/backend/app/freshness_logic.py
+++ b/backend/app/freshness_logic.py
@@ -17,10 +17,94 @@ from datetime import datetime
 from typing import Optional
 
 
+# How many hours before we consider a source "stale". Shared between the
+# /api/freshness router (per-source detail) and the ETL pipeline's stale-source
+# sweep so the two can never drift apart. Historically this lived only in
+# app.routers.freshness, so is_stale existed solely on an endpoint no frontend
+# reads — and every monthly source sat two months stale (2026-07-17) without a
+# single alert. Moving it here lets the scheduler alert on the same numbers.
+DEFAULT_STALENESS_THRESHOLD_HOURS = 168  # 1 week
+
+STALENESS_THRESHOLDS: dict[str, int] = {
+    "crashes_ccrs": 48,      # CHP updates daily; 48h buffer
+    "parties": 48,
+    "victims": 48,
+    "backfill": 48,
+    "backfill_conditions": 48,
+    "matviews": 48,
+    "demographics": 720,     # Census: monthly (30 days)
+    "weather": 720,
+    "hospitals": 720,
+    "schools": 720,
+    "speed_limits": 720,
+    "aadt": 720,
+    "vehicles": 720,
+    "unemployment": 720,
+    "calenviroscreen": 720,
+    "licensed_drivers": 720,
+    "road_miles": 720,
+    "insights": 48,
+    "vacuum": 72,
+    "data_quality": 48,
+    "validate_coords": 48,
+    # Water module: all three run on the daily schedule (drought data only
+    # changes weekly upstream, but the JOB runs daily, and freshness tracks
+    # job success — so 48h catches a broken loader within two cycles).
+    "reservoirs": 48,
+    "snowpack": 48,
+    "drought": 48,
+}
+
+
 def _hours_between(now: datetime, then: Optional[datetime]) -> Optional[float]:
     if then is None:
         return None
     return round((now - then).total_seconds() / 3600, 1)
+
+
+def threshold_for(source: str) -> int:
+    """Staleness threshold for a source, falling back to the 1-week default."""
+    return STALENESS_THRESHOLDS.get(source, DEFAULT_STALENESS_THRESHOLD_HOURS)
+
+
+def stale_sources(
+    now: datetime,
+    last_sync_by_source: dict[str, Optional[datetime]],
+    sources: set[str],
+) -> list[tuple[str, Optional[float], int]]:
+    """Sources overdue for an upstream-sync confirmation.
+
+    Args:
+        now: current time (naive UTC, matching stored timestamps).
+        last_sync_by_source: last confirmed-sync time per source (a successful
+            load OR a verified-unchanged check), from the etl_runs table.
+        sources: the set of source names to evaluate (the live registry jobs).
+
+    Returns:
+        (source, hours_since_sync, threshold_hours) for each stale source,
+        most overdue first (never-synced sources — hours None — lead). A source
+        is stale when it has no recorded sync, or its last sync is older than
+        its threshold.
+    """
+    stale: list[tuple[str, Optional[float], int]] = []
+    for source in sources:
+        threshold = threshold_for(source)
+        last_sync = last_sync_by_source.get(source)
+        is_stale, _, hours_since_check = compute_staleness(
+            now=now,
+            last_load_at=last_sync,
+            last_check_at=last_sync,
+            threshold_hours=threshold,
+        )
+        if is_stale:
+            stale.append((source, hours_since_check, threshold))
+
+    # Most overdue first; never-synced (None) sorts ahead of everything.
+    stale.sort(
+        key=lambda item: item[1] if item[1] is not None else float("inf"),
+        reverse=True,
+    )
+    return stale
 
 
 def compute_staleness(

--- a/backend/app/routers/freshness.py
+++ b/backend/app/routers/freshness.py
@@ -27,7 +27,11 @@ from sqlalchemy import desc, func, text
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.freshness_logic import compute_staleness
+from app.freshness_logic import (
+    DEFAULT_STALENESS_THRESHOLD_HOURS,
+    STALENESS_THRESHOLDS,
+    compute_staleness,
+)
 from app.models import EtlRun
 from app.routers.meta import latest_successful_runs
 
@@ -61,36 +65,9 @@ class FreshnessSummary(BaseModel):
     sources_never_loaded: int
 
 
-# How many hours before we consider a source "stale"
-_STALENESS_THRESHOLDS = {
-    "crashes_ccrs": 48,      # CHP updates daily; 48h buffer
-    "parties": 48,
-    "victims": 48,
-    "backfill": 48,
-    "backfill_conditions": 48,
-    "matviews": 48,
-    "demographics": 720,     # Census: monthly (30 days)
-    "weather": 720,
-    "hospitals": 720,
-    "schools": 720,
-    "speed_limits": 720,
-    "aadt": 720,
-    "vehicles": 720,
-    "unemployment": 720,
-    "calenviroscreen": 720,
-    "licensed_drivers": 720,
-    "road_miles": 720,
-    "insights": 48,
-    "vacuum": 72,
-    "data_quality": 48,
-    "validate_coords": 48,
-    # Water module: all three run on the daily schedule (drought data only
-    # changes weekly upstream, but the JOB runs daily, and freshness tracks
-    # job success — so 48h catches a broken loader within two cycles).
-    "reservoirs": 48,
-    "snowpack": 48,
-    "drought": 48,
-}
+# Staleness thresholds moved to app.freshness_logic so the ETL pipeline's
+# stale-source alert sweep and this API read the same numbers (2026-07-17).
+_STALENESS_THRESHOLDS = STALENESS_THRESHOLDS
 
 
 # deprecated (#291): no frontend callers — the UI reads /api/meta/data-freshness.
@@ -127,7 +104,7 @@ def get_freshness(
     results = []
 
     for run in rows:
-        threshold = _STALENESS_THRESHOLDS.get(run.source, 168)  # default 1 week
+        threshold = _STALENESS_THRESHOLDS.get(run.source, DEFAULT_STALENESS_THRESHOLD_HOURS)
         last_check = last_check_by_source.get(run.source, run.finished_at)
         is_stale, hours_since_load, hours_since_check = compute_staleness(
             now=now,

--- a/backend/etl/pipeline.py
+++ b/backend/etl/pipeline.py
@@ -38,6 +38,10 @@ from etl.alerts import send_alert, send_heartbeat, AlertLevel, check_disk_and_al
 from etl.jobs import build_default_registry
 from etl.orchestrator import run_pipeline
 
+# Statuses that count as "we confirmed sync with upstream" — a successful load
+# OR a verified-unchanged check. Mirrors app.routers.freshness._SYNC_STATUSES.
+_SYNC_STATUSES = ("success", "skipped_unchanged")
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
@@ -155,6 +159,72 @@ def _alert_validation_failures(results, pipeline_name: str) -> None:
     )
 
 
+def _fetch_last_sync_times() -> dict[str, object]:
+    """Last confirmed-sync time per source from etl_runs (success OR unchanged).
+
+    Separated out so the stale-source sweep can be tested without a database.
+    """
+    from sqlalchemy import func  # noqa: PLC0415
+
+    from app.database import SessionLocal  # noqa: PLC0415
+    from app.models import EtlRun  # noqa: PLC0415
+
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(EtlRun.source, func.max(EtlRun.finished_at))
+            .filter(EtlRun.status.in_(_SYNC_STATUSES))
+            .group_by(EtlRun.source)
+            .all()
+        )
+        return {source: finished_at for source, finished_at in rows}
+    finally:
+        db.close()
+
+
+def _alert_stale_sources(registry, pipeline_name: str) -> None:
+    """Alert when a registered source hasn't confirmed sync within its threshold.
+
+    Closes the 2026-07-17 gap: every monthly source (weather, demographics,
+    unemployment, vehicles, calenviroscreen) sat ~2 months stale after the
+    scheduler crash-loop, but is_stale lived only on the deprecated
+    /api/freshness endpoint nobody reads, so no alert ever fired. This sweep
+    runs the same shared thresholds after every pipeline. Best-effort: any
+    failure here must never break the pipeline run.
+    """
+    try:
+        from datetime import datetime, timezone  # noqa: PLC0415
+
+        from app.freshness_logic import stale_sources  # noqa: PLC0415
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        last_sync = _fetch_last_sync_times()
+        sources = set(registry.jobs.keys())
+        stale = stale_sources(now, last_sync, sources)
+        if not stale:
+            return
+
+        def _age(hours):
+            if hours is None:
+                return "never synced"
+            days = hours / 24
+            return f"{days:.0f}d since sync" if days >= 1 else f"{hours:.0f}h since sync"
+
+        details = "\n".join(
+            f"  - {source}: {_age(hours)} (threshold {threshold}h)"
+            for source, hours, threshold in stale
+        )
+        send_alert(
+            AlertLevel.WARNING,
+            f"{pipeline_name}: {len(stale)} data source(s) stale",
+            f"These sources haven't confirmed sync with upstream within their "
+            f"staleness threshold — a loader may be silently failing or the "
+            f"schedule that feeds them isn't running:\n\n{details}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Stale-source sweep failed (non-fatal): %s", exc)
+
+
 def run_daily_pipeline():
     """Execute the standard daily ETL pipeline."""
     logger.info("=" * 60)
@@ -204,6 +274,11 @@ def run_daily_pipeline():
     # alert above.
     _alert_validation_failures(results, "Daily ETL")
 
+    # Alert on any source that has drifted past its staleness threshold —
+    # independent of this run's outcome, since the whole point is to catch
+    # sources whose schedule silently stopped feeding them.
+    _alert_stale_sources(registry, "Daily ETL")
+
     return results
 
 
@@ -236,6 +311,7 @@ def run_weekly_pipeline():
         )
 
     _alert_validation_failures(results, "Weekly refresh")
+    _alert_stale_sources(registry, "Weekly refresh")
 
     return results
 

--- a/backend/tests/test_freshness_logic.py
+++ b/backend/tests/test_freshness_logic.py
@@ -9,7 +9,11 @@ load rarely but are checked daily, so they should read as fresh.
 
 from datetime import datetime, timedelta
 
-from app.freshness_logic import compute_staleness
+from app.freshness_logic import (
+    STALENESS_THRESHOLDS,
+    compute_staleness,
+    stale_sources,
+)
 
 
 NOW = datetime(2026, 6, 30, 12, 0, 0)
@@ -74,3 +78,60 @@ def test_check_exactly_at_threshold_is_not_stale():
         threshold_hours=48,
     )
     assert is_stale is False
+
+
+# ---------------------------------------------------------------------------
+# stale_sources — the sweep the pipeline alerts from (2026-07-17: every
+# monthly source sat 2 months stale and nothing fired, because is_stale
+# lived only on the deprecated /api/freshness endpoint nobody reads).
+# ---------------------------------------------------------------------------
+
+
+def test_stale_sources_flags_only_overdue_sources():
+    checks = {
+        "crashes_ccrs": NOW - timedelta(hours=5),     # fresh (48h threshold)
+        "weather": NOW - timedelta(days=45),          # stale (720h threshold)
+    }
+    stale = stale_sources(NOW, checks, {"crashes_ccrs", "weather"})
+    assert [s[0] for s in stale] == ["weather"]
+    source, hours, threshold = stale[0]
+    assert hours == 1080.0
+    assert threshold == 720
+
+
+def test_stale_sources_never_synced_source_is_stale():
+    stale = stale_sources(NOW, {}, {"weather"})
+    assert len(stale) == 1
+    source, hours, threshold = stale[0]
+    assert source == "weather"
+    assert hours is None
+
+
+def test_stale_sources_unknown_source_uses_default_threshold():
+    # A job not in the thresholds table gets the 1-week default (mirrors
+    # the /api/freshness router behavior).
+    checks = {"brand_new_job": NOW - timedelta(hours=169)}
+    stale = stale_sources(NOW, checks, {"brand_new_job"})
+    assert [s[0] for s in stale] == ["brand_new_job"]
+    assert stale[0][2] == 168
+
+
+def test_stale_sources_oldest_sync_first_with_never_synced_leading():
+    checks = {
+        "weather": NOW - timedelta(days=45),       # 1080h since last sync
+        "crashes_ccrs": NOW - timedelta(days=30),  # 720h since last sync
+    }
+    stale = stale_sources(NOW, checks, {"weather", "crashes_ccrs", "never_loaded"})
+    assert [s[0] for s in stale] == ["never_loaded", "weather", "crashes_ccrs"]
+
+
+def test_stale_sources_empty_when_all_fresh():
+    checks = {"reservoirs": NOW - timedelta(hours=2)}
+    assert stale_sources(NOW, checks, {"reservoirs"}) == []
+
+
+def test_thresholds_table_covers_the_monthly_sources():
+    # The dict moved here from the freshness router so the pipeline sweep
+    # and the API can never drift apart. Pin the sources that motivated it.
+    for source in ("weather", "demographics", "unemployment", "vehicles", "calenviroscreen"):
+        assert STALENESS_THRESHOLDS[source] == 720

--- a/backend/tests/test_pipeline_alerts.py
+++ b/backend/tests/test_pipeline_alerts.py
@@ -142,6 +142,109 @@ class TestDailyPipelineValidationAlerts:
         assert "no details recorded" in body  # None diff_summary handled
 
 
+class TestStaleSourceAlerts:
+    """2026-07-17: every monthly source had been stalled since mid-May and no
+    alert fired — is_stale lived only on the deprecated /api/freshness
+    endpoint. The daily pipeline now sweeps registry jobs against the shared
+    thresholds and sends a WARNING listing stale sources."""
+
+    def _registry(self):
+        return SimpleNamespace(jobs={"crashes_ccrs": object(), "weather": object()})
+
+    def test_stale_source_sends_warning(self, alerts, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        _patch_run(monkeypatch, [_result(source="crashes_ccrs")])
+        monkeypatch.setattr(pipeline, "build_default_registry", self._registry)
+        monkeypatch.setattr(
+            pipeline,
+            "_fetch_last_sync_times",
+            lambda: {
+                "crashes_ccrs": now - timedelta(hours=5),
+                "weather": now - timedelta(days=59),
+            },
+        )
+
+        pipeline.run_daily_pipeline()
+
+        warnings = [c for c in alerts if c[0] == AlertLevel.WARNING]
+        assert len(warnings) == 1
+        _level, title, body = warnings[0]
+        assert "stale" in title
+        assert "weather" in body
+        assert "crashes_ccrs" not in body
+
+    def test_never_synced_source_alerts(self, alerts, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        _patch_run(monkeypatch, [_result(source="crashes_ccrs")])
+        monkeypatch.setattr(pipeline, "build_default_registry", self._registry)
+        monkeypatch.setattr(
+            pipeline,
+            "_fetch_last_sync_times",
+            lambda: {"crashes_ccrs": now - timedelta(hours=5)},
+        )
+
+        pipeline.run_daily_pipeline()
+
+        warnings = [c for c in alerts if c[0] == AlertLevel.WARNING]
+        assert len(warnings) == 1
+        assert "weather" in warnings[0][2]
+        assert "never" in warnings[0][2]
+
+    def test_all_fresh_sends_no_warning(self, alerts, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        _patch_run(monkeypatch, [_result(source="crashes_ccrs")])
+        monkeypatch.setattr(pipeline, "build_default_registry", self._registry)
+        monkeypatch.setattr(
+            pipeline,
+            "_fetch_last_sync_times",
+            lambda: {
+                "crashes_ccrs": now - timedelta(hours=5),
+                "weather": now - timedelta(days=2),
+            },
+        )
+
+        pipeline.run_daily_pipeline()
+
+        assert _levels(alerts) == [AlertLevel.INFO]
+
+    def test_sweep_failure_never_breaks_the_pipeline(self, alerts, monkeypatch):
+        def _boom():
+            raise RuntimeError("db unreachable")
+
+        _patch_run(monkeypatch, [_result(source="crashes_ccrs")])
+        monkeypatch.setattr(pipeline, "build_default_registry", self._registry)
+        monkeypatch.setattr(pipeline, "_fetch_last_sync_times", _boom)
+
+        results = pipeline.run_daily_pipeline()
+
+        assert results  # pipeline still returned its results
+        assert _levels(alerts) == [AlertLevel.INFO]
+
+    def test_weekly_pipeline_also_sweeps(self, alerts, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        _patch_run(monkeypatch, [_result(source="crashes_ccrs")])
+        monkeypatch.setattr(pipeline, "build_default_registry", self._registry)
+        monkeypatch.setattr(
+            pipeline,
+            "_fetch_last_sync_times",
+            lambda: {"crashes_ccrs": now, "weather": now - timedelta(days=59)},
+        )
+
+        pipeline.run_weekly_pipeline()
+
+        warnings = [c for c in alerts if c[0] == AlertLevel.WARNING]
+        assert len(warnings) == 1
+        assert "weather" in warnings[0][2]
+
+
 class TestWeeklyPipelineValidationAlerts:
     def test_failed_validation_sends_warning(self, alerts, monkeypatch):
         _patch_run(monkeypatch, [


### PR DESCRIPTION
## The gap this closes
For ~2 months every monthly-cadence source (weather, demographics, unemployment, vehicles, calenviroscreen) sat stale after the scheduler crash-loop — and **nothing alerted**. `is_stale` was computed only inside `GET /api/freshness`, a deprecated endpoint the frontend never reads and no external monitor polls. The pipelines alerted on job *failures*, but a source that silently stopped being fed (its schedule broke, or its loader added nothing) produced no signal at all.

Discovered while researching weather gaps: `/api/freshness` showed weather last loaded 2026-05-19 with `is_stale: false`, and the weather table had zero 2026 rows.

## Change
- **Move the thresholds table** out of `app/routers/freshness.py` into `app/freshness_logic.py` (`STALENESS_THRESHOLDS` + `DEFAULT_STALENESS_THRESHOLD_HOURS`), so the API and the new pipeline sweep read the *same* numbers and can never drift. The router now imports them (pure refactor — same dict).
- **`freshness_logic.stale_sources()`**: pure, DB-free helper returning overdue sources, most-overdue-first, never-synced leading.
- **`pipeline._alert_stale_sources()`**: after each daily and weekly run, sweeps the live job registry against those thresholds and sends a single `WARNING` listing any stale sources. Best-effort — a sweep error is logged and swallowed so it can never break the pipeline. `_fetch_last_sync_times()` isolates the DB query (`success`/`skipped_unchanged` = confirmed sync) for testability.

## Why an alert, not a code fix to the schedule
The monthly sources self-heal on the next weekly_full (Sun). The real defect was *silence* — this makes the same staleness the API already knew about actually page someone.

## Testing (TDD)
- `stale_sources` ordering / threshold / never-synced / all-fresh cases — DB-free.
- Pipeline paths: stale warns, never-synced warns, all-fresh stays INFO-only, sweep failure is swallowed, weekly also sweeps.
- **23 unit tests pass**; **10 DB-backed freshness API tests pass** against real Postgres (router refactor verified end to end); ruff clean.