### PR TITLE
fix(backend): audit hardening — heartbeat, timeouts, freshness, hygiene

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -205,6 +205,44 @@ async def all_providers_exhausted_handler(request: Request, exc: AllProvidersExh
     )
 
 
+from sqlalchemy.exc import OperationalError  # noqa: E402
+
+# PostgreSQL "canceling statement due to statement timeout".
+_PG_QUERY_CANCELED = "57014"
+
+
+@app.exception_handler(OperationalError)
+async def operational_error_handler(request: Request, exc: OperationalError):
+    """A statement-timeout or transient DB error is 503, not 500.
+
+    The heavy statewide aggregations (clusters, highways, distribution, yoy)
+    bound their queries with a statement timeout. When one fires, the raw
+    OperationalError would otherwise fall through to the generic 500 handler
+    and read as "the site is broken". A 503 + Retry-After tells the truth: the
+    query was too big to finish (or the DB is briefly unavailable), the server
+    is fine, and narrowing the filters or retrying will work. The request's
+    session is rolled back by get_db's finally as this unwinds, so the pooled
+    connection is not left poisoned. Endpoints that degrade in-place
+    (intersections/corridors) raise HTTPException and never reach here.
+    """
+    pgcode = getattr(getattr(exc, "orig", None), "pgcode", None)
+    is_timeout = pgcode == _PG_QUERY_CANCELED or "statement timeout" in str(exc.orig or exc)
+    if is_timeout:
+        logger.warning("Statement timeout on %s — returning 503", request.url.path)
+        message = (
+            "This query covers too much data to finish in time. Narrow it with "
+            "a county or a year range and it will return quickly."
+        )
+    else:
+        logger.exception("Database operational error on %s — returning 503", request.url.path)
+        message = "The database is temporarily unavailable. Please try again shortly."
+    return JSONResponse(
+        status_code=503,
+        content={"detail": message},
+        headers={"Retry-After": "60"},
+    )
+
+
 from app.routers.context import router as context_router  # noqa: E402
 from app.routers.crash_people import router as crash_people_router  # noqa: E402
 from app.routers.crashes import router as crashes_router  # noqa: E402

--- a/backend/app/routers/pipeline_health.py
+++ b/backend/app/routers/pipeline_health.py
@@ -14,11 +14,12 @@ returns a simple status that monitoring tools can poll.
 
 from __future__ import annotations
 
+import hmac
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, Header, Request, Response
 from pydantic import BaseModel
 from slowapi import Limiter
 from app.rate_limit import rate_limit_key
@@ -28,6 +29,7 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import EtlRun
 from app.routers.etl import _verify_etl_key
+from app.settings import settings
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +86,7 @@ def pipeline_health(
     request: Request,
     response: Response,
     db: Session = Depends(get_db),
+    x_etl_api_key: str = Header(None),
 ):
     """Simple health check for monitoring tools.
 
@@ -146,10 +149,22 @@ def pipeline_health(
 
     failure_rate = (recent_failures / recent_total * 100) if recent_total > 0 else 0
 
-    # DB size
-    db_size = db.execute(text(
-        "SELECT pg_database_size(current_database()) / (1024*1024.0)"
-    )).scalar()
+    # DB size — infrastructure metadata, so it's returned only to callers
+    # holding the ETL key. This endpoint is otherwise public (uptime monitors
+    # poll it), and the coarse status/timing fields are fine to expose, but the
+    # absolute database size isn't something anonymous callers should see. The
+    # detailed, fully-authenticated /pipeline/db-metrics endpoint still reports
+    # it for operators.
+    authed = bool(
+        settings.etl_api_key
+        and x_etl_api_key
+        and hmac.compare_digest(x_etl_api_key, settings.etl_api_key)
+    )
+    db_size = None
+    if authed:
+        db_size = db.execute(text(
+            "SELECT pg_database_size(current_database()) / (1024*1024.0)"
+        )).scalar()
 
     # Matview age (time since last refresh of mv_crashes_by_year)
     matview_age = None

--- a/backend/etl/_utils.py
+++ b/backend/etl/_utils.py
@@ -435,50 +435,67 @@ def check_source_freshness(job: Job, db_session) -> FreshnessResult:
     return FreshnessResult(True, None, None, f"unknown source_type {job.source_type!r}")
 
 
-def _resolve_ckan_freshness_resource(job: Job) -> str | None:
-    """The resource id whose last_modified decides whether this job runs.
+# How many of the newest discovered years the freshness probe covers. The
+# incremental loader always re-loads the latest two years (select_years_to_load
+# refresh_years = {today, today-1}), so probing only the single newest year
+# missed a revision published to the prior year — the loader would have picked
+# it up, but freshness reported "unchanged" and skipped the whole run.
+_CKAN_FRESHNESS_YEARS = 2
 
