### PR TITLE
feat(water): precipitation-index section on the water page

### DIFF
--- a/frontend/src/components/water/PrecipSection.test.tsx
+++ b/frontend/src/components/water/PrecipSection.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import PrecipSection from "./PrecipSection";
+import type { PrecipIndex } from "../../hooks/usePrecipData";
+
+const PRECIP: PrecipIndex[] = [
+  { station_id: "8SI", name: "Northern Sierra 8-Station Index", region: "Northern Sierra (8-Station)", latest_date: "2026-07-17", accum_in: 50.8, avg_accum_in: 40.0, pct_of_average: 127 },
+  { station_id: "5SI", name: "San Joaquin 5-Station Index", region: "San Joaquin (5-Station)", latest_date: "2026-07-17", accum_in: 35.0, avg_accum_in: 30.0, pct_of_average: 117 },
+  { station_id: "6SI", name: "Tulare Basin 6-Station Index", region: "Tulare Basin (6-Station)", latest_date: "2026-07-17", accum_in: 24.1, avg_accum_in: null, pct_of_average: null },
+];
+
+function mockApi(precip: PrecipIndex[] | null) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes("/api/water/precip")) {
+      if (precip === null) return new Response("not found", { status: 404 });
+      return new Response(JSON.stringify(precip), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+}
+
+function renderSection() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<PrecipSection />, { wrapper });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("PrecipSection", () => {
+  it("headlines the 8-Station Index percent of average", async () => {
+    mockApi(PRECIP);
+    renderSection();
+    expect(
+      await screen.findByRole("heading", { name: /8-Station Index is 127% of average/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a bar per index with its percent and accumulated total", async () => {
+    mockApi(PRECIP);
+    renderSection();
+    await screen.findByRole("heading", { name: /8-Station Index/ });
+    const north = screen.getByRole("progressbar", { name: /Northern Sierra/ });
+    expect(north).toHaveAttribute("aria-valuenow", "127");
+    expect(screen.getByText(/50.8″ so far this water year/)).toBeInTheDocument();
+  });
+
+  it("shows a dash for an index with no comparable history", async () => {
+    mockApi(PRECIP);
+    renderSection();
+    const tulare = await screen.findByRole("progressbar", { name: /Tulare Basin.*no comparison/i });
+    expect(tulare).not.toHaveAttribute("aria-valuenow");
+  });
+
+  it("credits CDEC precipitation indices", async () => {
+    mockApi(PRECIP);
+    renderSection();
+    expect(
+      await screen.findByText(/California Data Exchange Center \(CDEC\)/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when no precip data is loaded", async () => {
+    mockApi(null);
+    const { container } = renderSection();
+    await waitFor(() => expect(container.innerHTML).toBe(""));
+  });
+
+  it("shows an error state instead of vanishing when the fetch fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => new Response("boom", { status: 500 }),
+    );
+    renderSection();
+    expect(await screen.findByRole("alert")).toHaveTextContent(/precipitation/i);
+  });
+
+  it("falls back to a neutral heading when the 8-Station Index has no percent", async () => {
+    const noHistory = PRECIP.map((p) =>
+      p.station_id === "8SI" ? { ...p, avg_accum_in: null, pct_of_average: null } : p,
+    );
+    mockApi(noHistory);
+    renderSection();
+    expect(
+      await screen.findByRole("heading", { name: /Sierra precipitation by index/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/water/PrecipSection.tsx
+++ b/frontend/src/components/water/PrecipSection.tsx
@@ -1,0 +1,109 @@
+import { usePrecipIndices, type PrecipIndex } from "../../hooks/usePrecipData";
+
+/** Percent-of-average → a bar fill fraction, capped at 200% so a huge wet
+ * year doesn't blow out the layout (mirrors SnowpackSection). */
+function barFraction(pct: number): number {
+  return Math.min(pct, 200) / 200;
+}
+
+/** The 8-Station Index (Northern Sierra) is the marquee California
+ * wet-season number, so it drives the section headline. */
+const HEADLINE_INDEX = "8SI";
+
+function IndexRow({ index }: { index: PrecipIndex }) {
+  const pct = index.pct_of_average;
+  return (
+    <div className="grid grid-cols-[10rem_1fr_4rem] items-center gap-3">
+      <div className="min-w-0">
+        <p className="text-sm text-on-surface truncate">{index.region}</p>
+        <p className="text-[10px] text-on-surface-variant">
+          {index.accum_in.toFixed(1)}″ so far this water year
+        </p>
+      </div>
+      <div
+        className="relative h-2 bg-surface-container-high rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuenow={pct != null ? Math.round(pct) : undefined}
+        aria-valuemin={0}
+        aria-valuemax={200}
+        aria-label={`${index.region}: ${pct != null ? `${pct.toFixed(0)}% of average` : "no comparison available"}`}
+      >
+        {pct != null && (
+          <div
+            className="h-full bg-primary rounded-full transition-all"
+            style={{ width: `${barFraction(pct) * 100}%` }}
+          />
+        )}
+        {/* 100%-of-average reference tick */}
+        <div
+          aria-hidden="true"
+          className="absolute top-0 h-full w-0.5 bg-on-surface"
+          style={{ left: "50%" }}
+          title="100% of average"
+        />
+      </div>
+      <span className="text-xs text-on-surface-variant text-right tabular-nums">
+        {pct != null ? `${pct.toFixed(0)}%` : "—"}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * DWR's three regional precipitation indices (8SI/5SI/6SI) as accumulated
+ * water-year precipitation versus the average for this day of year. The
+ * 8-Station Index headlines. Self-contained fetch; renders nothing until CDEC
+ * precip-index data is loaded.
+ */
+export default function PrecipSection() {
+  const { data, isError } = usePrecipIndices();
+
+  // A failed fetch is not the same as "no data loaded yet" (404 → null): the
+  // section must not silently vanish on an outage.
+  if (isError) {
+    return (
+      <section aria-label="Precipitation indices" className="mt-20 max-w-2xl mx-auto">
+        <p role="alert" className="text-center text-error py-8">
+          Couldn&rsquo;t load precipitation conditions. Please try again shortly.
+        </p>
+      </section>
+    );
+  }
+
+  if (!data || data.length === 0) return null;
+
+  const headline = data.find((d) => d.station_id === HEADLINE_INDEX);
+  const headlinePct =
+    headline != null ? headline.pct_of_average : null;
+  const latestDate = data[0].latest_date;
+
+  return (
+    <section aria-label="Precipitation indices" className="mt-20 max-w-2xl mx-auto">
+      <span className="font-label text-xs uppercase tracking-[0.3em] text-on-surface-variant block text-center">
+        Sierra precipitation · {latestDate}
+      </span>
+      <h2 className="font-headline text-3xl md:text-4xl font-bold tracking-tighter text-on-surface text-center mt-4">
+        {headlinePct != null
+          ? `The 8-Station Index is ${headlinePct.toFixed(0)}% of average`
+          : "Sierra precipitation by index"}
+      </h2>
+      <p className="text-on-surface-variant text-center mt-3">
+        Accumulated precipitation since October 1 vs. the average for this day
+        of the water year, by DWR index. The tick marks 100% of average.
+      </p>
+
+      <div className="mt-8 space-y-4">
+        {data.map((index) => (
+          <IndexRow key={index.station_id} index={index} />
+        ))}
+      </div>
+
+      <p className="text-xs text-on-surface-variant text-center mt-8">
+        Source: California Department of Water Resources, California Data
+        Exchange Center (CDEC) precipitation indices. Accumulated inches since
+        October 1; averages are computed per calendar day across all loaded
+        years.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/hooks/usePrecipData.ts
+++ b/frontend/src/hooks/usePrecipData.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { API_BASE } from "../config";
+
+export interface PrecipIndex {
+  station_id: string; // CDEC index id, e.g. "8SI"
+  name: string;
+  region: string;
+  latest_date: string;
+  accum_in: number; // accumulated water-year precipitation, inches
+  avg_accum_in: number | null; // same-day-of-year average (null until history)
+  pct_of_average: number | null;
+}
+
+export function usePrecipIndices() {
+  return useQuery<PrecipIndex[] | null>({
+    queryKey: ["water", "precip"],
+    queryFn: async () => {
+      const res = await fetch(`${API_BASE}/api/water/precip`);
+      // 404 = no precip-index data loaded yet — the section hides itself.
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`water/precip ${res.status}`);
+      return res.json();
+    },
+    staleTime: 60 * 60 * 1000,
+  });
+}

--- a/frontend/src/pages/WaterPage.test.tsx
+++ b/frontend/src/pages/WaterPage.test.tsx
@@ -50,6 +50,10 @@ function renderPage(rows: ReservoirCondition[] | Error) {
       // No snowpack data either — that section hides itself too.
       return new Response("not found", { status: 404 });
     }
+    if (url.includes("/api/water/precip")) {
+      // No precip-index data either — that section hides itself too.
+      return new Response("not found", { status: 404 });
+    }
     throw new Error(`unexpected fetch: ${url}`);
   });
   const client = new QueryClient({

--- a/frontend/src/pages/WaterPage.tsx
+++ b/frontend/src/pages/WaterPage.tsx
@@ -1,5 +1,6 @@
 import MetaTags from "../components/seo/MetaTags";
 import DroughtSection from "../components/water/DroughtSection";
+import PrecipSection from "../components/water/PrecipSection";
 import ReservoirCard from "../components/water/ReservoirCard";
 import SnowpackSection from "../components/water/SnowpackSection";
 import {
@@ -109,6 +110,8 @@ export default function WaterPage() {
       </p>
 
       <SnowpackSection />
+
+      <PrecipSection />
 
       <DroughtSection />
     </main>


### PR DESCRIPTION
## Summary
Surfaces the Sierra precipitation indices (from #387's `GET /api/water/precip`) as a section on `/water`, **completing the precip/snow/storage triad in the UI**. This is the frontend follow-on flagged in #387.

> **Stacked on #387** — base branch is `feat/precip-indices` (this section needs that endpoint). Merge #387 first; this then retargets to main automatically.

## Design
Mirrors the existing tested `SnowpackSection` exactly for visual + code consistency:
- One **percent-of-average bar per DWR index** (8SI / 5SI / 6SI) with a 100%-of-average reference tick.
- Accumulated water-year total ("50.8″ so far this water year") as the per-row detail.
- The **8-Station Index** — the headline California wet-season number — drives the section headline ("The 8-Station Index is N% of average"), with a neutral fallback before history exists.
- Self-contained fetch: hides on 404 (no data yet), shows an error state on failure so it never silently vanishes on an outage.
- Still behind `WATER_PAGE_PUBLIC`.

## Testing
7 component tests (headline, per-index bars, no-history dash, source credit, empty/error states, neutral-headline fallback); WaterPage test updated to mock the new fetch. Full frontend suite **137 files / 1009 tests green**, tsc + eslint clean. No new Material Symbols icons (icon-subset test still green).