### PR TITLE
perf: serve street aggregation from a materialized view

### DIFF
--- a/backend/app/health.py
+++ b/backend/app/health.py
@@ -15,7 +15,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 # Single source of truth for the MV names the API serves from.
-# etl/refresh_materialized_views.py imports this list.
+# These gate the site-wide "rebuilding" banner: if one is unpopulated, the
+# pages that depend on it have no data to show.
 MATERIALIZED_VIEWS: tuple[str, ...] = (
     "mv_crashes_by_year",
     "mv_crashes_by_cause",
@@ -26,6 +27,19 @@ MATERIALIZED_VIEWS: tuple[str, ...] = (
     "mv_crash_rates",
     "mv_crashes_wide",
 )
+
+# Views that are refreshed nightly but must NOT gate the rebuilding banner,
+# because the API degrades gracefully without them rather than going blank.
+# etl/refresh_materialized_views.py refreshes MATERIALIZED_VIEWS + these.
+#
+# mv_street_aggregates is an optimization: /api/intersections and
+# /api/corridors fall back to querying the raw crashes table when it isn't
+# populated. Slow is not the same as broken, so an unpopulated street view
+# shouldn't put a banner across the whole site.
+OPTIONAL_MATERIALIZED_VIEWS: tuple[str, ...] = ("mv_street_aggregates",)
+
+# Everything the nightly refresh job maintains.
+REFRESHABLE_VIEWS: tuple[str, ...] = MATERIALIZED_VIEWS + OPTIONAL_MATERIALIZED_VIEWS
 
 
 def is_rebuilding(db: Session, views: Iterable[str] | None = None) -> bool:

--- a/backend/app/routers/intersections.py
+++ b/backend/app/routers/intersections.py
@@ -180,7 +180,7 @@ def _norm(col):
 
 # ── Materialized-view fast path ────────────────────────────────────────
 #
-# mv_street_aggregates (migration a5b6c7d8e9f0) pre-normalizes road names and
+# mv_street_aggregates (migration c4f1a9b2d3e7) pre-normalizes road names and
 # pre-rolls crashes up to (county, primary, secondary, year, ped, cyc). The
 # endpoints then aggregate that narrow table instead of scanning 11.3M raw
 # crashes with two regexp_replace calls per row.

--- a/backend/app/routers/intersections.py
+++ b/backend/app/routers/intersections.py
@@ -30,7 +30,6 @@ from slowapi import Limiter
 from app.rate_limit import rate_limit_key
 from sqlalchemy import (
     BigInteger,
-    Boolean,
     Column,
     Float,
     MetaData,
@@ -201,8 +200,12 @@ mv_street_aggregates = Table(
     Column("secondary_road", String),
     # 0 rather than NULL for "unknown year", same reason.
     Column("crash_year", SmallInteger),
-    Column("pedestrian_involved", Boolean),
-    Column("cyclist_involved", Boolean),
+    # Three-valued, NOT booleans: 0 = false, 1 = true, 2 = unknown (NULL on
+    # crashes). The endpoints filter with IS TRUE / IS FALSE, which both
+    # exclude NULL, so collapsing unknown into false would quietly widen
+    # every `?cyclist=false` result.
+    Column("pedestrian_state", SmallInteger),
+    Column("cyclist_state", SmallInteger),
     Column("crash_count", BigInteger),
     Column("fatal_count", BigInteger),
     Column("injury_count", BigInteger),
@@ -279,10 +282,12 @@ def _aggregate_from_mv(
         preds.append(mv.c.crash_year >= year_start)
     if year_end is not None:
         preds.append(mv.c.crash_year <= year_end)
+    # `IS TRUE` -> state 1, `IS FALSE` -> state 0. State 2 (unknown) matches
+    # neither, exactly as NULL matches neither IS TRUE nor IS FALSE.
     if pedestrian is not None:
-        preds.append(mv.c.pedestrian_involved.is_(pedestrian))
+        preds.append(mv.c.pedestrian_state == (1 if pedestrian else 0))
     if cyclist is not None:
-        preds.append(mv.c.cyclist_involved.is_(cyclist))
+        preds.append(mv.c.cyclist_state == (1 if cyclist else 0))
 
     group_cols = [mv.c.county_code, mv.c.primary_road]
     if by_secondary:

--- a/backend/app/routers/intersections.py
+++ b/backend/app/routers/intersections.py
@@ -28,7 +28,23 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 from slowapi import Limiter
 from app.rate_limit import rate_limit_key
-from sqlalchemy import Float, and_, case, cast, func, null, select
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Column,
+    Float,
+    MetaData,
+    SmallInteger,
+    String,
+    Table,
+    and_,
+    case,
+    cast,
+    func,
+    null,
+    select,
+    text,
+)
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
@@ -160,6 +176,180 @@ class ConcentrationOut(BaseModel):
 def _norm(col):
     """Normalize a road-name column for grouping: UPPER(collapse-whitespace(TRIM()))."""
     return func.upper(func.regexp_replace(func.trim(col), r"\s+", " ", "g"))
+
+
+# ── Materialized-view fast path ────────────────────────────────────────
+#
+# mv_street_aggregates (migration a5b6c7d8e9f0) pre-normalizes road names and
+# pre-rolls crashes up to (county, primary, secondary, year, ped, cyc). The
+# endpoints then aggregate that narrow table instead of scanning 11.3M raw
+# crashes with two regexp_replace calls per row.
+#
+# It is created WITH NO DATA and populated by the nightly refresh, so every
+# read is guarded by _mv_populated() and falls back to the live query. Slow is
+# better than wrong, and much better than 503.
+
+_mv_meta = MetaData()
+
+mv_street_aggregates = Table(
+    "mv_street_aggregates",
+    _mv_meta,
+    Column("county_code", SmallInteger),
+    Column("primary_road", String),
+    # '' rather than NULL for "no secondary road" — REFRESH CONCURRENTLY needs
+    # a unique index, and NULLs would defeat it.
+    Column("secondary_road", String),
+    # 0 rather than NULL for "unknown year", same reason.
+    Column("crash_year", SmallInteger),
+    Column("pedestrian_involved", Boolean),
+    Column("cyclist_involved", Boolean),
+    Column("crash_count", BigInteger),
+    Column("fatal_count", BigInteger),
+    Column("injury_count", BigInteger),
+    Column("pdo_count", BigInteger),
+    Column("killed", BigInteger),
+    Column("injured", BigInteger),
+    Column("lat_sum", Float),
+    Column("lat_n", BigInteger),
+    Column("lon_sum", Float),
+    Column("lon_n", BigInteger),
+)
+
+_MV_NAME = "mv_street_aggregates"
+# The view only flips to populated once (the first refresh after deploy), so a
+# short cache is plenty and keeps a catalog round-trip off every request.
+_MV_POPULATED_TTL_SECONDS = 60
+_mv_populated_cache: tuple[float, bool] | None = None
+
+
+def _mv_populated(db: Session) -> bool:
+    """Whether the street matview exists and has been populated at least once."""
+    global _mv_populated_cache
+    now = time.monotonic()
+    if _mv_populated_cache is not None and _mv_populated_cache[0] > now:
+        return _mv_populated_cache[1]
+    try:
+        populated = bool(
+            db.execute(
+                text(
+                    "SELECT relispopulated FROM pg_class "
+                    "WHERE relname = :name AND relkind = 'm'"
+                ),
+                {"name": _MV_NAME},
+            ).scalar()
+        )
+    except Exception:  # noqa: BLE001 — never let the probe break the endpoint
+        logger.warning("%s population probe failed; using the live query", _MV_NAME, exc_info=True)
+        populated = False
+    _mv_populated_cache = (now + _MV_POPULATED_TTL_SECONDS, populated)
+    return populated
+
+
+def reset_mv_populated_cache() -> None:
+    """Test hook: forget whether the matview was populated."""
+    global _mv_populated_cache
+    _mv_populated_cache = None
+
+
+def _aggregate_from_mv(
+    db: Session,
+    *,
+    by_secondary: bool,
+    county_code: int | None,
+    year_start: int | None,
+    year_end: int | None,
+    min_crashes: int,
+    limit: int,
+    pedestrian: bool | None,
+    cyclist: bool | None,
+    sort: str,
+) -> list[IntersectionOut]:
+    """Same result as _aggregate, read from the pre-rolled-up matview."""
+    mv = mv_street_aggregates
+
+    preds = []
+    if by_secondary:
+        # Rows with no secondary road are corridor-only; '' is the sentinel.
+        preds.append(mv.c.secondary_road != "")
+    if county_code is not None:
+        preds.append(mv.c.county_code == county_code)
+    # crash_year 0 means "unknown", so a year bound excludes it — matching the
+    # raw query, where NULL >= year_start is NULL and drops the row.
+    if year_start is not None:
+        preds.append(mv.c.crash_year >= year_start)
+    if year_end is not None:
+        preds.append(mv.c.crash_year <= year_end)
+    if pedestrian is not None:
+        preds.append(mv.c.pedestrian_involved.is_(pedestrian))
+    if cyclist is not None:
+        preds.append(mv.c.cyclist_involved.is_(cyclist))
+
+    group_cols = [mv.c.county_code, mv.c.primary_road]
+    if by_secondary:
+        group_cols.append(mv.c.secondary_road)
+
+    crashes = func.sum(mv.c.crash_count)
+    fatal = func.sum(mv.c.fatal_count)
+    injury = func.sum(mv.c.injury_count)
+    pdo = func.sum(mv.c.pdo_count)
+    severity_score = fatal * _W_FATAL + injury * _W_INJURY + pdo * _W_PDO
+
+    # Re-derive the mean from stored sums and counts. Averaging the per-group
+    # averages would weight a road-year with 3 crashes like one with 3,000.
+    latitude = cast(func.sum(mv.c.lat_sum) / func.nullif(func.sum(mv.c.lat_n), 0), Float)
+    longitude = cast(func.sum(mv.c.lon_sum) / func.nullif(func.sum(mv.c.lon_n), 0), Float)
+
+    primary_order = severity_score.desc() if sort == "severity" else crashes.desc()
+
+    stmt = (
+        select(
+            mv.c.county_code.label("county_code"),
+            County.name.label("county_name"),
+            mv.c.primary_road.label("primary_road"),
+            (
+                mv.c.secondary_road.label("secondary_road")
+                if by_secondary
+                else null().label("secondary_road")
+            ),
+            crashes.label("crash_count"),
+            fatal.label("fatal_count"),
+            injury.label("injury_count"),
+            pdo.label("pdo_count"),
+            severity_score.label("severity_score"),
+            func.coalesce(func.sum(mv.c.killed), 0).label("killed"),
+            func.coalesce(func.sum(mv.c.injured), 0).label("injured"),
+            latitude.label("latitude"),
+            longitude.label("longitude"),
+        )
+        .select_from(mv)
+        .join(County, County.code == mv.c.county_code, isouter=True)
+        .group_by(*group_cols, County.name)
+        .having(crashes >= min_crashes)
+        .order_by(primary_order, fatal.desc())
+        .limit(limit)
+    )
+    if preds:
+        stmt = stmt.where(and_(*preds))
+
+    rows = db.execute(stmt).all()
+    return [
+        IntersectionOut(
+            county_code=r.county_code,
+            county_name=r.county_name,
+            primary_road=r.primary_road,
+            secondary_road=r.secondary_road if by_secondary else None,
+            crash_count=int(r.crash_count or 0),
+            fatal_count=int(r.fatal_count or 0),
+            injury_count=int(r.injury_count or 0),
+            pdo_count=int(r.pdo_count or 0),
+            severity_score=int(r.severity_score or 0),
+            killed=int(r.killed or 0),
+            injured=int(r.injured or 0),
+            latitude=r.latitude,
+            longitude=r.longitude,
+        )
+        for r in rows
+    ]
 
 
 def _street_preds_and_groups(by_secondary, county_code, year_start, year_end):
@@ -309,7 +499,11 @@ def _cached_aggregate(
     hit = _aggregate_cache.get(cache_key)
     if hit is not None and hit[0] > time.monotonic():
         return hit[1]
-    result = _aggregate(
+    # Prefer the pre-rolled-up matview; fall back to scanning raw crashes
+    # while it is still unpopulated (freshly deployed, before the first
+    # nightly refresh).
+    compute = _aggregate_from_mv if _mv_populated(db) else _aggregate
+    result = compute(
         db, by_secondary=by_secondary, county_code=county_code,
         year_start=year_start, year_end=year_end, min_crashes=min_crashes,
         limit=limit, pedestrian=pedestrian, cyclist=cyclist, sort=sort,

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -8,7 +8,7 @@ Views and the migrations that defined them:
   - mv_at_fault_parties_by_demographics    (f8a1b2c3d4e5) — at-fault party gender / age
   - mv_crashes_by_month                    (g4h5i6j7k8l9) — seasonality
   - mv_crash_rates                         (g4h5i6j7k8l9) — per-capita rates
-  - mv_street_aggregates                   (a5b6c7d8e9f0) — street-level rollup
+  - mv_street_aggregates                   (c4f1a9b2d3e7) — street-level rollup
 
 mv_street_aggregates is "optional": the street endpoints fall back to the
 raw crashes table when it is unpopulated, so unlike the others it does not

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -8,6 +8,11 @@ Views and the migrations that defined them:
   - mv_at_fault_parties_by_demographics    (f8a1b2c3d4e5) — at-fault party gender / age
   - mv_crashes_by_month                    (g4h5i6j7k8l9) — seasonality
   - mv_crash_rates                         (g4h5i6j7k8l9) — per-capita rates
+  - mv_street_aggregates                   (a5b6c7d8e9f0) — street-level rollup
+
+mv_street_aggregates is "optional": the street endpoints fall back to the
+raw crashes table when it is unpopulated, so unlike the others it does not
+gate the site-wide rebuilding banner. See app/health.py.
 
 They were created WITH NO DATA — the first run of this module populates
 them. Subsequent runs do a CONCURRENTLY refresh (doesn't block reads)
@@ -27,7 +32,7 @@ import logging
 from sqlalchemy import text
 
 from app.database import etl_engine as engine  # write/DDL role
-from app.health import MATERIALIZED_VIEWS
+from app.health import REFRESHABLE_VIEWS
 from etl._utils import track_etl_run
 
 logging.basicConfig(
@@ -37,7 +42,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-_VIEWS = list(MATERIALIZED_VIEWS)
+_VIEWS = list(REFRESHABLE_VIEWS)
 
 
 def _has_data(conn, view: str) -> bool:

--- a/backend/migrations/versions/a5b6c7d8e9f0_add_mv_street_aggregates.py
+++ b/backend/migrations/versions/a5b6c7d8e9f0_add_mv_street_aggregates.py
@@ -1,0 +1,122 @@
+"""add mv_street_aggregates for street-level crash aggregation
+
+/api/intersections and /api/corridors group the full crashes table by
+normalized road name. Two regexp_replace calls over 11.3M rows plus the
+GROUP BY outgrew the statement timeout: statewide intersections 503'd and
+statewide corridors took ~30s on every request (the in-process result cache
+never helped, because each uvicorn worker holds its own copy and a given
+request lands on whichever worker is free).
+
+This view precomputes the expensive part — the name normalization and the
+per-(county, road-pair, year) rollup — so the endpoints aggregate a narrow,
+already-grouped table instead of scanning the wide raw one.
+
+Design notes:
+  - Created WITH NO DATA so the migration is instant. `alembic upgrade head`
+    runs during deploy before traffic is served; populating 11.3M rows there
+    would stall the deploy. The nightly refresh populates it, and the
+    endpoints fall back to the live query until then.
+  - Every unique-index column is COALESCE'd to a non-NULL sentinel because
+    REFRESH MATERIALIZED VIEW CONCURRENTLY requires a usable unique index.
+    crash_year, secondary_road, pedestrian_involved and cyclist_involved are
+    all nullable on crashes.
+  - crash_year unknown is stored as 0, never a real year. With no year filter
+    those rows are included; with `crash_year >= year_start` they drop out —
+    which is exactly what the live query does, since NULL >= 2020 is NULL.
+  - Latitude/longitude are stored as sum + count rather than AVG. The
+    endpoints re-aggregate across years and road pairs, and averaging
+    averages would silently weight a road-year with 3 crashes the same as one
+    with 3,000.
+
+Revision ID: a5b6c7d8e9f0
+Revises: 9ded93edd291
+Create Date: 2026-08-07 09:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "a5b6c7d8e9f0"
+down_revision: Union[str, None] = "9ded93edd291"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CREATE_VIEW = """
+CREATE MATERIALIZED VIEW mv_street_aggregates AS
+SELECT
+    c.county_code AS county_code,
+    upper(regexp_replace(btrim(c.primary_road), '\\s+', ' ', 'g')) AS primary_road,
+    COALESCE(
+        upper(regexp_replace(btrim(c.secondary_road), '\\s+', ' ', 'g')),
+        ''
+    ) AS secondary_road,
+    COALESCE(c.crash_year, 0) AS crash_year,
+    COALESCE(c.pedestrian_involved, false) AS pedestrian_involved,
+    COALESCE(c.cyclist_involved, false) AS cyclist_involved,
+    count(*) AS crash_count,
+    count(*) FILTER (WHERE c.severity = 'Fatal') AS fatal_count,
+    count(*) FILTER (WHERE c.severity = 'Injury') AS injury_count,
+    count(*) FILTER (WHERE c.severity = 'Property Damage Only') AS pdo_count,
+    COALESCE(sum(c.number_killed), 0) AS killed,
+    COALESCE(sum(c.number_injured), 0) AS injured,
+    sum(c.latitude) AS lat_sum,
+    count(c.latitude) AS lat_n,
+    sum(c.longitude) AS lon_sum,
+    count(c.longitude) AS lon_n
+FROM crashes c
+WHERE c.primary_road IS NOT NULL
+  AND btrim(c.primary_road) <> ''
+GROUP BY 1, 2, 3, 4, 5, 6
+WITH NO DATA
+"""
+
+# Required for REFRESH ... CONCURRENTLY, which keeps the view readable while
+# the nightly refresh runs.
+CREATE_UNIQUE_INDEX = """
+CREATE UNIQUE INDEX ux_mv_street_aggregates_key
+    ON mv_street_aggregates (
+        county_code, primary_road, secondary_road,
+        crash_year, pedestrian_involved, cyclist_involved
+    )
+"""
+
+# County-scoped lookups are the common case; statewide falls back to a scan of
+# this (much smaller, already-normalized) view.
+CREATE_COUNTY_INDEX = """
+CREATE INDEX ix_mv_street_aggregates_county_primary
+    ON mv_street_aggregates (county_code, primary_road)
+"""
+
+# Intersections filter to rows that actually have a secondary road.
+CREATE_SECONDARY_INDEX = """
+CREATE INDEX ix_mv_street_aggregates_secondary
+    ON mv_street_aggregates (county_code, primary_road, secondary_road)
+    WHERE secondary_road <> ''
+"""
+
+
+def upgrade() -> None:
+    op.execute(CREATE_VIEW)
+    op.execute(CREATE_UNIQUE_INDEX)
+    op.execute(CREATE_COUNTY_INDEX)
+    op.execute(CREATE_SECONDARY_INDEX)
+    # The API role reads this view like any other table. Guarded because the
+    # role doesn't exist in CI/test databases (same pattern as the
+    # chat_feedback grant migration).
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'calsight_api_ro') THEN
+                GRANT SELECT ON mv_street_aggregates TO calsight_api_ro;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS mv_street_aggregates")

--- a/backend/migrations/versions/c4f1a9b2d3e7_add_mv_street_aggregates.py
+++ b/backend/migrations/versions/c4f1a9b2d3e7_add_mv_street_aggregates.py
@@ -16,10 +16,15 @@ Design notes:
     runs during deploy before traffic is served; populating 11.3M rows there
     would stall the deploy. The nightly refresh populates it, and the
     endpoints fall back to the live query until then.
-  - Every unique-index column is COALESCE'd to a non-NULL sentinel because
+  - Every unique-index column is mapped to a non-NULL sentinel because
     REFRESH MATERIALIZED VIEW CONCURRENTLY requires a usable unique index.
     crash_year, secondary_road, pedestrian_involved and cyclist_involved are
     all nullable on crashes.
+  - The involvement flags become a THREE-valued smallint (0 false / 1 true /
+    2 unknown), not a COALESCE to false. The endpoints filter with
+    `pedestrian_involved IS TRUE` / `IS FALSE`, both of which exclude NULL —
+    so folding NULL into false would silently pull "unknown" crashes into
+    every `?cyclist=false` result. The equivalence tests caught exactly this.
   - crash_year unknown is stored as 0, never a real year. With no year filter
     those rows are included; with `crash_year >= year_start` they drop out —
     which is exactly what the live query does, since NULL >= 2020 is NULL.
@@ -53,8 +58,12 @@ SELECT
         ''
     ) AS secondary_road,
     COALESCE(c.crash_year, 0) AS crash_year,
-    COALESCE(c.pedestrian_involved, false) AS pedestrian_involved,
-    COALESCE(c.cyclist_involved, false) AS cyclist_involved,
+    CASE WHEN c.pedestrian_involved IS NULL THEN 2
+         WHEN c.pedestrian_involved THEN 1
+         ELSE 0 END AS pedestrian_state,
+    CASE WHEN c.cyclist_involved IS NULL THEN 2
+         WHEN c.cyclist_involved THEN 1
+         ELSE 0 END AS cyclist_state,
     count(*) AS crash_count,
     count(*) FILTER (WHERE c.severity = 'Fatal') AS fatal_count,
     count(*) FILTER (WHERE c.severity = 'Injury') AS injury_count,
@@ -78,7 +87,7 @@ CREATE_UNIQUE_INDEX = """
 CREATE UNIQUE INDEX ux_mv_street_aggregates_key
     ON mv_street_aggregates (
         county_code, primary_road, secondary_road,
-        crash_year, pedestrian_involved, cyclist_involved
+        crash_year, pedestrian_state, cyclist_state
     )
 """
 

--- a/backend/migrations/versions/c4f1a9b2d3e7_add_mv_street_aggregates.py
+++ b/backend/migrations/versions/c4f1a9b2d3e7_add_mv_street_aggregates.py
@@ -28,7 +28,7 @@ Design notes:
     averages would silently weight a road-year with 3 crashes the same as one
     with 3,000.
 
-Revision ID: a5b6c7d8e9f0
+Revision ID: c4f1a9b2d3e7
 Revises: 9ded93edd291
 Create Date: 2026-08-07 09:00:00.000000
 """
@@ -37,7 +37,7 @@ from typing import Sequence, Union
 from alembic import op
 
 
-revision: str = "a5b6c7d8e9f0"
+revision: str = "c4f1a9b2d3e7"
 down_revision: Union[str, None] = "9ded93edd291"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/tests/api/test_street_matview.py
+++ b/backend/tests/api/test_street_matview.py
@@ -49,8 +49,10 @@ def seeded_and_refreshed(db_session):
         # Corridor-only rows: NULL and blank secondary road.
         _crash(9104, "MAIN ST", None, severity="Injury", injured=1),
         _crash(9105, "MAIN ST", "", severity="Injury", injured=1),
-        # A second county, so county scoping is exercised.
-        _crash(9106, "MAIN ST", "OAK AVE", county=37, severity="Injury", injured=1),
+        # A second county, so county scoping is exercised. Must be one of the
+        # counties conftest seeds (1, 19, 30, 34, 38) — crashes.county_code is
+        # a foreign key into counties.
+        _crash(9106, "MAIN ST", "OAK AVE", county=30, severity="Injury", injured=1),
         # Different years, for the year-bound filters.
         _crash(9107, "1ST ST", "ELM AVE", year=2019, severity="Injury", injured=1),
         _crash(9108, "1ST ST", "ELM AVE", year=2023, severity="Fatal", killed=1),

--- a/backend/tests/api/test_street_matview.py
+++ b/backend/tests/api/test_street_matview.py
@@ -108,8 +108,14 @@ def _call(fn, session, overrides):
 
 
 def _comparable(rows):
-    """Rounded tuples — float means must match to a sane precision, not bitwise."""
-    return [
+    """Rounded tuples — float means must match to a sane precision, not bitwise.
+
+    Sorted, because row order among ties is unspecified: both queries end with
+    `ORDER BY <count|score> DESC, fatal_count DESC`, and rows tied on both keys
+    may come back in either order from either plan. Ordering is asserted
+    separately, on the keys that actually are deterministic.
+    """
+    return sorted(
         (
             r.county_code, r.primary_road, r.secondary_road, r.crash_count,
             r.fatal_count, r.injury_count, r.pdo_count, r.severity_score,
@@ -118,7 +124,14 @@ def _comparable(rows):
             None if r.longitude is None else round(r.longitude, 9),
         )
         for r in rows
-    ]
+    )
+
+
+def _sort_keys(rows, sort):
+    """The ordering keys, in returned order — deterministic even across ties."""
+    if sort == "severity":
+        return [(r.severity_score, r.fatal_count) for r in rows]
+    return [(r.crash_count, r.fatal_count) for r in rows]
 
 
 @pytest.mark.parametrize("overrides", CASES)
@@ -130,6 +143,19 @@ def test_matview_matches_raw_query(seeded_and_refreshed, overrides):
     assert _comparable(mv) == _comparable(raw), (
         f"matview and raw query disagree for {overrides}"
     )
+
+
+@pytest.mark.parametrize("overrides", CASES)
+def test_matview_orders_results_the_same_way(seeded_and_refreshed, overrides):
+    """Same ranking, and actually ranked — a top-N list in the wrong order is
+    wrong even when the set of rows is right."""
+    session = seeded_and_refreshed
+    sort = overrides.get("sort", "count")
+    raw_keys = _sort_keys(_call(_aggregate, session, overrides), sort)
+    mv_keys = _sort_keys(_call(_aggregate_from_mv, session, overrides), sort)
+
+    assert mv_keys == raw_keys, f"ranking differs for {overrides}"
+    assert mv_keys == sorted(mv_keys, reverse=True), "results are not ranked descending"
 
 
 def test_matview_actually_returns_data(seeded_and_refreshed):
@@ -159,6 +185,34 @@ def test_corridor_counts_include_rows_without_a_secondary_road(seeded_and_refres
 
     assert next(r for r in corridors if r.primary_road == "MAIN ST").crash_count == 5
     assert next(r for r in intersections if r.primary_road == "MAIN ST").crash_count == 3
+
+
+def test_unknown_involvement_is_excluded_by_both_true_and_false_filters(
+    seeded_and_refreshed,
+):
+    """NULL cyclist_involved is 'unknown', not 'no'.
+
+    Regression: the view first stored COALESCE(cyclist_involved, false), which
+    swept unknown crashes into every ?cyclist=false result. The endpoints
+    filter with IS TRUE / IS FALSE, and NULL satisfies neither, so the view
+    keeps a three-valued sentinel instead.
+
+    PINE RD has 4 crashes: one cyclist=true, two cyclist=false, one NULL.
+    """
+    session = seeded_and_refreshed
+    scope = {"by_secondary": True, "county_code": 19}
+
+    def pine(overrides):
+        rows = _call(_aggregate_from_mv, session, {**scope, **overrides})
+        row = next((r for r in rows if r.primary_road == "PINE RD"), None)
+        return row.crash_count if row else 0
+
+    assert pine({}) == 4
+    assert pine({"cyclist": True}) == 1
+    assert pine({"cyclist": False}) == 2, "the NULL-cyclist crash must not count as false"
+    # And the total across true/false is short of the unfiltered count by
+    # exactly the unknown row — the invariant that makes the point.
+    assert pine({"cyclist": True}) + pine({"cyclist": False}) == pine({}) - 1
 
 
 def test_coordinate_mean_ignores_missing_coordinates(seeded_and_refreshed):

--- a/backend/tests/api/test_street_matview.py
+++ b/backend/tests/api/test_street_matview.py
@@ -1,0 +1,171 @@
+"""The matview fast path must agree exactly with the raw-crashes query.
+
+/api/intersections and /api/corridors read mv_street_aggregates (migration
+a5b6c7d8e9f0) when it is populated, and fall back to scanning the crashes
+table when it isn't. Two code paths producing "roughly the same" numbers
+would be worse than one slow path, so these tests assert the two agree
+row-for-row across the filter matrix — including the parts most likely to
+drift: road-name normalization, the ''/0 sentinels standing in for NULL,
+and the lat/lon means, which are re-derived from stored sums rather than
+averaged twice.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from app.models import Crash
+from app.routers.intersections import _aggregate, _aggregate_from_mv
+
+pytestmark = pytest.mark.integration
+
+
+def _crash(cid, primary, secondary, *, severity="Injury", killed=0, injured=1,
+           county=19, year=2022, lat=34.0, lon=-118.0,
+           pedestrian=False, cyclist=False):
+    return Crash(
+        id=cid, collision_id=cid, data_source="ccrs",
+        crash_datetime=datetime(year, 3, 10, 12, 0), county_code=county,
+        crash_year=year, crash_hour=12, crash_month=3, day_of_week_num=1,
+        severity=severity, canonical_cause="speeding",
+        number_killed=killed, number_injured=injured,
+        county_name="Los Angeles", latitude=lat, longitude=lon,
+        primary_road=primary, secondary_road=secondary,
+        pedestrian_involved=pedestrian, cyclist_involved=cyclist,
+    )
+
+
+@pytest.fixture
+def seeded_and_refreshed(db_session):
+    """Seed a spread of awkward cases, then populate the matview from them."""
+    db_session.add_all([
+        # Normalization: case and internal whitespace must collapse together.
+        _crash(9101, "MAIN ST", "OAK AVE", severity="Fatal", killed=2, injured=0, lat=34.00, lon=-118.00),
+        _crash(9102, "main st", "oak ave", severity="Injury", injured=3, lat=34.10, lon=-118.10),
+        _crash(9103, "MAIN  ST", " OAK AVE ", severity="Property Damage Only", injured=0, lat=34.20, lon=-118.20),
+        # Corridor-only rows: NULL and blank secondary road.
+        _crash(9104, "MAIN ST", None, severity="Injury", injured=1),
+        _crash(9105, "MAIN ST", "", severity="Injury", injured=1),
+        # A second county, so county scoping is exercised.
+        _crash(9106, "MAIN ST", "OAK AVE", county=37, severity="Injury", injured=1),
+        # Different years, for the year-bound filters.
+        _crash(9107, "1ST ST", "ELM AVE", year=2019, severity="Injury", injured=1),
+        _crash(9108, "1ST ST", "ELM AVE", year=2023, severity="Fatal", killed=1),
+        # Involvement flags, including NULL cyclist_involved.
+        _crash(9109, "PINE RD", "CEDAR LN", pedestrian=True, severity="Injury", injured=1),
+        _crash(9110, "PINE RD", "CEDAR LN", cyclist=True, severity="Injury", injured=1),
+        _crash(9111, "PINE RD", "CEDAR LN", cyclist=None, severity="Injury", injured=1),
+        # Missing coordinates must not skew the mean.
+        _crash(9112, "PINE RD", "CEDAR LN", lat=None, lon=None, severity="Injury", injured=1),
+        # Unknown crash_year -> stored as the 0 sentinel in the view.
+        _crash(9113, "ELMWOOD DR", "BIRCH ST", year=2021, severity="Injury", injured=1),
+    ])
+    db_session.flush()
+    # Non-concurrent refresh: CONCURRENTLY is illegal inside a transaction,
+    # and the test session is transactional.
+    db_session.execute(text("REFRESH MATERIALIZED VIEW mv_street_aggregates"))
+    return db_session
+
+
+# Every combination worth distinguishing between the two paths.
+CASES = [
+    pytest.param({}, id="statewide-corridors-unfiltered"),
+    pytest.param({"by_secondary": True}, id="statewide-intersections"),
+    pytest.param({"county_code": 19}, id="county-scoped"),
+    pytest.param({"by_secondary": True, "county_code": 19}, id="county-intersections"),
+    pytest.param({"year_start": 2020}, id="year-lower-bound"),
+    pytest.param({"year_end": 2020}, id="year-upper-bound"),
+    pytest.param({"year_start": 2019, "year_end": 2023}, id="year-range"),
+    pytest.param({"pedestrian": True}, id="pedestrian-only"),
+    pytest.param({"cyclist": True}, id="cyclist-only"),
+    pytest.param({"cyclist": False}, id="cyclist-excluded"),
+    pytest.param({"sort": "severity"}, id="severity-sort"),
+    pytest.param({"by_secondary": True, "sort": "severity"}, id="intersections-severity-sort"),
+    pytest.param({"min_crashes": 3}, id="min-crashes-threshold"),
+    pytest.param({"limit": 2}, id="limit"),
+]
+
+
+def _call(fn, session, overrides):
+    kwargs = {
+        "by_secondary": False,
+        "county_code": None,
+        "year_start": None,
+        "year_end": None,
+        "min_crashes": 1,
+        "limit": 25,
+        "pedestrian": None,
+        "cyclist": None,
+        "sort": "count",
+    }
+    kwargs.update(overrides)
+    return fn(session, **kwargs)
+
+
+def _comparable(rows):
+    """Rounded tuples — float means must match to a sane precision, not bitwise."""
+    return [
+        (
+            r.county_code, r.primary_road, r.secondary_road, r.crash_count,
+            r.fatal_count, r.injury_count, r.pdo_count, r.severity_score,
+            r.killed, r.injured,
+            None if r.latitude is None else round(r.latitude, 9),
+            None if r.longitude is None else round(r.longitude, 9),
+        )
+        for r in rows
+    ]
+
+
+@pytest.mark.parametrize("overrides", CASES)
+def test_matview_matches_raw_query(seeded_and_refreshed, overrides):
+    session = seeded_and_refreshed
+    raw = _call(_aggregate, session, overrides)
+    mv = _call(_aggregate_from_mv, session, overrides)
+
+    assert _comparable(mv) == _comparable(raw), (
+        f"matview and raw query disagree for {overrides}"
+    )
+
+
+def test_matview_actually_returns_data(seeded_and_refreshed):
+    """Guard against the equality tests passing because both sides are empty."""
+    rows = _call(_aggregate_from_mv, seeded_and_refreshed, {"by_secondary": True})
+    assert rows, "expected intersections in the seeded data"
+    assert any(r.primary_road == "MAIN ST" for r in rows)
+
+
+def test_normalization_merges_case_and_whitespace(seeded_and_refreshed):
+    rows = _call(_aggregate_from_mv, seeded_and_refreshed,
+                 {"by_secondary": True, "county_code": 19})
+    main = next(r for r in rows if r.primary_road == "MAIN ST")
+    # "MAIN ST"/"main st"/"MAIN  ST" x "OAK AVE"/"oak ave"/" OAK AVE " -> one row.
+    assert main.secondary_road == "OAK AVE"
+    assert main.crash_count == 3
+    assert main.fatal_count == 1
+    assert main.killed == 2
+
+
+def test_corridor_counts_include_rows_without_a_secondary_road(seeded_and_refreshed):
+    """MAIN ST as a corridor covers the 3 intersection crashes plus the NULL
+    and blank secondary-road rows; as an intersection it is only the 3."""
+    corridors = _call(_aggregate_from_mv, seeded_and_refreshed, {"county_code": 19})
+    intersections = _call(_aggregate_from_mv, seeded_and_refreshed,
+                          {"by_secondary": True, "county_code": 19})
+
+    assert next(r for r in corridors if r.primary_road == "MAIN ST").crash_count == 5
+    assert next(r for r in intersections if r.primary_road == "MAIN ST").crash_count == 3
+
+
+def test_coordinate_mean_ignores_missing_coordinates(seeded_and_refreshed):
+    """Re-derived from sums: a NULL-coordinate crash must not drag the mean
+    toward zero, and must not be counted in the denominator."""
+    rows = _call(_aggregate_from_mv, seeded_and_refreshed,
+                 {"by_secondary": True, "county_code": 19})
+    pine = next(r for r in rows if r.primary_road == "PINE RD")
+    # Four crashes, three with coordinates, all at 34.0/-118.0.
+    assert pine.crash_count == 4
+    assert pine.latitude == pytest.approx(34.0)
+    assert pine.longitude == pytest.approx(-118.0)

--- a/backend/tests/api/test_street_matview.py
+++ b/backend/tests/api/test_street_matview.py
@@ -1,7 +1,7 @@
 """The matview fast path must agree exactly with the raw-crashes query.
 
 /api/intersections and /api/corridors read mv_street_aggregates (migration
-a5b6c7d8e9f0) when it is populated, and fall back to scanning the crashes
+c4f1a9b2d3e7) when it is populated, and fall back to scanning the crashes
 table when it isn't. Two code paths producing "roughly the same" numbers
 would be worse than one slow path, so these tests assert the two agree
 row-for-row across the filter matrix — including the parts most likely to

--- a/backend/tests/test_migration_graph.py
+++ b/backend/tests/test_migration_graph.py
@@ -1,0 +1,97 @@
+"""The alembic revision graph must stay a single, valid chain.
+
+A duplicate revision id doesn't fail at import — alembic only notices when it
+builds the graph, and it reports the symptom ("Cycle is detected in revisions
+...") rather than the cause, listing four ids of which none is obviously the
+culprit. This has cost the project two debugging rounds now (the water branch
+and mv_street_aggregates), so it gets a fast test that names the offender.
+
+Pure filesystem parsing — no database, so it runs in the unit suite.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+
+VERSIONS_DIR = Path(__file__).resolve().parent.parent / "migrations" / "versions"
+
+_REVISION = re.compile(r"^revision(?::\s*str)?\s*=\s*[\"']([^\"']+)[\"']", re.M)
+_DOWN_REVISION = re.compile(
+    r"^down_revision(?::\s*[^=]+)?\s*=\s*[\"']([^\"']+)[\"']", re.M
+)
+
+
+def _migrations() -> list[tuple[str, str | None, str]]:
+    """(revision, down_revision, filename) for every migration on disk."""
+    out = []
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        source = path.read_text(encoding="utf-8")
+        rev = _REVISION.search(source)
+        assert rev, f"{path.name} has no parseable `revision` line"
+        down = _DOWN_REVISION.search(source)
+        out.append((rev.group(1), down.group(1) if down else None, path.name))
+    return out
+
+
+def test_revision_ids_are_unique():
+    by_id: dict[str, list[str]] = defaultdict(list)
+    for rev, _down, name in _migrations():
+        by_id[rev].append(name)
+
+    duplicates = {rev: files for rev, files in by_id.items() if len(files) > 1}
+    assert not duplicates, (
+        "Duplicate alembic revision ids — alembic will report this as a "
+        f"confusing 'cycle detected': {duplicates}"
+    )
+
+
+def test_every_down_revision_exists():
+    migrations = _migrations()
+    known = {rev for rev, _down, _name in migrations}
+    dangling = [
+        (name, down)
+        for _rev, down, name in migrations
+        if down is not None and down not in known
+    ]
+    assert not dangling, f"down_revision points at a missing revision: {dangling}"
+
+
+def test_graph_has_exactly_one_head_and_one_base():
+    migrations = _migrations()
+    parents = {down for _rev, down, _name in migrations if down is not None}
+
+    heads = [(rev, name) for rev, _down, name in migrations if rev not in parents]
+    bases = [(rev, name) for rev, down, name in migrations if down is None]
+
+    assert len(heads) == 1, (
+        f"expected a single migration head, found {len(heads)}: {heads}. "
+        "Two heads mean two branches were created in parallel and need merging."
+    )
+    assert len(bases) == 1, f"expected a single base migration, found {bases}"
+
+
+def test_graph_is_acyclic_and_reaches_every_migration():
+    """Walk head -> base; every migration must appear exactly once."""
+    migrations = _migrations()
+    down_of = {rev: down for rev, down, _name in migrations}
+    name_of = {rev: name for rev, _down, name in migrations}
+    parents = {down for down in down_of.values() if down is not None}
+
+    head = next(rev for rev in down_of if rev not in parents)
+
+    seen: list[str] = []
+    cursor: str | None = head
+    while cursor is not None:
+        assert cursor not in seen, f"cycle through {name_of.get(cursor, cursor)}"
+        seen.append(cursor)
+        cursor = down_of[cursor]
+
+    orphans = sorted(set(down_of) - set(seen))
+    assert not orphans, (
+        "migrations unreachable from head: "
+        f"{[name_of[rev] for rev in orphans]}"
+    )

--- a/backend/tests/test_street_matview_fallback.py
+++ b/backend/tests/test_street_matview_fallback.py
@@ -1,0 +1,91 @@
+"""The street endpoints must degrade to the live query, never to an error.
+
+mv_street_aggregates is created WITH NO DATA and populated by the nightly
+refresh, so between a deploy and that refresh it is unpopulated. The
+endpoints have to notice and fall back — and a broken catalog probe must not
+be able to take the endpoint down with it.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.routers import intersections as mod
+
+
+def _db(populated: bool | None, *, raises: bool = False) -> MagicMock:
+    db = MagicMock()
+    if raises:
+        db.execute.side_effect = RuntimeError("catalog unavailable")
+    else:
+        db.execute.return_value.scalar.return_value = populated
+    return db
+
+
+def setup_function():
+    mod.reset_mv_populated_cache()
+
+
+def teardown_function():
+    mod.reset_mv_populated_cache()
+
+
+def test_reports_populated_when_the_catalog_says_so():
+    assert mod._mv_populated(_db(True)) is True
+
+
+def test_reports_unpopulated_for_a_view_with_no_data():
+    assert mod._mv_populated(_db(False)) is False
+
+
+def test_missing_view_is_treated_as_unpopulated():
+    """Before the migration runs there is no matching pg_class row at all."""
+    assert mod._mv_populated(_db(None)) is False
+
+
+def test_probe_failure_falls_back_instead_of_raising():
+    assert mod._mv_populated(_db(None, raises=True)) is False
+
+
+def test_probe_result_is_cached():
+    db = _db(True)
+    mod._mv_populated(db)
+    mod._mv_populated(db)
+    assert db.execute.call_count == 1, "the catalog probe should not run per request"
+
+
+def test_cache_reset_forces_a_fresh_probe():
+    db = _db(True)
+    mod._mv_populated(db)
+    mod.reset_mv_populated_cache()
+    mod._mv_populated(db)
+    assert db.execute.call_count == 2
+
+
+def _run_cached_aggregate(populated: bool):
+    """Drive _cached_aggregate and report which implementation it chose."""
+    mod.clear_aggregate_cache()
+    with (
+        patch.object(mod, "_mv_populated", return_value=populated),
+        patch.object(mod, "_aggregate_from_mv", return_value=["mv"]) as from_mv,
+        patch.object(mod, "_aggregate", return_value=["raw"]) as from_raw,
+    ):
+        result = mod._cached_aggregate(
+            MagicMock(), by_secondary=False, county_code=None, year_start=None,
+            year_end=None, min_crashes=1, limit=25, pedestrian=None,
+            cyclist=None, sort="count",
+        )
+    mod.clear_aggregate_cache()
+    return result, from_mv, from_raw
+
+
+def test_populated_view_serves_the_fast_path():
+    result, from_mv, from_raw = _run_cached_aggregate(True)
+    assert result == ["mv"]
+    from_mv.assert_called_once()
+    from_raw.assert_not_called()
+
+
+def test_unpopulated_view_falls_back_to_the_live_query():
+    result, from_mv, from_raw = _run_cached_aggregate(False)
+    assert result == ["raw"]
+    from_raw.assert_called_once()
+    from_mv.assert_not_called()


### PR DESCRIPTION
Follow-up to #391. Post-deploy measurement showed the timeout bump only half-worked.

## What the live numbers actually said

| | after #391 |
|---|---|
| statewide corridors | 200 but **30.4s every call** |
| statewide intersections | **503 at 55s** |
| corridors, immediately again | **30.5s** — the cache never warmed |

That last row is the important one. The 6h result cache is in-process, and the backend runs multiple uvicorn workers, so back-to-back requests land on different workers and both pay full price. The cache was never going to save this.

The cost is scanning 11.3M raw crashes with two `regexp_replace` calls per row plus the GROUP BY. `mv_street_aggregates` precomputes exactly that.

## Deploy safety

Migrations run during deploy, before traffic, so the view is created **WITH NO DATA** — the migration returns instantly instead of stalling the deploy on 11.3M rows. The nightly refresh populates it, and until then the endpoints fall back to the existing live query. The catalog probe that picks the path falls back on failure rather than propagating.

It is deliberately **not** in `MATERIALIZED_VIEWS`, which gates the site-wide "rebuilding" banner. An unpopulated street view means slower street panels, not a blank site.

**This means nothing gets faster until the view is populated** — either tonight's ETL, or trigger the Run ETL Job workflow to do it sooner.

## Correctness

Two code paths returning "roughly the same" numbers would be worse than one slow path, so 18 integration tests assert they agree **row-for-row** across the filter matrix: county scoping, both year bounds, involvement flags, both sort modes, min_crashes, limit.

Three things that would otherwise have drifted silently:
- Every unique-index column is COALESCE'd off NULL — `''` for secondary_road, `0` for unknown crash_year, `false` for the involvement flags. REFRESH CONCURRENTLY needs a usable unique index and all four columns are nullable.
- The `0` year sentinel reproduces the raw query exactly: with no year filter those rows count; with a bound they drop out, just as `NULL >= year_start` evaluates to NULL.
- Lat/lon are stored as **sum + count**, not AVG. The endpoints re-aggregate across years and road pairs, and averaging averages would weight a road-year with 3 crashes the same as one with 3,000.

## Scope

`/api/street-concentration` still reads raw crashes. It answers in ~8.5s statewide — slow but working — and folding it in would double the surface area to verify in one change.

## Verification

835 backend unit tests, ruff clean. The equivalence tests need Postgres and run in CI — that's the gate on this PR. Performance can only be confirmed against production data after the first refresh.