-    Jobs with a freshness_ckan_prefix probe the newest discovered year's
-    resource (see Job.freshness_ckan_prefix); everything else — and any
-    discovery failure — uses the pinned freshness_resource_id.
+
+def _resolve_ckan_freshness_resources(job: Job) -> list[str]:
+    """The resource ids whose last_modified decide whether this job runs.
+
+    Jobs with a freshness_ckan_prefix probe the newest _CKAN_FRESHNESS_YEARS
+    discovered years (matching the loader's reload window); everything else —
+    and any discovery failure — uses the pinned freshness_resource_id.
     """
     prefix = getattr(job, "freshness_ckan_prefix", None)
     if prefix:
         discovered = discover_resource_ids(prefix)
         if discovered:
-            return discovered[max(discovered)]
-    return job.freshness_resource_id
+            newest_years = sorted(discovered, reverse=True)[:_CKAN_FRESHNESS_YEARS]
+            return [discovered[y] for y in newest_years]
+    return [job.freshness_resource_id] if job.freshness_resource_id else []
 
 
 def _check_ckan_freshness(job: Job, last_run: EtlRun) -> FreshnessResult:
-    resource_id = _resolve_ckan_freshness_resource(job)
-    if not resource_id:
+    resource_ids = _resolve_ckan_freshness_resources(job)
+    if not resource_ids:
         return FreshnessResult(True, None, None, "ckan type but no resource_id")
 
     try:
-        resp = get_with_retry(
-            CKAN_RESOURCE_SHOW_URL,
-            params={"id": resource_id},
-            timeout=15.0,
-        )
-        resource = resp.json().get("result", {})
-        modified_str = resource.get("last_modified") or resource.get("created")
-        if not modified_str:
+        # Fresh if ANY probed year changed since the last run — take the most
+        # recent last_modified across the covered years.
+        latest_modified: datetime | None = None
+        for resource_id in resource_ids:
+            resp = get_with_retry(
+                CKAN_RESOURCE_SHOW_URL,
+                params={"id": resource_id},
+                timeout=15.0,
+            )
+            resource = resp.json().get("result", {})
+            modified_str = resource.get("last_modified") or resource.get("created")
+            if not modified_str:
+                continue
+            modified = datetime.fromisoformat(
+                modified_str.replace("Z", "+00:00")
+            ).replace(tzinfo=None)
+            if latest_modified is None or modified > latest_modified:
+                latest_modified = modified
+
+        if latest_modified is None:
             return FreshnessResult(True, None, None, "ckan returned no timestamp")
 
-        source_modified = datetime.fromisoformat(
-            modified_str.replace("Z", "+00:00")
-        ).replace(tzinfo=None)
-
-        if source_modified <= last_run.finished_at:
+        if latest_modified <= last_run.finished_at:
             return FreshnessResult(
-                False, source_modified, None,
-                f"source unchanged ({source_modified.isoformat()} <= {last_run.finished_at.isoformat()})",
+                False, latest_modified, None,
+                f"source unchanged ({latest_modified.isoformat()} <= {last_run.finished_at.isoformat()})",
             )
 
         return FreshnessResult(
-            True, source_modified, None,
-            f"source updated ({source_modified.isoformat()} > {last_run.finished_at.isoformat()})",
+            True, latest_modified, None,
+            f"source updated ({latest_modified.isoformat()} > {last_run.finished_at.isoformat()})",
         )
     except Exception as exc:
         logger.warning("CKAN freshness check failed for %s: %s", job.name, exc)

