### PR TITLE
fix(frontend): map attribution, highway error state, sort-aware heading

### DIFF
--- a/frontend/src/__mocks__/react-leaflet.tsx
+++ b/frontend/src/__mocks__/react-leaflet.tsx
@@ -9,6 +9,10 @@ export function TileLayer() {
   return null;
 }
 
+export function AttributionControl() {
+  return null;
+}
+
 /** Declarative marker mock: renders as a plain div (position + icon html
  *  exposed as data attributes) with its children (e.g. Popup) inside, so
  *  tests can assert markers and popup content with testing-library. */

--- a/frontend/src/components/map/MapCanvas.tsx
+++ b/frontend/src/components/map/MapCanvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
-import { MapContainer, TileLayer, Marker, useMap, useMapEvents } from "react-leaflet";
+import { MapContainer, TileLayer, Marker, AttributionControl, useMap, useMapEvents } from "react-leaflet";
 import L from "leaflet";
 import type { LatLngBoundsExpression, Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -313,6 +313,11 @@ export default function MapCanvas({
     >
       <ReducedMotionSync />
       {onViewportChange && <ViewportSync onChange={onViewportChange} />}
+      {/* Required tile-provider credit. The MapContainer disables the default
+          control (to drop the "Leaflet" promo prefix); this renders the one
+          remaining, obligatory OSM + CARTO attribution. PNG export strips
+          leaflet controls, so it doesn't appear in exports. */}
+      <AttributionControl position="bottomright" prefix={false} />
       <TileLayer
         key={baseTileUrl}
         url={baseTileUrl}

--- a/frontend/src/components/stats/HighwayRankingsTable.test.tsx
+++ b/frontend/src/components/stats/HighwayRankingsTable.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import HighwayRankingsTable from "./HighwayRankingsTable";
+import type { StatsFilters } from "../../hooks/useStats";
+
+const FILTERS: StatsFilters = {
+  dateRange: null,
+  severities: [],
+  causes: [],
+  counties: [],
+  alcohol: false,
+  pedestrian: false,
+  cyclist: false,
+  drug: false,
+};
+
+function renderTable() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrap = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<HighwayRankingsTable filters={FILTERS} />, { wrapper: wrap });
+}
+
+describe("HighwayRankingsTable", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("shows ONLY an error state on failure — not the empty-state too", async () => {
+    // Regression: on a server error the component rendered "Failed to load"
+    // AND "No highway crashes match the current filters" together, making an
+    // error look like a successful zero-result. 400 so it doesn't retry.
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("boom", { status: 400 }));
+    renderTable();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No highway crashes match/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the empty-state only on a genuine empty success", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("[]", { status: 200 }));
+    renderTable();
+
+    expect(
+      await screen.findByText(/No highway crashes match/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("renders rows on success", async () => {
+    const rows = [{
+      route_number: "US-101", crash_count: 1234, fatal_count: 10,
+      fatality_rate: 0.8, crashes_per_mile: 5.1, corridor_miles: 240,
+    }];
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(rows), { status: 200 }),
+    );
+    renderTable();
+
+    await waitFor(() =>
+      expect(screen.getByText("US-101")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/No highway crashes match/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/stats/HighwayRankingsTable.tsx
+++ b/frontend/src/components/stats/HighwayRankingsTable.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useHighwayRankings, type HighwaySort, type HighwayRow } from "../../hooks/useHighwayRankings";
 import type { StatsFilters } from "../../hooks/useStats";
+import { ErrorState } from "../ui/ErrorState";
 
 interface HighwayRankingsTableProps {
   filters: StatsFilters;
@@ -38,7 +39,7 @@ function fmtPerMile(v: number | null): string {
 
 export default function HighwayRankingsTable({ filters }: HighwayRankingsTableProps) {
   const [sort, setSort] = useState<HighwaySort>("crash_count");
-  const { data, isLoading, error } = useHighwayRankings(filters, sort, 20);
+  const { data, isLoading, error, refetch } = useHighwayRankings(filters, sort, 20);
 
   return (
     <section className="space-y-3">
@@ -67,11 +68,16 @@ export default function HighwayRankingsTable({ filters }: HighwayRankingsTablePr
         </div>
       </header>
 
-      {error && (
-        <div className="text-xs text-error" role="alert">Failed to load highway rankings.</div>
-      )}
-
-      {isLoading ? (
+      {error ? (
+        // Only reachable on a real failure — the empty-state ("No highway
+        // crashes match") must not also render here, or an error looks like a
+        // successful zero-result.
+        <ErrorState
+          title="Couldn't load highway rankings"
+          description="The server may be temporarily unavailable. Please try again."
+          onRetry={() => refetch()}
+        />
+      ) : isLoading ? (
         <div className="space-y-1.5" aria-busy="true" aria-label="Loading highway rankings">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="h-9 rounded-md bg-surface-container animate-pulse" />

--- a/frontend/src/components/stats/IntersectionsPanel.test.tsx
+++ b/frontend/src/components/stats/IntersectionsPanel.test.tsx
@@ -152,6 +152,11 @@ describe("IntersectionsPanel", () => {
     await vi.waitFor(() =>
       expect(spy.mock.calls.some((c) => String(c[0]).includes("sort=severity"))).toBe(true),
     );
+
+    // The heading must follow the sort, not stay pinned to "by crash count".
+    expect(
+      await screen.findByRole("heading", { name: /by severity-weighted score/ }),
+    ).toBeInTheDocument();
   });
 
   it("links each row to the map centered on its coordinates", async () => {

--- a/frontend/src/components/stats/IntersectionsPanel.tsx
+++ b/frontend/src/components/stats/IntersectionsPanel.tsx
@@ -104,13 +104,15 @@ export default function IntersectionsPanel() {
 
   const rows = data ?? [];
   const unit = scope === "intersections" ? "intersections" : "corridors";
+  const scopeLabel = scope === "intersections" ? "Intersections" : "Corridors";
+  const rankLabel = sort === "severity" ? "by severity-weighted score" : "by crash count";
 
   return (
     <section className="space-y-3" aria-label="Street-level crash aggregation">
       <header className="flex items-baseline justify-between gap-3 flex-wrap">
         <div>
           <h2 className="text-lg font-bold text-on-surface font-headline">
-            {scope === "intersections" ? "Intersections by crash count" : "Corridors by crash count"}
+            {scopeLabel} {rankLabel}
           </h2>
           <p className="text-[11px] text-on-surface-variant mt-0.5">
             {singleCounty ? `${singleCounty} County` : "Statewide"} ·{" "}
@@ -237,7 +239,7 @@ export default function IntersectionsPanel() {
         <div className="overflow-x-auto rounded-lg bg-surface-container-lowest ghost-border">
           <table className="w-full text-xs">
             <caption className="sr-only">
-              {scope === "intersections" ? "Intersections" : "Corridors"} ranked by crash count
+              {scopeLabel} ranked {rankLabel}
             </caption>
             <thead>
               <tr className="text-[10px] uppercase tracking-widest text-on-surface-variant">


### PR DESCRIPTION
Three confirmed frontend findings from the 2026-08-08 agent audit.

- **#13 Map attribution (licensing):** the Leaflet map disabled its attribution control, so the required **OpenStreetMap + CARTO** tile credit never rendered. Restored via an explicit `<AttributionControl prefix={false}>` — keeps the obligatory credit, drops the "Leaflet" promo prefix. PNG export already strips leaflet controls, so exports are unaffected.
- **#14 Highway table error-vs-empty:** on a server error the table showed *"Failed to load"* **and** *"No highway crashes match the current filters"* together, so an error read as a successful zero-result. The states are now mutually exclusive — error shows only an `ErrorState` with Retry; the empty-state is reachable only on a genuine empty success.
- **#15 Sort-aware heading:** the intersections/corridors `<h2>` (and sr-only caption) was hardcoded to *"by crash count"* even when sorted by severity-weighted score, contradicting its own subtitle. Both now follow the active sort.

## Verification
New HighwayRankingsTable test (error XOR empty-state), extended IntersectionsPanel test (heading follows sort), AttributionControl added to the shared react-leaflet mock. **1027 frontend tests pass**, tsc + eslint clean, build succeeds.