### PR TITLE
feat(water): Sierra precipitation indices (8SI/5SI/6SI)

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1087,6 +1087,36 @@ class SnowDaily(Base):
     )
 
 
+class PrecipIndexDaily(Base):
+    """Daily accumulated water-year precipitation for a DWR regional index.
+
+    One row per index station (8SI/5SI/6SI) per day. The value is CDEC
+    sensor 2 (accumulated inches), already cumulative from Oct 1. Station
+    metadata (name, region) is static in etl/cdec_api.PRECIP_INDEX_STATIONS;
+    percent-of-average-for-this-date is derived at query time from
+    same-day-of-year history, exactly like reservoir_daily and snow_daily.
+
+    Source: DWR California Data Exchange Center (cdec.water.ca.gov).
+    """
+
+    __tablename__ = "precip_index_daily"
+
+    id = Column(Integer, primary_key=True)
+    station_id = Column(String(10), nullable=False)  # CDEC index id, e.g. "8SI"
+    date = Column(Date, nullable=False)
+    accum_in = Column(Float, nullable=False)  # accumulated water-year precip, inches
+    created_at = Column(DateTime, server_default=func.now())
+
+    # As with snow_daily/reservoir_daily: the unique constraint's index serves
+    # (station_id, date); the migration adds an expression index on
+    # (station_id, extract(month), extract(day)) for the day-of-year query.
+    __table_args__ = (
+        UniqueConstraint(
+            "station_id", "date", name="uq_precip_index_daily_station_date"
+        ),
+    )
+
+
 class DroughtCountyWeekly(Base):
     """Weekly drought severity per county — US Drought Monitor.
 

--- a/backend/app/routers/freshness.py
+++ b/backend/app/routers/freshness.py
@@ -90,6 +90,7 @@ _STALENESS_THRESHOLDS = {
     "reservoirs": 48,
     "snowpack": 48,
     "drought": 48,
+    "precip_indices": 48,
 }
 
 

--- a/backend/app/routers/water.py
+++ b/backend/app/routers/water.py
@@ -12,6 +12,7 @@ from app.database import get_db
 from app.models import (
     County,
     DroughtCountyWeekly,
+    PrecipIndexDaily,
     Reservoir,
     ReservoirDaily,
     SnowDaily,
@@ -23,6 +24,7 @@ from app.schemas.drought import (
     DroughtSnapshotOut,
     DroughtWeekPoint,
 )
+from app.schemas.precip import PrecipIndexOut
 from app.schemas.snow import RegionSnowpack, SnowpackOut
 from app.rate_limit import rate_limit_key
 from app.schemas.water import (
@@ -210,6 +212,61 @@ def reservoir_series(
             ReservoirSeriesPoint(date=d, storage_af=s) for d, s in points
         ],
     )
+
+
+# A precip index's latest reading must be within this many days of the newest
+# across the three indices to count as current — same rationale as reservoirs.
+_PRECIP_RECENCY_DAYS = 14
+
+
+@router.get("/water/precip", response_model=list[PrecipIndexOut])
+@_limiter.limit("1000/minute;20000/hour")
+def precip_indices(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    """DWR's three regional precipitation indices (8SI/5SI/6SI) with their
+    latest accumulated water-year total and percent of the historical average
+    for that day of year. The 8-Station Index is the headline Northern Sierra
+    wet-season number."""
+    response.headers["Cache-Control"] = _ONE_HOUR
+
+    # Imported here (not at module top) to keep the ETL station map — an ETL
+    # concern — out of the API module's import surface, matching how the
+    # water endpoints already avoid importing loader internals.
+    from etl.cdec_api import PRECIP_INDEX_STATIONS
+
+    conditions = latest_with_doy_average(
+        db, PrecipIndexDaily, PrecipIndexDaily.accum_in
+    )
+    if not conditions:
+        raise HTTPException(status_code=404, detail="No precip-index data loaded")
+
+    newest = max(c.latest_date for c in conditions.values())
+    cutoff = newest - timedelta(days=_PRECIP_RECENCY_DAYS)
+
+    out = []
+    for station_id, meta in PRECIP_INDEX_STATIONS.items():
+        c = conditions.get(station_id)
+        if c is None or c.latest_date < cutoff:
+            continue
+        out.append(
+            PrecipIndexOut(
+                station_id=station_id,
+                name=meta["name"],
+                region=meta["region"],
+                latest_date=c.latest_date,
+                accum_in=round(c.value, 1),
+                avg_accum_in=round(c.avg, 1) if c.has_history else None,
+                pct_of_average=(
+                    round(c.value / c.avg * 100, 1)
+                    if c.has_history and c.avg > 0
+                    else None
+                ),
+            )
+        )
+    return out
 
 
 _PCT_COLS = ("none_pct", "d0_pct", "d1_pct", "d2_pct", "d3_pct", "d4_pct")

--- a/backend/app/schemas/precip.py
+++ b/backend/app/schemas/precip.py
@@ -1,0 +1,22 @@
+"""Response models for /api/water/precip."""
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class PrecipIndexOut(BaseModel):
+    """One DWR regional precipitation index's latest accumulated total.
+
+    accum_in is the water-year-to-date precipitation; pct_of_average compares
+    it to the same-day-of-year historical average (None until >1 year of
+    history exists), exactly like the reservoir and snowpack conventions.
+    """
+
+    station_id: str          # CDEC index id, e.g. "8SI"
+    name: str
+    region: str
+    latest_date: date
+    accum_in: float
+    avg_accum_in: float | None = None  # same-day-of-year average (None until history)
+    pct_of_average: float | None = None

--- a/backend/etl/cdec_api.py
+++ b/backend/etl/cdec_api.py
@@ -52,8 +52,26 @@ REQUEST_DELAY = 0.5  # courtesy delay between batched requests
 SENSOR_STORAGE = 15  # reservoir storage, acre-feet
 SENSOR_SNOW_WATER_CONTENT = 3  # snow water content (raw daily SWE), inches
 SENSOR_SNOW_WATER_CONTENT_REVISED = 82  # DWR-adjusted daily SWE, inches
+SENSOR_PRECIP_ACCUM = 2  # accumulated precipitation (water-year total), inches
 
 MISSING_VALUE = -9999
+
+# DWR's three regional precipitation indices — the headline California
+# wet-season numbers journalists reproduce every winter. Each is itself a
+# CDEC "station" whose sensor 2 reports the region's accumulated water-year
+# precipitation (inches), so no per-gauge aggregation is needed: one index =
+# one region. Station codes + station counts verified live 2026-07 against the
+# CDEC JSONDataServlet (sensor 2 returns "RAIN"/INCHES cumulative). The
+# 8-Station Index is the canonical Northern Sierra figure.
+PRECIP_REGION_NORTH = "Northern Sierra (8-Station)"
+PRECIP_REGION_SANJOAQUIN = "San Joaquin (5-Station)"
+PRECIP_REGION_TULARE = "Tulare Basin (6-Station)"
+
+PRECIP_INDEX_STATIONS = {
+    "8SI": {"name": "Northern Sierra 8-Station Index", "region": PRECIP_REGION_NORTH},
+    "5SI": {"name": "San Joaquin 5-Station Index", "region": PRECIP_REGION_SANJOAQUIN},
+    "6SI": {"name": "Tulare Basin 6-Station Index", "region": PRECIP_REGION_TULARE},
+}
 
 # DWR groups its ~130 electronic snow sensors into three Sierra regions and
 # reports each as a percent of average. These are five verified snow-pillow
@@ -259,6 +277,18 @@ def fetch_snow_water_content(start: date, end: date) -> list[Observation]:
     raw = fetch_sensor_data(
         stations=sorted(MAJOR_SNOW_STATIONS),
         sensor=SENSOR_SNOW_WATER_CONTENT,
+        start=start,
+        end=end,
+    )
+    return parse_observations(raw)
+
+
+def fetch_precip_indices(start: date, end: date) -> list[Observation]:
+    """Fetch daily accumulated water-year precipitation for the three DWR
+    regional indices (8SI/5SI/6SI). Sensor 2 is the cumulative total."""
+    raw = fetch_sensor_data(
+        stations=sorted(PRECIP_INDEX_STATIONS),
+        sensor=SENSOR_PRECIP_ACCUM,
         start=start,
         end=end,
     )

--- a/backend/etl/jobs.py
+++ b/backend/etl/jobs.py
@@ -237,6 +237,17 @@ def build_default_registry() -> JobRegistry:
         source_type="none",
     ))
     registry.register(Job(
+        name="precip_indices",
+        module="etl.load_precip_indices",
+        # Accumulated water-year precip for the 8SI/5SI/6SI indices; daily
+        # trailing-window pull. Like the other CDEC jobs, no freshness probe.
+        schedule="daily",
+        table_name="precip_index_daily",
+        # Upserts never delete; a shrink means CDEC data vanished — fail loudly.
+        max_drop_pct=1,
+        source_type="none",
+    ))
+    registry.register(Job(
         name="drought",
         module="etl.load_drought",
         # The pipeline runs every non-static job on its daily cadence

--- a/backend/etl/load_precip_indices.py
+++ b/backend/etl/load_precip_indices.py
@@ -1,0 +1,141 @@
+"""Precipitation-index ETL — daily accumulated water-year precip for the
+three DWR regional indices (CDEC 8SI/5SI/6SI, sensor 2).
+
+Fetches daily accumulated precipitation (inches, cumulative from Oct 1) from
+the CDEC JSON servlet and upserts into precip_index_daily. Each index is
+itself a CDEC station, so there is no per-gauge aggregation and no station
+table — metadata lives in the static PRECIP_INDEX_STATIONS map.
+
+Like reservoirs and snowpack, the value resets each water year and the trailing
+window keeps the current year fresh; --backfill loads the multi-decade history
+for the day-of-year percent-of-average baseline.
+
+Source: DWR California Data Exchange Center (cdec.water.ca.gov).
+
+Usage:
+    python -m etl.load_precip_indices                    # trailing 120 days
+    python -m etl.load_precip_indices --start 2025-10-01 --end 2026-07-01
+    python -m etl.load_precip_indices --backfill         # from 2000-01-01
+"""
+
+import argparse
+import logging
+import sys
+import time
+from datetime import date, timedelta
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.database import EtlSessionLocal as SessionLocal  # write/DDL role
+from app.models import PrecipIndexDaily
+from etl._utils import date_windows, dedupe_rows, track_etl_run
+from etl.cdec_api import (
+    PRECIP_INDEX_STATIONS,
+    REQUEST_DELAY,
+    Observation,
+    fetch_precip_indices,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+DEFAULT_TRAILING_DAYS = 120
+BACKFILL_START = date(2000, 1, 1)
+BATCH_SIZE = 1000
+
+
+def upsert_observations(db, observations: list[Observation]) -> int:
+    """Bulk-upsert daily accumulated-precip rows keyed on (station_id, date)."""
+    known = set(PRECIP_INDEX_STATIONS)
+    rows = []
+    skipped = 0
+    for obs in observations:
+        if obs.station_id not in known:
+            skipped += 1
+            continue
+        rows.append(
+            {
+                "station_id": obs.station_id,
+                "date": obs.date,
+                # Accumulated precip is monotonic and non-negative; clamp any
+                # small negative telemetry drift to zero (mirrors snowpack).
+                "accum_in": max(obs.value, 0.0),
+            }
+        )
+    if skipped:
+        logger.warning(
+            "Dropped %d observations for stations not in PRECIP_INDEX_STATIONS",
+            skipped,
+        )
+
+    # CDEC can return an original plus a revised reading for one station-day;
+    # duplicate conflict keys in a single statement are a Postgres error.
+    rows = dedupe_rows(rows, key=("station_id", "date"))
+
+    for i in range(0, len(rows), BATCH_SIZE):
+        batch = rows[i : i + BATCH_SIZE]
+        stmt = pg_insert(PrecipIndexDaily).values(batch)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_precip_index_daily_station_date",
+            set_={"accum_in": stmt.excluded.accum_in},
+        )
+        db.execute(stmt)
+        db.commit()
+
+    return len(rows)
+
+
+@track_etl_run("precip_indices")
+def run(start: date, end: date) -> int:
+    """Fetch and upsert accumulated precip for [start, end]. Returns rows loaded."""
+    db = SessionLocal()
+    try:
+        total = 0
+        windows = date_windows(start, end)
+        for i, (win_start, win_end) in enumerate(windows):
+            if i:
+                time.sleep(REQUEST_DELAY)
+            logger.info(
+                "Window %d/%d: %s → %s", i + 1, len(windows), win_start, win_end
+            )
+            observations = fetch_precip_indices(win_start, win_end)
+            total += upsert_observations(db, observations)
+
+        logger.info("Done. %d daily precip-index rows upserted.", total)
+        return total
+    finally:
+        db.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Load CDEC Sierra precipitation indices (8SI/5SI/6SI)"
+    )
+    parser.add_argument("--start", type=date.fromisoformat)
+    parser.add_argument("--end", type=date.fromisoformat)
+    parser.add_argument(
+        "--backfill",
+        action="store_true",
+        help=f"load everything from {BACKFILL_START} (overrides --start)",
+    )
+    args = parser.parse_args()
+
+    end = args.end or date.today()
+    if args.backfill:
+        start = BACKFILL_START
+    else:
+        start = args.start or end - timedelta(days=DEFAULT_TRAILING_DAYS)
+
+    if start > end:
+        parser.error(f"--start {start} is after --end {end}")
+
+    run(start, end)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/migrations/versions/9ded93edd291_add_precip_index_daily.py
+++ b/backend/migrations/versions/9ded93edd291_add_precip_index_daily.py
@@ -1,0 +1,63 @@
+"""add precip_index_daily table (water module — Sierra precipitation indices)
+
+Daily accumulated water-year precipitation for DWR's three regional indices
+(8SI/5SI/6SI). New empty table — plain CREATE TABLE. Mirrors snow_daily: the
+unique constraint backs (station_id, date) lookups, plus an expression index
+on (station_id, extract(month), extract(day)) INCLUDE (accum_in) for the
+day-of-year percent-of-average query. Grants SELECT to the read-only API role
+where it exists. No station-metadata table — the three indices are static in
+etl/cdec_api.PRECIP_INDEX_STATIONS.
+
+Revision ID: 9ded93edd291
+Revises: e09358c7c0d1
+Create Date: 2026-07-17 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "9ded93edd291"
+down_revision: Union[str, None] = "e09358c7c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "precip_index_daily",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("station_id", sa.String(length=10), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("accum_in", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "station_id", "date", name="uq_precip_index_daily_station_date"
+        ),
+    )
+    op.execute(
+        """
+        CREATE INDEX ix_precip_index_daily_station_doy ON precip_index_daily
+            (station_id, EXTRACT(month FROM date), EXTRACT(day FROM date))
+            INCLUDE (accum_in)
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'calsight_api_ro') THEN
+                GRANT SELECT ON precip_index_daily TO calsight_api_ro;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_precip_index_daily_station_doy", table_name="precip_index_daily"
+    )
+    op.drop_table("precip_index_daily")

--- a/backend/tests/api/test_precip.py
+++ b/backend/tests/api/test_precip.py
@@ -1,0 +1,62 @@
+"""Integration tests for /api/water/precip (Sierra precipitation indices)."""
+
+from datetime import date
+
+import pytest
+
+from app.models import PrecipIndexDaily
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def precip_data(db_session):
+    """8SI has 3 years of Jan-15 history (avg 40, latest 60 → 150%). 5SI has a
+    single reading (no usable history)."""
+    db_session.add_all([
+        PrecipIndexDaily(station_id="8SI", date=date(2024, 1, 15), accum_in=20.0),
+        PrecipIndexDaily(station_id="8SI", date=date(2025, 1, 15), accum_in=40.0),
+        PrecipIndexDaily(station_id="8SI", date=date(2026, 1, 15), accum_in=60.0),  # latest
+        # An off-cycle reading that must not pollute the Jan-15 average.
+        PrecipIndexDaily(station_id="8SI", date=date(2026, 1, 10), accum_in=55.0),
+        PrecipIndexDaily(station_id="5SI", date=date(2026, 1, 15), accum_in=34.0),
+    ])
+    db_session.commit()
+    return db_session
+
+
+def test_precip_index_pct_of_same_day_average(client, precip_data):
+    body = client.get("/api/water/precip").json()
+    north = next(r for r in body if r["station_id"] == "8SI")
+    assert north["region"] == "Northern Sierra (8-Station)"
+    assert north["latest_date"] == "2026-01-15"
+    assert north["accum_in"] == pytest.approx(60.0)
+    assert north["avg_accum_in"] == pytest.approx(40.0)  # (20+40+60)/3
+    assert north["pct_of_average"] == pytest.approx(150.0)
+
+
+def test_precip_index_without_history_has_no_pct(client, precip_data):
+    body = client.get("/api/water/precip").json()
+    sj = next(r for r in body if r["station_id"] == "5SI")
+    assert sj["accum_in"] == pytest.approx(34.0)
+    assert sj["pct_of_average"] is None
+    assert sj["avg_accum_in"] is None
+
+
+def test_precip_excludes_stale_index(client, db_session):
+    """An index whose feed died years ago must not appear with a stale value."""
+    db_session.add_all([
+        PrecipIndexDaily(station_id="8SI", date=date(2026, 1, 15), accum_in=60.0),
+        # 6SI last reported in 2019 — far outside the recency window.
+        PrecipIndexDaily(station_id="6SI", date=date(2019, 1, 15), accum_in=25.0),
+    ])
+    db_session.commit()
+
+    body = client.get("/api/water/precip").json()
+    ids = {r["station_id"] for r in body}
+    assert "8SI" in ids
+    assert "6SI" not in ids
+
+
+def test_precip_404_without_data(client):
+    assert client.get("/api/water/precip").status_code == 404

--- a/backend/tests/test_load_precip_indices.py
+++ b/backend/tests/test_load_precip_indices.py
@@ -1,0 +1,109 @@
+"""Tests for the Sierra precipitation-index ETL (CDEC 8SI/5SI/6SI).
+
+The precip indices are CDEC's three regional precipitation stations — the
+famous 8-Station Index (Northern Sierra) plus the San Joaquin 5-Station and
+Tulare Basin 6-Station indices. Sensor 2 reports the accumulated water-year
+precipitation total (inches), so the value is already cumulative; the loader
+stores it as-is and the API derives percent-of-average-for-this-date the same
+way reservoirs and snowpack do.
+
+These tests pin the fetch wiring and the upsert (station filtering + dedupe)
+without hitting the network or a database.
+"""
+
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from etl import cdec_api
+from etl import load_precip_indices as mod
+from etl.cdec_api import (
+    PRECIP_INDEX_STATIONS,
+    SENSOR_PRECIP_ACCUM,
+    Observation,
+)
+
+
+class TestPrecipIndexStations:
+    def test_three_regional_indices_present(self):
+        assert set(PRECIP_INDEX_STATIONS) == {"8SI", "5SI", "6SI"}
+
+    def test_each_index_has_a_region_and_name(self):
+        for meta in PRECIP_INDEX_STATIONS.values():
+            assert meta["region"]
+            assert meta["name"]
+
+    def test_accumulation_sensor_is_2(self):
+        assert SENSOR_PRECIP_ACCUM == 2
+
+
+class TestFetchWiring:
+    def test_fetch_uses_the_three_index_stations_and_accum_sensor(self, monkeypatch):
+        captured = {}
+
+        def fake_fetch_sensor_data(stations, sensor, start, end, duration="D"):
+            captured["stations"] = stations
+            captured["sensor"] = sensor
+            return []
+
+        monkeypatch.setattr(cdec_api, "fetch_sensor_data", fake_fetch_sensor_data)
+        cdec_api.fetch_precip_indices(date(2026, 1, 1), date(2026, 1, 2))
+
+        assert set(captured["stations"]) == {"8SI", "5SI", "6SI"}
+        assert captured["sensor"] == SENSOR_PRECIP_ACCUM
+
+
+class TestUpsertObservations:
+    def _obs(self, station, d, value):
+        return Observation(station_id=station, sensor=2, date=d, value=value, units="INCHES")
+
+    def test_filters_to_known_index_stations(self):
+        db = MagicMock()
+        observations = [
+            self._obs("8SI", date(2026, 1, 1), 50.5),
+            self._obs("ZZZ", date(2026, 1, 1), 1.0),  # unknown — dropped
+        ]
+        loaded = mod.upsert_observations(db, observations)
+        assert loaded == 1
+
+    def test_dedupes_duplicate_station_date(self):
+        db = MagicMock()
+        observations = [
+            self._obs("8SI", date(2026, 1, 1), 50.5),
+            self._obs("8SI", date(2026, 1, 1), 50.6),  # revised same-day reading
+        ]
+        loaded = mod.upsert_observations(db, observations)
+        assert loaded == 1
+
+    def test_empty_is_noop(self):
+        db = MagicMock()
+        assert mod.upsert_observations(db, []) == 0
+
+
+def _patch_etl_run_tracking(monkeypatch):
+    from etl import _utils
+
+    monkeypatch.setattr(_utils, "SessionLocal", lambda: MagicMock())
+    monkeypatch.setattr(
+        _utils, "EtlRun",
+        lambda **kw: SimpleNamespace(**{"id": 1, "rows_loaded": None, **kw}),
+    )
+
+
+class TestRun:
+    def test_run_fetches_upserts_and_returns_count(self, monkeypatch):
+        _patch_etl_run_tracking(monkeypatch)
+        monkeypatch.setattr(mod.time, "sleep", lambda *_: None)
+
+        db = MagicMock()
+        monkeypatch.setattr(mod, "SessionLocal", lambda: db)
+        monkeypatch.setattr(
+            mod, "fetch_precip_indices",
+            lambda s, e: [Observation("8SI", 2, date(2026, 1, 1), 50.5, "INCHES")],
+        )
+
+        total = mod.run(date(2026, 1, 1), date(2026, 1, 1))
+
+        assert total == 1
+        assert db.execute.called
+        assert db.commit.called

--- a/backend/tests/test_orchestrator.py
+++ b/backend/tests/test_orchestrator.py
@@ -74,7 +74,7 @@ def test_resolve_detects_missing_dependency():
 
 def test_default_registry_has_all_jobs():
     registry = build_default_registry()
-    assert len(registry.jobs) == 28  # +3: reservoirs + drought + snowpack (water module)
+    assert len(registry.jobs) == 29  # +4: reservoirs + drought + snowpack + precip_indices (water module)
 
 
 def test_default_registry_resolves_without_error():


### PR DESCRIPTION
## Why
Completes the precip/snow/storage **triad** on the water module. The **8-Station Index** (Northern Sierra) is *the* headline California wet-season number journalists reproduce every winter; the San Joaquin 5-Station and Tulare Basin 6-Station indices cover the rest of the Sierra. This was the top-ranked "v3 quick win" in the water-gaps research — live-verified as an existing-client build.

Each index is itself a CDEC station whose **sensor 2** reports the region's accumulated water-year precipitation, so one index = one region — no per-gauge aggregation, and the value is already cumulative from Oct 1.

## Backend vertical slice (mirrors reservoir/snowpack exactly)
- **cdec_api.py**: `PRECIP_INDEX_STATIONS` (8SI/5SI/6SI → region+name) + `SENSOR_PRECIP_ACCUM` + `fetch_precip_indices()`.
- **`PrecipIndexDaily` model + migration** `9ded93edd291` (single head off `e09358c7c0d1`): table + day-of-year expression index `INCLUDE (accum_in)` + read-only-role GRANT, same shape as `snow_daily`.
- **`etl/load_precip_indices.py`**: trailing-window loader (`--backfill` for history), registered as a daily `source_type=none` job with a 48h freshness threshold (matching the other CDEC jobs — and now covered by the stale-source alert in #385).
- **`GET /api/water/precip`**: each index's latest accumulated total + percent of the same-day-of-year average, **reusing the existing `latest_with_doy_average` helper** and the reservoir recency-cutoff. Cache-Control 1h like the other water endpoints.

## Validation
- **Live CDEC fetch** returns the correct north→south gradient for WY2026: 8SI **50.8"**, 5SI **35.0"**, 6SI **24.1"**.
- **DB-backed endpoint tests** (against real Postgres) confirm the migration DDL applies and percent-of-average is derived correctly (150% case, no-history case, stale-index exclusion, 404-without-data).

## Testing (TDD)
12 unit tests (station map, fetch wiring, upsert filtering/dedupe, run) + 4 integration tests; ruff clean; snowpack tests still green (no regression to the shared helper).

## Follow-ups
- Frontend: a cumulative water-year chart on `/water` (still behind `WATER_PAGE_PUBLIC`).
- Post-merge: backfill history with `python -m etl.load_precip_indices --backfill` (daily pipeline maintains it thereafter).