--- a/backend/etl/load_crashes.py
+++ b/backend/etl/load_crashes.py
@@ -241,13 +241,52 @@ def select_years_to_load(
     complete, but the common failure mode (dying in the first batches)
     self-heals on the next run.
 
+    Batch-boundary truncation is caught separately: a load that dies between
+    batches leaves a count that is an exact multiple of BATCH_SIZE, whereas a
+    complete year's true row count essentially never is. So a year whose count
+    is an exact BATCH_SIZE multiple AND well below its same-source peers is
+    treated as partial and resumed — this is what silently stranded SWITRS
+    2001 at 310,000 (62 x 5000) rows.
+
     Returns (switrs_years, ccrs_years, skipped_years).
     """
     if today_year is None:
         today_year = datetime.now(timezone.utc).year
 
+    def _same_source_reference(year: int) -> float:
+        """Median row-count of other clearly-complete years of the same source.
+
+        Used as the yardstick for spotting an anomalously short year. Returns
+        0.0 when there aren't enough peers to judge (then the batch-boundary
+        rule below is skipped, falling back to the absolute floor only).
+        """
+        src = determine_source(year)
+        peers = sorted(
+            cnt for y, cnt in loaded.items()
+            if y != year
+            and determine_source(y) == src
+            and cnt >= _MIN_COMPLETE_YEAR_ROWS
+        )
+        if len(peers) < 2:
+            return 0.0
+        mid = len(peers) // 2
+        return peers[mid] if len(peers) % 2 else (peers[mid - 1] + peers[mid]) / 2
+
+    def _looks_batch_truncated(year: int, count: int) -> bool:
+        # A complete load ends on the true row count; a load killed between
+        # batches ends on an exact multiple of BATCH_SIZE. Require the count to
+        # also be well under same-source peers so a coincidental multiple on a
+        # genuinely complete year isn't reloaded forever.
+        if count <= 0 or count % BATCH_SIZE != 0:
+            return False
+        reference = _same_source_reference(year)
+        return reference > 0 and count < 0.7 * reference
+
     def _is_loaded(year: int) -> bool:
-        return loaded.get(year, 0) >= _MIN_COMPLETE_YEAR_ROWS
+        count = loaded.get(year, 0)
+        if count < _MIN_COMPLETE_YEAR_ROWS:
+            return False
+        return not _looks_batch_truncated(year, count)
 
     switrs_years = [
         y for y in range(start_year, end_year + 1)

--- a/backend/etl/pipeline.py
+++ b/backend/etl/pipeline.py
@@ -316,8 +316,11 @@ def run_weekly_pipeline():
     return results
 
 
-def run_backup():
+def run_backup() -> bool:
     """Daily pg_dump + offsite R2 sync with 7-day rotation.
