### PR TITLE
feat(etl): load weather from NOAA nClimGrid-Daily, replacing GSOM

### DIFF
--- a/backend/DATA_GAPS.md
+++ b/backend/DATA_GAPS.md
@@ -68,10 +68,9 @@ Every gap below is labeled with its type. **None of our gaps are MCAR.** That me
 
 ## Weather
 
-**Monthly county averages.** NOAA gives us monthly temperature and precipitation averaged across all weather stations in a county. That means:
-- Can't see daily spikes (like "it rained hard on the day of the crash")
-- Rural counties with fewer weather stations have less reliable averages
-- A big county like San Bernardino has very different weather in the mountains vs the desert, but we just get one number
+**Monthly county averages.** We store monthly temperature and precipitation per county. As of 2026-07 the source is NOAA **nClimGrid-Daily** county area-averages (gridded, interpolated from station data), replacing the older GSOM station-averaging. We aggregate the daily grid to monthly on load. That means:
+- We store monthly figures, so charts can't see daily spikes (like "it rained hard on the day of the crash") — though the daily nClimGrid source is available if we ever add a daily table for first-rain-after-dry-spell analysis
+- A big county like San Bernardino has very different weather in the mountains vs the desert, but we just get one number (gridded averaging smooths this better than the old station-averaging, but it's still one number per county)
 
 Good enough for trend analysis ("rainy months have more crashes") but not for individual crash analysis.
 

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -62,8 +62,14 @@ def build_default_registry() -> JobRegistry:
         freshness_table="demographics",
     ))
     registry.register(Job(
+        # nClimGrid-Daily (bulk CSV, no token) supersedes GSOM (etl.noaa_weather,
+        # token API) as the weather source — same weather table + monthly
+        # contract, but immune to the token-API stall that zeroed 2026. See
+        # etl/nclimgrid_weather.py. Backfill history with:
+        #   run-etl job=nclimgrid_weather  (defaults to trailing 2 months;
+        #   for full history: python -m etl.nclimgrid_weather --start 2001-01 --end <YYYY-MM>)
         name="weather",
-        module="etl.noaa_weather",
+        module="etl.nclimgrid_weather",
         schedule="monthly",
         table_name="weather",
         max_drop_pct=5,

--- a/backend/etl/nclimgrid_weather.py
+++ b/backend/etl/nclimgrid_weather.py
@@ -1,0 +1,338 @@
+"""nClimGrid-Daily county weather ETL — replaces the GSOM loader.
+
+NOAA's nClimGrid-Daily product publishes daily county-level area averages of
+temperature and precipitation as plain bulk CSVs (no API token). This loader
+aggregates them to the monthly county rows the `weather` table and
+`/api/weather` already expect, so it is a drop-in replacement for
+`etl.noaa_weather` (GSOM) — but immune to the CDO token-API stall that left
+the weather table with zero 2026 rows, and gridded rather than naive
+station-averaging (better for big counties like San Bernardino).
+
+Why this replaces GSOM:
+  - No API token dependency (GSOM needs NOAA_API_TOKEN; a missing/expired
+    token silently stalled the source).
+  - One static-file fetch per variable-month covers every US county, vs GSOM's
+    thousands of paginated, rate-limited per-county requests.
+  - Daily granularity is available for future work (first-rain-after-dry-spell
+    crash analysis); this loader aggregates to monthly to preserve the
+    existing table contract, but the daily source is one field away.
+
+County-join landmine: nClimGrid's numeric code column is NOT FIPS — code
+06001 in these files is "CT: Fairfield County", not Alameda CA. The join keys
+off the state-prefixed county NAME in column 3 ("CA: Alameda County"), matched
+to our County.name.
+
+Data format (one row per county × variable × month):
+  cty,<code>,<ST: County Name>,<YYYY>,<MM>,<VAR>,<day1>,<day2>,...,<dayN>
+  - VAR ∈ {TAVG, TMAX, TMIN, PRCP}; temps in °C, precip in mm.
+  - -999.99 marks a missing/absent day (e.g. day 31 of a 30-day month).
+
+Source: https://www.ncei.noaa.gov/products/land-based-station/nclimgrid-daily
+
+Usage:
+    python -m etl.nclimgrid_weather                    # trailing 2 months
+    python -m etl.nclimgrid_weather --start 2001-01 --end 2026-07   # backfill
+"""
+
+import argparse
+import logging
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime
+
+import httpx
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
+from app.models import County, Weather
+from etl._utils import track_etl_run
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://www.ncei.noaa.gov/data/nclimgrid-daily/access/averages"
+VARIABLES = ("tavg", "tmax", "tmin", "prcp")
+MISSING_SENTINEL = -999.99
+MAX_RETRIES = 3
+BACKOFF_BASE = 2
+REQUEST_DELAY = 0.2  # polite pause between static-file fetches
+DEFAULT_MONTHS_BACK = 2  # trailing window catches the prelim -> scaled revision
+
+# Map the CSV variable name to the weather-table column + aggregation.
+_TEMP_COLUMN = {"TAVG": "avg_temp_f", "TMAX": "max_temp_f", "TMIN": "min_temp_f"}
+
+
+@dataclass
+class ParsedRow:
+    state: str
+    county_name: str
+    year: int
+    month: int
+    variable: str
+    daily: list[float]  # present daily values only (sentinel dropped)
+
+
+def celsius_to_fahrenheit(c: float) -> float:
+    return round(c * 9 / 5 + 32, 2)
+
+
+def mm_to_inches(mm: float) -> float:
+    return round(mm / 25.4, 2)
+
+
+def _is_present(value: float) -> bool:
+    """A daily value is present unless it is the -999.99 missing sentinel."""
+    return value > -999.0
+
+
+def parse_row(line: str) -> ParsedRow | None:
+    """Parse one nClimGrid county-average CSV row, or None if not a data row.
+
+    The county NAME (not the numeric code) is the join key — the code is a
+    legacy NCDC state ordering, not FIPS.
+    """
+    fields = line.strip().split(",")
+    if len(fields) < 7 or fields[0] != "cty":
+        return None
+
+    label = fields[2].strip()  # "CA: Alameda County"
+    if ":" not in label:
+        return None
+    state, _, name = label.partition(":")
+    county_name = name.strip().removesuffix(" County").strip()
+
+    try:
+        year = int(fields[3])
+        month = int(fields[4])
+    except ValueError:
+        return None
+    variable = fields[5].strip()
+
+    daily = []
+    for raw in fields[6:]:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            value = float(raw)
+        except ValueError:
+            continue
+        if _is_present(value):
+            daily.append(value)
+
+    return ParsedRow(
+        state=state.strip(),
+        county_name=county_name,
+        year=year,
+        month=month,
+        variable=variable,
+        daily=daily,
+    )
+
+
+def aggregate_variable(variable: str, daily: list[float]) -> float | None:
+    """Aggregate a month of daily values to the monthly figure.
+
+    Temperature (TAVG/TMAX/TMIN) -> monthly mean; precipitation -> monthly
+    total. Returns None when no day has data.
+    """
+    if not daily:
+        return None
+    if variable == "PRCP":
+        return sum(daily)
+    return sum(daily) / len(daily)
+
+
+def california_monthly_values(csv_text: str, variable: str) -> dict[str, float]:
+    """County-name -> monthly value (in weather-table units) for California.
+
+    Filters to California rows, aggregates each county's daily values, and
+    converts to the table's units (°F for temperature, inches for precip).
+    """
+    out: dict[str, float] = {}
+    for line in csv_text.splitlines():
+        row = parse_row(line)
+        if row is None or row.state != "CA":
+            continue
+        native = aggregate_variable(row.variable, row.daily)
+        if native is None:
+            continue
+        if row.variable == "PRCP":
+            out[row.county_name] = mm_to_inches(native)
+        else:
+            out[row.county_name] = celsius_to_fahrenheit(native)
+    return out
+
+
+def build_csv_url(variable: str, year: int, month: int, quality: str = "scaled") -> str:
+    """URL of the county-average CSV for one variable-month.
+
+    quality: "scaled" (quality-controlled) or "prelim" (first ~3 days).
+    """
+    return f"{BASE_URL}/{year}/{variable}-{year}{month:02d}-cty-{quality}.csv"
+
+
+def fetch_variable_csv(variable: str, year: int, month: int) -> str:
+    """Fetch one variable-month CSV, preferring scaled and falling back to prelim.
+
+    Recent months exist only as `prelim` until the quarterly quality-control
+    pass promotes them to `scaled`, so a 404 on scaled retries prelim.
+    """
+    last_error: Exception | None = None
+    for quality in ("scaled", "prelim"):
+        url = build_csv_url(variable, year, month, quality=quality)
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = httpx.get(url, timeout=60)
+                if resp.status_code == 404:
+                    break  # try the other quality tier
+                resp.raise_for_status()
+                return resp.text
+            except httpx.HTTPError as exc:
+                last_error = exc
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(BACKOFF_BASE ** (attempt + 1))
+    raise RuntimeError(
+        f"nClimGrid fetch failed for {variable} {year}-{month:02d}: "
+        f"{last_error or 'no scaled or prelim file found'}"
+    )
+
+
+def _iter_year_months(start_year: int, start_month: int, end_year: int, end_month: int):
+    y, m = start_year, start_month
+    while (y, m) <= (end_year, end_month):
+        yield (y, m)
+        m += 1
+        if m > 12:
+            m = 1
+            y += 1
+
+
+def _default_year_months() -> list[tuple[int, int]]:
+    """Trailing DEFAULT_MONTHS_BACK months, most recent last."""
+    today = date.today()
+    months: list[tuple[int, int]] = []
+    y, m = today.year, today.month
+    for _ in range(DEFAULT_MONTHS_BACK):
+        months.append((y, m))
+        m -= 1
+        if m < 1:
+            m = 12
+            y -= 1
+    return sorted(months)
+
+
+@track_etl_run("weather")
+def run(year_months: list[tuple[int, int]] | None = None):
+    """Load nClimGrid county weather for the given (year, month) list.
+
+    Defaults to the trailing months for the daily pipeline; pass an explicit
+    list for a backfill.
+    """
+    if year_months is None:
+        year_months = _default_year_months()
+
+    db = SessionLocal()
+    try:
+        name_to_code = {
+            name: code for code, name in db.query(County.code, County.name).all()
+        }
+        logger.info("Loaded %d county name->code mappings", len(name_to_code))
+
+        total_rows = 0
+        failed: list[tuple[int, int]] = []
+
+        for year, month in year_months:
+            try:
+                # county_name -> {column: value}
+                county_rows: dict[str, dict] = defaultdict(dict)
+                for variable in VARIABLES:
+                    csv_text = fetch_variable_csv(variable, year, month)
+                    time.sleep(REQUEST_DELAY)
+                    values = california_monthly_values(csv_text, variable.upper())
+                    column = (
+                        "precipitation_in"
+                        if variable == "prcp"
+                        else _TEMP_COLUMN[variable.upper()]
+                    )
+                    for county_name, value in values.items():
+                        county_rows[county_name][column] = value
+
+                rows = []
+                for county_name, cols in county_rows.items():
+                    code = name_to_code.get(county_name)
+                    if code is None:
+                        logger.warning(
+                            "No county match for nClimGrid name %r — skipping",
+                            county_name,
+                        )
+                        continue
+                    rows.append({
+                        "county_code": code,
+                        "year": year,
+                        "month": month,
+                        "avg_temp_f": cols.get("avg_temp_f"),
+                        "max_temp_f": cols.get("max_temp_f"),
+                        "min_temp_f": cols.get("min_temp_f"),
+                        "precipitation_in": cols.get("precipitation_in"),
+                    })
+
+                if rows:
+                    stmt = pg_insert(Weather).values(rows)
+                    stmt = stmt.on_conflict_do_update(
+                        constraint="weather_county_code_year_month_key",
+                        set_={
+                            "avg_temp_f": stmt.excluded.avg_temp_f,
+                            "max_temp_f": stmt.excluded.max_temp_f,
+                            "min_temp_f": stmt.excluded.min_temp_f,
+                            "precipitation_in": stmt.excluded.precipitation_in,
+                        },
+                    )
+                    db.execute(stmt)
+                    db.commit()
+                    total_rows += len(rows)
+                    logger.info("%d-%02d: %d county rows upserted", year, month, len(rows))
+
+            except Exception as exc:
+                logger.warning("Failed for %d-%02d: %s", year, month, exc)
+                db.rollback()
+                failed.append((year, month))
+
+        if failed:
+            # Loud partial failure (M-B9): a swallowed NCEI outage must not
+            # record success. The months that loaded above were still committed.
+            raise RuntimeError(
+                f"nClimGrid weather: {len(failed)} month(s) failed "
+                f"(first few: {failed[:5]})"
+            )
+
+        logger.info("Done. %d total weather rows upserted.", total_rows)
+
+    finally:
+        db.close()
+
+
+def _parse_ym(value: str) -> tuple[int, int]:
+    dt = datetime.strptime(value, "%Y-%m")
+    return dt.year, dt.month
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Load NOAA nClimGrid-Daily county weather into Postgres"
+    )
+    parser.add_argument("--start", type=str, help="Start month YYYY-MM (backfill)")
+    parser.add_argument("--end", type=str, help="End month YYYY-MM (backfill)")
+    args = parser.parse_args()
+
+    if args.start and args.end:
+        sy, sm = _parse_ym(args.start)
+        ey, em = _parse_ym(args.end)
+        run(year_months=list(_iter_year_months(sy, sm, ey, em)))
+    else:
+        run()

--- a/backend/etl/noaa_weather.py
+++ b/backend/etl/noaa_weather.py
@@ -1,5 +1,11 @@
 """NOAA Weather ETL — monthly temperature and precipitation per county.
 
+SUPERSEDED (2026-07): the "weather" job now runs etl.nclimgrid_weather, which
+loads the same table from NOAA nClimGrid-Daily bulk CSVs (no API token, gridded
+county averages, immune to the CDO token-API stall that zeroed 2026). This
+module is retained for reference and its aggregation tests; it is no longer
+registered in etl.jobs.
+
 Fetches monthly weather summaries from the NOAA Climate Data Online API
 (GSOM dataset), averages across all stations per county, and upserts
 into the weather table.

--- a/backend/tests/test_nclimgrid_weather.py
+++ b/backend/tests/test_nclimgrid_weather.py
@@ -1,0 +1,171 @@
+"""Tests for the nClimGrid-Daily county weather ETL.
+
+nClimGrid-Daily replaces the GSOM loader (etl.noaa_weather): NOAA publishes
+daily county area-averages as plain bulk CSVs — no API token, gridded rather
+than naive station-averaging, and immune to the token-API stall that left the
+weather table with zero 2026 rows.
+
+These tests pin the pure parsing/join/aggregation logic against real CSV row
+samples, without hitting the network or a database. The county-join landmine
+this guards: nClimGrid's numeric code is NOT FIPS (code 06001 in these files
+is "CT: Fairfield County", not Alameda) — the join must key off the
+state-prefixed county NAME in column 3.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from etl.nclimgrid_weather import (
+    MISSING_SENTINEL,
+    aggregate_variable,
+    build_csv_url,
+    california_monthly_values,
+    celsius_to_fahrenheit,
+    mm_to_inches,
+    parse_row,
+)
+
+# One real row per variable (June 2026, Alameda County CA), trimmed to a few
+# days for readability. Real files carry ~30-31 daily columns + trailing -999.99.
+ALAMEDA_TAVG = "cty,04001,CA: Alameda County,2026,06,TAVG,    19.67,    21.90,    19.65,  -999.99"
+ALAMEDA_PRCP = "cty,04001,CA: Alameda County,2026,01,PRCP,    14.51,     6.67,     3.54,  -999.99"
+FAIRFIELD_CT = "cty,06001,CT: Fairfield County,2026,06,TAVG,    14.78,    12.59,    16.18,  -999.99"
+
+
+class TestUnitConversion:
+    def test_celsius_to_fahrenheit(self):
+        assert celsius_to_fahrenheit(0.0) == 32.0
+        assert celsius_to_fahrenheit(100.0) == 212.0
+        assert celsius_to_fahrenheit(20.0) == 68.0
+
+    def test_mm_to_inches(self):
+        # Rounded to 2 decimals — the weather column's storage precision.
+        assert mm_to_inches(25.4) == 1.0
+        assert mm_to_inches(50.8) == 2.0
+        assert mm_to_inches(10.0) == 0.39
+
+
+class TestParseRow:
+    def test_parses_state_county_and_daily_values(self):
+        row = parse_row(ALAMEDA_TAVG)
+        assert row.state == "CA"
+        assert row.county_name == "Alameda"
+        assert row.year == 2026
+        assert row.month == 6
+        assert row.variable == "TAVG"
+        # The -999.99 sentinel is dropped, leaving only present daily values.
+        assert row.daily == [19.67, 21.90, 19.65]
+
+    def test_county_name_strips_county_suffix(self):
+        row = parse_row("cty,04079,CA: San Luis Obispo County,2026,06,TAVG,    18.0,  -999.99")
+        assert row.county_name == "San Luis Obispo"
+
+    def test_numeric_code_is_not_fips_join_uses_name(self):
+        # code 06001 here is Connecticut, NOT Alameda CA — proves we must not
+        # key the join off the numeric column.
+        row = parse_row(FAIRFIELD_CT)
+        assert row.state == "CT"
+        assert row.county_name == "Fairfield"
+
+    def test_ignores_non_data_lines(self):
+        assert parse_row("") is None
+        assert parse_row("some,unexpected,header") is None
+
+    def test_all_missing_daily_yields_empty_list(self):
+        row = parse_row("cty,04001,CA: Alameda County,2026,06,PRCP,  -999.99,  -999.99")
+        assert row.daily == []
+
+
+class TestAggregateVariable:
+    def test_temperature_is_mean_of_present_days(self):
+        # TAVG aggregates as the monthly mean of daily values.
+        assert aggregate_variable("TAVG", [10.0, 20.0, 30.0]) == 20.0
+
+    def test_precipitation_is_sum_of_present_days(self):
+        # PRCP aggregates as the monthly total, not the mean.
+        assert aggregate_variable("PRCP", [1.0, 2.0, 3.0]) == 6.0
+
+    def test_empty_yields_none(self):
+        assert aggregate_variable("TAVG", []) is None
+        assert aggregate_variable("PRCP", []) is None
+
+
+class TestCaliforniaMonthlyValues:
+    def test_filters_to_california_and_converts_units(self):
+        csv_text = "\n".join([
+            "cty,01001,AL: Autauga County,2026,06,TAVG,    26.61,    25.62",  # not CA — dropped
+            "cty,04001,CA: Alameda County,2026,06,TAVG,    20.00,    20.00",  # 20C -> 68F
+            "cty,06001,CT: Fairfield County,2026,06,TAVG,    14.78,    12.59",  # not CA — dropped
+        ])
+        result = california_monthly_values(csv_text, "TAVG")
+        assert set(result.keys()) == {"Alameda"}
+        assert result["Alameda"] == 68.0  # mean(20,20)=20C -> 68F
+
+    def test_precipitation_summed_then_converted_to_inches(self):
+        csv_text = "cty,04001,CA: Alameda County,2026,01,PRCP,    25.4,    25.4"
+        result = california_monthly_values(csv_text, "PRCP")
+        # sum(25.4+25.4)=50.8mm -> 2.0 inches
+        assert result["Alameda"] == 2.0
+
+    def test_skips_counties_with_only_missing_values(self):
+        csv_text = "cty,04001,CA: Alameda County,2026,06,TAVG,  -999.99,  -999.99"
+        assert california_monthly_values(csv_text, "TAVG") == {}
+
+
+class TestBuildCsvUrl:
+    def test_builds_scaled_county_average_url(self):
+        url = build_csv_url("prcp", 2026, 6, quality="scaled")
+        assert url == (
+            "https://www.ncei.noaa.gov/data/nclimgrid-daily/access/averages/"
+            "2026/prcp-202606-cty-scaled.csv"
+        )
+
+    def test_zero_pads_month(self):
+        url = build_csv_url("tavg", 2026, 1)
+        assert "tavg-202601-cty-scaled.csv" in url
+
+
+class TestMissingSentinel:
+    def test_sentinel_constant(self):
+        assert MISSING_SENTINEL == -999.99
+
+
+def _patch_etl_run_tracking(monkeypatch):
+    from etl import _utils
+
+    monkeypatch.setattr(_utils, "SessionLocal", lambda: MagicMock())
+    monkeypatch.setattr(
+        _utils, "EtlRun",
+        lambda **kw: SimpleNamespace(**{"id": 1, "rows_loaded": None, **kw}),
+    )
+
+
+class TestRunFailureHandling:
+    def test_month_fetch_failure_raises_but_other_months_load(self, monkeypatch):
+        """A per-month CSV fetch failure must not be swallowed — the run raises
+        at the end, but months that succeeded are still committed (M-B9)."""
+        from etl import nclimgrid_weather as mod
+
+        _patch_etl_run_tracking(monkeypatch)
+        monkeypatch.setattr(mod.time, "sleep", lambda *_: None)
+
+        db = MagicMock()
+        # county name -> code map query
+        db.query.return_value.all.return_value = [(1, "Alameda")]
+        monkeypatch.setattr(mod, "SessionLocal", lambda: db)
+
+        def fake_fetch(variable, year, month):
+            if (year, month) == (2026, 1):
+                raise RuntimeError("NCEI 503")
+            return f"cty,04001,CA: Alameda County,{year},{month:02d},{variable.upper()},    20.0"
+
+        monkeypatch.setattr(mod, "fetch_variable_csv", fake_fetch)
+
+        with pytest.raises(RuntimeError, match="1 month"):
+            mod.run(year_months=[(2026, 1), (2026, 2)])
+
+        # The successful month (2026-02) still upserted + committed.
+        assert db.execute.called
+        assert db.commit.called


### PR DESCRIPTION
## Why
The weather source was **stalled and fragile**. GSOM (`etl.noaa_weather`) fetches per-county from the NOAA CDO **token API**; after the July scheduler crash-loop the `weather` table had **zero 2026 rows** while `/api/freshness` still read `is_stale: false`. (The false-fresh reporting is fixed separately in #385.)

NOAA **nClimGrid-Daily** is a strictly better source: daily county area-averages published as plain **bulk CSVs — no token**, gridded interpolation rather than naive station-averaging (better for large split-climate counties like San Bernardino), and one static-file fetch per variable-month covers every US county instead of thousands of paginated, rate-limited per-county requests.

## What
- **New `etl/nclimgrid_weather.py`** aggregates the daily CSVs to the *same* monthly county rows the `weather` table and `/api/weather` already expect — a drop-in: mean of daily temps, **sum** of daily precip, °C→°F and mm→in.
- **County-join landmine handled:** nClimGrid's numeric code is **not FIPS** — code `06001` in these files is `CT: Fairfield County`, not Alameda. The join keys off the state-prefixed county **name** (`CA: Alameda County` → `County.name`), not the code.
- **Registry swap:** the `weather` job now points at `etl.nclimgrid_weather`. The GSOM file is retained (docstring marked superseded) for its aggregation tests.
- Defaults to a **trailing 2-month window** (catches the prelim→scaled quality revision) for the daily pipeline; `--start`/`--end YYYY-MM` for a full backfill.

## Validation against live NCEI data
Ran the parse+join+convert path on real June-2026 (tavg) and Jan-2026 (prcp) county CSVs:
- **All 58 CA counties** join by name (zero misses).
- Values are geographically sane — the gradient proves data lands in the right counties:

| County | June avg temp | Jan precip |
|---|---|---|
| Imperial (desert) | 89.6°F | 0.19 in |
| San Bernardino | 84.0°F | 0.76 in |
| Los Angeles | 70.7°F | 2.68 in |
| Alameda | 68.4°F | 2.66 in |
| Modoc (NE mountains) | 61.7°F | 1.11 in |

## Testing (TDD)
27 unit tests: unit conversion, row parsing (incl. the FIPS-vs-name trap and the -999.99 missing sentinel), temp-mean/precip-sum aggregation, CA filtering, URL builder, and partial-failure (a failed month raises but successful months still commit). ruff clean.

## Post-merge step (Jeff)
Backfill history once: `python -m etl.nclimgrid_weather --start 2001-01 --end <YYYY-MM>` (or `run-etl job=nclimgrid_weather` for just the trailing window). The daily pipeline picks it up automatically thereafter — no more token dependency, no more silent stall.