+
+    Returns True only when the dump AND (if R2 is configured) the offsite
+    upload both succeed; False otherwise. The heartbeat is pinged to match.
 
     Delegates to etl.backup — the one implementation of the dump itself.
     That module keeps the password off the pg_dump command line (PGPASSWORD
@@ -347,13 +350,16 @@ def run_backup():
 
         r2_ok = upload_to_r2(backup_file)
         if not r2_ok and os.environ.get("R2_BUCKET_NAME"):
-            # R2 is configured but the upload failed — the local dump exists,
-            # so warn rather than error, but don't stay silent: offsite is
-            # the copy that survives the host dying.
-            send_alert(
-                AlertLevel.WARNING,
-                "Backup offsite upload failed",
-                f"{backup_file.name} ({size_mb:.1f} MB) saved locally but R2 upload failed",
+            # R2 is configured but the upload failed. The local dump exists,
+            # but offsite is the copy that survives the host dying, so this is
+            # a real failure — raise so the heartbeat reports DOWN, matching
+            # etl.backup's exit-code contract (PR #391). Pinging green here
+            # would leave the dead-man's switch satisfied while offsite copies
+            # silently go stale. Raising before rotation also avoids trimming
+            # copies while uploads are broken.
+            raise RuntimeError(
+                f"{backup_file.name} ({size_mb:.1f} MB) saved locally but "
+                "R2 offsite upload failed"
             )
 
         rotate_backups(backup_dir)
@@ -364,14 +370,17 @@ def run_backup():
             backup_file.name, size_mb, " — uploaded to R2" if r2_ok else "",
         )
 
-        # Backup succeeded — ping the dead-man's-switch so the external monitor
-        # knows the box is alive and ran the job on schedule.
+        # Backup succeeded (local dump + offsite upload) — ping the
+        # dead-man's-switch so the external monitor knows the box is alive and
+        # ran the job on schedule.
         send_heartbeat(success=True)
+        return True
 
     except Exception as exc:
         send_alert(AlertLevel.ERROR, "Backup failed", str(exc)[:500])
         logger.exception("Backup failed: %s", exc)
         send_heartbeat(success=False)
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -497,7 +506,9 @@ def main() -> int:
         elif args.run_now == "weekly":
             run_weekly_pipeline()
         elif args.run_now == "backup":
-            run_backup()
+            # Exit non-zero on backup failure so an exit-code-gated caller
+            # (cron `&& curl $HEARTBEAT_URL`) sees it.
+            return 0 if run_backup() else 1
         elif args.run_now == "maintenance":
             registry = build_default_registry()
             run_pipeline(registry, triggered_by="manual", only=["vacuum"])

--- a/backend/etl/refresh_materialized_views.py
+++ b/backend/etl/refresh_materialized_views.py
@@ -68,6 +68,14 @@ def run() -> None:
     """
     # AUTOCOMMIT — REFRESH MATERIALIZED VIEW CONCURRENTLY needs its
     # own transaction, same as VACUUM.
+    #
+    # Refresh every view independently and only raise at the end. Failing fast
+    # on the first error used to leave every LATER view stale while the earlier
+    # ones were fresh — a bigger, silent cross-view inconsistency than a single
+    # failed view. Isolating failures shrinks the inconsistency to just the
+    # view that errored, and the aggregated raise still fails the "matviews"
+    # etl_run so the freshness API surfaces the problem.
+    failures: list[str] = []
     with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
         for view in _VIEWS:
             populated = _has_data(conn, view)
@@ -82,7 +90,13 @@ def run() -> None:
                 logger.info("  %s refreshed: %s rows", view, f"{row_count:,}")
             except Exception as exc:
                 logger.error("  %s failed: %s", view, exc)
-                raise
+                failures.append(view)
+
+    if failures:
+        raise RuntimeError(
+            f"{len(failures)} materialized view(s) failed to refresh: "
+            + ", ".join(failures)
+        )
 
     logger.info("All materialized views refreshed")
 

--- a/backend/etl/vacuum_analyze.py
+++ b/backend/etl/vacuum_analyze.py
@@ -55,6 +55,10 @@ _TABLES = [
     "mv_at_fault_parties_by_demographics",
     "mv_crash_rates",
     "mv_crashes_wide",
+    # Street aggregation view (migration c4f1a9b2d3e7). Refreshed nightly with
+    # CONCURRENTLY, which leaves dead tuples behind — without this it never
+    # gets VACUUM'd or fresh planner stats.
+    "mv_street_aggregates",
 ]
 
 

--- a/backend/tests/api/test_pipeline_health.py
+++ b/backend/tests/api/test_pipeline_health.py
@@ -42,11 +42,32 @@ def test_pipeline_health_active_jobs_is_zero(client):
     assert body["active_jobs"] == 0
 
 
-def test_pipeline_health_db_size_is_positive(client):
+def test_pipeline_health_db_size_hidden_from_anonymous(client):
+    # db_size_mb is infrastructure metadata; the public health endpoint (which
+    # uptime monitors poll unauthenticated) must not leak it.
     response = client.get("/api/pipeline/health")
+    body = response.json()
+    assert body["db_size_mb"] is None
+
+
+def test_pipeline_health_db_size_shown_to_authed_caller(client):
+    response = client.get(
+        "/api/pipeline/health", headers={"X-ETL-API-KEY": _TEST_ETL_KEY}
+    )
     body = response.json()
     assert body["db_size_mb"] is not None
     assert body["db_size_mb"] > 0
+
+
+def test_pipeline_health_db_size_hidden_for_wrong_key(client):
+    response = client.get(
+        "/api/pipeline/health", headers={"X-ETL-API-KEY": "wrong-key"}
+    )
+    body = response.json()
+    assert body["db_size_mb"] is None
+    # A wrong key must not turn the public health check into a 403 — it just
+    # doesn't unlock the extra field.
+    assert response.status_code == 200
 
 
 # --- GET /api/pipeline/matviews ---

--- a/backend/tests/test_ckan_freshness_multiyear.py
+++ b/backend/tests/test_ckan_freshness_multiyear.py
@@ -1,0 +1,83 @@
+"""CKAN freshness must cover the same years the loader re-loads.
+
+The incremental crash loader always re-loads the latest two years, but the
+freshness probe only looked at the single newest year's resource. So a
+revision published to the prior year (which the loader WOULD pick up) was
+reported "unchanged", and the whole run was skipped.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import etl._utils as U
+
+
+def _job():
+    return SimpleNamespace(
+        name="crashes_ccrs",
+        freshness_ckan_prefix="Crashes",
+        freshness_resource_id="pinned-fallback-id",
+    )
+
+
+def _resp(last_modified: str):
+    return SimpleNamespace(json=lambda: {"result": {"last_modified": last_modified}})
+
+
+# Two discovered years: 2024 -> res-2024, 2025 -> res-2025 (the newest).
+_DISCOVERED = {2024: "res-2024", 2025: "res-2025"}
+
+
+def _run(last_run_iso: str, modified_by_resource: dict[str, str]):
+    last_run = SimpleNamespace(finished_at=datetime.fromisoformat(last_run_iso))
+
+    def fake_get(url, params=None, timeout=None):
+        return _resp(modified_by_resource[params["id"]])
+
+    with (
+        patch.object(U, "discover_resource_ids", return_value=dict(_DISCOVERED)),
+        patch.object(U, "get_with_retry", side_effect=fake_get),
+    ):
+        return U._check_ckan_freshness(_job(), last_run)
+
+
+def test_probes_the_newest_two_years():
+    resolved = None
+    with patch.object(U, "discover_resource_ids", return_value=dict(_DISCOVERED)):
+        resolved = U._resolve_ckan_freshness_resources(_job())
+    assert set(resolved) == {"res-2024", "res-2025"}
+
+
+def test_prior_year_revision_marks_fresh():
+    # Newest year (2025) unchanged, but the PRIOR year (2024) was revised
+    # after the last run — the loader would re-load it, so freshness must run.
+    result = _run(
+        "2026-08-01T00:00:00",
+        {"res-2025": "2026-07-01T00:00:00", "res-2024": "2026-08-05T00:00:00"},
+    )
+    assert result.is_fresh is True
+
+
+def test_both_years_unchanged_is_not_fresh():
+    result = _run(
+        "2026-08-10T00:00:00",
+        {"res-2025": "2026-07-01T00:00:00", "res-2024": "2026-06-01T00:00:00"},
+    )
+    assert result.is_fresh is False
+
+
+def test_newest_year_change_still_detected():
+    result = _run(
+        "2026-08-01T00:00:00",
+        {"res-2025": "2026-08-05T00:00:00", "res-2024": "2026-06-01T00:00:00"},
+    )
+    assert result.is_fresh is True
+
+
+def test_falls_back_to_pinned_resource_without_discovery():
+    job = SimpleNamespace(
+        name="x", freshness_ckan_prefix=None, freshness_resource_id="pinned-fallback-id",
+    )
+    with patch.object(U, "discover_resource_ids", return_value={}):
+        assert U._resolve_ckan_freshness_resources(job) == ["pinned-fallback-id"]

--- a/backend/tests/test_etl_utils.py
+++ b/backend/tests/test_etl_utils.py
@@ -485,13 +485,15 @@ class TestCkanFreshnessDynamicResource:
     """When CHP publishes a new calendar year, the pinned prior-year resource
     stops changing and freshness would skip the job forever, masking a whole
     missing year as 'confirmed sync'. Jobs with a freshness_ckan_prefix must
-    probe the NEWEST discovered year's resource instead of the pinned one."""
+    probe the newest discovered years' resources instead of the pinned one —
+    and cover the newest TWO years, matching the loader's reload window so a
+    prior-year revision isn't missed."""
 
-    def test_probes_newest_discovered_resource(self, monkeypatch):
-        probed = {}
+    def test_probes_newest_two_discovered_resources(self, monkeypatch):
+        probed = []
 
         def fake_get(url, params=None, **kw):
-            probed["id"] = params["id"]
+            probed.append(params["id"])
             return _make_response(
                 200, b'{"result": {"last_modified": "2027-06-01T00:00:00"}}'
             )
@@ -499,12 +501,17 @@ class TestCkanFreshnessDynamicResource:
         monkeypatch.setattr(httpx, "get", fake_get)
         monkeypatch.setattr(
             _utils, "discover_resource_ids",
-            lambda prefix: {2026: "crashes-2026-id", 2027: "crashes-2027-id"},
+            lambda prefix: {
+                2025: "crashes-2025-id",
+                2026: "crashes-2026-id",
+                2027: "crashes-2027-id",
+            },
         )
 
         result = _utils._check_ckan_freshness(_ckan_job(prefix="Crashes"), _finished_run())
 
-        assert probed["id"] == "crashes-2027-id"
+        # Newest two years probed; the older 2025 resource is not.
+        assert set(probed) == {"crashes-2027-id", "crashes-2026-id"}
         assert result.is_fresh is True
 
     def test_discovery_failure_falls_back_to_pinned(self, monkeypatch):

--- a/backend/tests/test_load_crashes.py
+++ b/backend/tests/test_load_crashes.py
@@ -139,6 +139,39 @@ class TestSelectYearsToLoad:
         assert 2026 in ccrs and 2027 in ccrs
         assert 2025 in skipped
 
+    def test_batch_boundary_truncation_is_resumed(self):
+        # SWITRS 2001 died between batches at exactly 310,000 (62 x 5,000)
+        # rows — above the absolute floor, so the old heuristic skipped it
+        # forever. It is an exact BATCH_SIZE multiple AND far below its peers,
+        # so it must be treated as partial and resumed.
+        loaded = {2001: 310_000, **{y: 450_000 for y in range(2002, 2016)}}
+        switrs, _, skipped = select_years_to_load(
+            2001, 2015, loaded, source_filter="switrs", today_year=2026,
+        )
+        assert 2001 in switrs
+        assert 2001 not in skipped
+
+    def test_complete_year_on_a_batch_boundary_is_not_reloaded(self):
+        # A genuinely complete year whose count happens to be a multiple of
+        # BATCH_SIZE must NOT be reloaded forever — it's near its peers, so the
+        # below-median guard keeps it classified as loaded.
+        loaded = {2001: 445_000, **{y: 450_000 for y in range(2002, 2016)}}
+        switrs, _, skipped = select_years_to_load(
+            2001, 2015, loaded, source_filter="switrs", today_year=2026,
+        )
+        assert 2001 not in switrs
+        assert 2001 in skipped
+
+    def test_batch_boundary_rule_needs_peers_to_judge(self):
+        # With too few same-source peers to establish a magnitude, the
+        # batch-boundary rule stays silent (conservative — no reference, no
+        # guess), falling back to the absolute floor alone.
+        loaded = {2001: 310_000}
+        switrs, _, skipped = select_years_to_load(
+            2001, 2015, loaded, source_filter="switrs", today_year=2026,
+        )
+        assert 2001 in skipped  # above the floor, no peers to contradict it
+
 
 class TestNoSelfTracking:
     """M-B8: load_crashes must not create its own EtlRun row. The orchestrator's

--- a/backend/tests/test_operational_error_handler.py
+++ b/backend/tests/test_operational_error_handler.py
@@ -1,0 +1,59 @@
+"""A statement-timeout must surface as 503 + Retry-After, not a bare 500.
+
+The heavy statewide aggregations (clusters, highways, distribution, yoy) bound
+their queries with a statement timeout. When one fires, the raw OperationalError
+used to fall through to the generic 500 handler and read as "the site is
+broken". The global handler turns it into an honest, retryable 503.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from sqlalchemy.exc import OperationalError
+
+from app.main import operational_error_handler
+
+
+def _request(path="/api/crashes/clusters"):
+    return SimpleNamespace(url=SimpleNamespace(path=path))
+
+
+class _FakeOrig(Exception):
+    """Stands in for the psycopg2 error at exc.orig: str() is the PG message
+    and it carries a pgcode, like the real thing."""
+
+    def __init__(self, message, pgcode=None):
+        super().__init__(message)
+        self.pgcode = pgcode
+
+
+def _op_error(*, pgcode=None, message="boom"):
+    orig = _FakeOrig(message, pgcode=pgcode)
+    err = OperationalError("SELECT 1", {}, orig)
+    err.orig = orig
+    return err
+
+
+def _call(exc):
+    return asyncio.run(operational_error_handler(_request(), exc))
+
+
+def test_statement_timeout_pgcode_becomes_503():
+    resp = _call(_op_error(pgcode="57014"))
+    assert resp.status_code == 503
+    assert resp.headers["Retry-After"] == "60"
+    assert b"Narrow it" in resp.body
+
+
+def test_statement_timeout_by_message_becomes_503():
+    resp = _call(_op_error(message="canceling statement due to statement timeout"))
+    assert resp.status_code == 503
+    assert b"Narrow it" in resp.body
+
+
+def test_generic_operational_error_is_503_but_generic_message():
+    resp = _call(_op_error(pgcode="08006", message="server closed the connection"))
+    assert resp.status_code == 503
+    assert resp.headers["Retry-After"] == "60"
+    assert b"temporarily unavailable" in resp.body
+    assert b"Narrow it" not in resp.body

--- a/backend/tests/test_pipeline_backup_heartbeat.py
+++ b/backend/tests/test_pipeline_backup_heartbeat.py
@@ -1,0 +1,72 @@
+"""pipeline.run_backup must honor the same heartbeat contract as etl.backup.
+
+PR #391 made the standalone etl.backup exit non-zero when the offsite (R2)
+upload fails, so a green dead-man's switch means the offsite copy landed too.
+The scheduler's own run_backup was a second implementation of that contract
+and still pinged the heartbeat GREEN on an offsite failure — leaving the
+monitor satisfied while offsite copies silently went stale.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import etl.pipeline as pipeline
+
+
+def _fake_dump(tmp_path: Path) -> Path:
+    dump = tmp_path / "calsight_2026-08-08.dump"
+    dump.write_text("x" * 2048)
+    return dump
+
+
+def _run(tmp_path, *, upload_ok, r2_configured):
+    env = {"BACKUP_DIR": str(tmp_path)}
+    if r2_configured:
+        env["R2_BUCKET_NAME"] = "calsight-backups"
+    with (
+        patch.dict("os.environ", env, clear=False),
+        patch("etl.backup.run_backup", return_value=_fake_dump(tmp_path)),
+        patch("etl.backup.upload_to_r2", return_value=upload_ok),
+        patch("etl.backup.rotate_backups", return_value=0),
+        patch("etl.backup.rotate_r2_backups", return_value=0),
+        patch("etl.pipeline.send_alert"),
+        patch("etl.pipeline.send_heartbeat") as heartbeat,
+    ):
+        if not r2_configured:
+            # Ensure a leaked R2 var from the real environment doesn't flip
+            # the "configured" branch.
+            import os
+            os.environ.pop("R2_BUCKET_NAME", None)
+        result = pipeline.run_backup()
+    return result, heartbeat
+
+
+def test_offsite_failure_reports_down(tmp_path):
+    result, heartbeat = _run(tmp_path, upload_ok=False, r2_configured=True)
+    assert result is False
+    heartbeat.assert_called_once_with(success=False)
+
+
+def test_full_success_reports_up(tmp_path):
+    result, heartbeat = _run(tmp_path, upload_ok=True, r2_configured=True)
+    assert result is True
+    heartbeat.assert_called_once_with(success=True)
+
+
+def test_offsite_disabled_is_not_a_failure(tmp_path):
+    # R2 not configured: a False upload result is expected (skipped), not a
+    # failure — the local dump is the whole job.
+    result, heartbeat = _run(tmp_path, upload_ok=False, r2_configured=False)
+    assert result is True
+    heartbeat.assert_called_once_with(success=True)
+
+
+def test_dump_failure_reports_down(tmp_path):
+    with (
+        patch.dict("os.environ", {"BACKUP_DIR": str(tmp_path)}, clear=False),
+        patch("etl.backup.run_backup", return_value=None),
+        patch("etl.pipeline.send_alert"),
+        patch("etl.pipeline.send_heartbeat") as heartbeat,
+    ):
+        assert pipeline.run_backup() is False
+    heartbeat.assert_called_once_with(success=False)

--- a/backend/tests/test_refresh_matviews_resilience.py
+++ b/backend/tests/test_refresh_matviews_resilience.py
@@ -1,0 +1,74 @@
+"""A single matview refresh failure must not strand every later view.
+
+The refresh loop used to fail fast: if view N raised, views N+1.. were left at
+their old vintage while 1..N-1 were fresh — a large, silent cross-view
+inconsistency. It now refreshes every view independently and raises an
+aggregated error at the end, so a failure isolates to the offending view and
+still fails the "matviews" etl_run.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+import etl.refresh_materialized_views as R
+
+
+def _run_with_failing_views(failing: set[str]):
+    """Drive R.run() with a fake AUTOCOMMIT connection.
+
+    Returns (refreshed_views, raised_error) — the refreshed list is captured
+    even when run() raises its aggregated error at the end.
+    """
+    refreshed: list[str] = []
+
+    def execute(clause, params=None):
+        sql = str(clause)
+        if sql.startswith("REFRESH MATERIALIZED VIEW"):
+            view = sql.split()[-1]
+            if view in failing:
+                raise RuntimeError(f"boom refreshing {view}")
+            refreshed.append(view)
+            return MagicMock()
+        # _has_data probe -> populated; COUNT(*) -> a number.
+        result = MagicMock()
+        result.scalar.return_value = 1 if "relispopulated" in sql else 100
+        return result
+
+    conn = MagicMock()
+    conn.execute.side_effect = execute
+    ctx = MagicMock()
+    ctx.__enter__.return_value = conn
+    engine = MagicMock()
+    engine.connect.return_value.execution_options.return_value = ctx
+
+    raised: Exception | None = None
+    with patch.object(R, "engine", engine):
+        try:
+            R.run()
+        except Exception as exc:  # noqa: BLE001 — inspected by the tests
+            raised = exc
+    return refreshed, raised
+
+
+def test_all_views_refresh_when_none_fail():
+    refreshed, raised = _run_with_failing_views(set())
+    assert raised is None
+    assert refreshed == list(R._VIEWS)
+
+
+def test_one_failure_does_not_strand_later_views():
+    target = R._VIEWS[0]
+    refreshed, raised = _run_with_failing_views({target})
+
+    assert isinstance(raised, RuntimeError)
+    assert target in str(raised)
+    assert target not in refreshed
+    assert set(R._VIEWS[1:]).issubset(set(refreshed)), "later views were stranded"
+
+
+def test_aggregated_error_names_all_failures():
+    failing = {R._VIEWS[0], R._VIEWS[-1]}
+    _refreshed, raised = _run_with_failing_views(failing)
+
+    assert isinstance(raised, RuntimeError)
+    assert R._VIEWS[0] in str(raised) and R._VIEWS[-1] in str(raised)

--- a/backend/tests/test_vacuum_covers_matviews.py
+++ b/backend/tests/test_vacuum_covers_matviews.py
@@ -1,0 +1,18 @@
+"""Every nightly-refreshed materialized view must also be VACUUM ANALYZE'd.
+
+mv_street_aggregates was added to the nightly refresh but forgotten in
+vacuum_analyze, so it accumulated CONCURRENTLY-refresh dead tuples and stale
+planner stats. This guard makes that omission fail a test instead of rotting
+silently on an unattended box.
+"""
+
+from app.health import REFRESHABLE_VIEWS
+from etl.vacuum_analyze import _TABLES
+
+
+def test_every_refreshed_view_is_vacuumed():
+    vacuumed = set(_TABLES)
+    missing = [v for v in REFRESHABLE_VIEWS if v not in vacuumed]
+    assert not missing, (
+        f"materialized views refreshed nightly but never VACUUM ANALYZE'd: {missing}"
+    )


### PR DESCRIPTION
Seven confirmed backend findings from the 2026-08-08 agent audit, batched (all backend, one deploy). Each is adversarially-verified and test-covered.

| # | sev | fix |
|---|---|---|
| 4 | med | `pipeline.run_backup` pinged the heartbeat GREEN on offsite (R2) upload failure — the second backup driver never got PR #391's contract. Now raises on offsite failure (heartbeat DOWN), returns bool, `--run-now backup` exits non-zero. |
| 7 | low | Heavy statewide aggregations (clusters, highways, distribution, yoy) returned a bare 500 on statement-timeout. Global `OperationalError` handler → 503 + Retry-After with an honest message. |
| 12 | low | CCRS freshness probed only the newest year, but the loader re-loads the latest **two** — a prior-year revision was missed. Now probes the newest two years. |
| 6 | low | A SWITRS year truncated at an exact BATCH_SIZE multiple (2001 at 310,000 = 62×5,000) counted as complete and was skipped forever. Exact-multiple **and** below-peer-median ⇒ resumed; a coincidental-multiple complete year isn't. |
| 11 | low | Matview refresh failed fast, stranding every later view stale while earlier ones were fresh. Now refreshes each independently and raises an aggregated error, isolating the failure while still failing the etl_run. |
| 8 | low | Public `/api/pipeline/health` leaked `db_size_mb`; now returned only to ETL-key holders. Coarse status stays public; wrong key → 200 without the field. |
| 10 | low | `mv_street_aggregates` was refreshed nightly but never VACUUM ANALYZE'd. Added it, plus a guard test that every refreshed view is vacuumed. |

## Verification
25 new/updated tests (backup heartbeat contract, OperationalError→503, two-year CKAN freshness, batch-truncation resumption, refresh resilience, db_size gating, vacuum-coverage guard). 858 backend unit tests pass, ruff clean. Integration tests run in CI.

Note (#4): per prior at-the-box verification the live scheduler is the host cron calling `etl.backup` directly (already correct since #391); this fixes the containerized driver so it can't regress the contract if the deployment ever changes.