### PR TITLE
chore(ci,docs): enforce expand/contract migrations; fix stale runbook & CSP notes

### DIFF
--- a/backend/scripts/check_migration_expand_contract.py
+++ b/backend/scripts/check_migration_expand_contract.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Guard new Alembic migrations against unacknowledged contracting changes.
+
+The deploy pipeline never runs `alembic downgrade` and, on a failed deploy,
+rolls the *code* back to the previous image while leaving the schema migrated
+(deploy.yml). That only stays safe if every migration is backward-compatible:
+the previous code must keep working against the new schema. A contracting
+change in `upgrade()` — dropping or renaming a column/table the old code still
+reads — breaks that assumption and turns a rollback into an outage.
+
+This checks migration files (typically the ones ADDED in a PR) for contracting
+operations in their `upgrade()` function. A migration that genuinely needs one
+must acknowledge it with a marker comment so the reviewer sees the intent:
+
+    # migration-safety: drops the legacy column in a later release; no live
+    #   code reads it as of this deploy.
+
+Only `upgrade()` is inspected — drops in `downgrade()` are expected and fine.
+
+Usage:
+    python -m scripts.check_migration_expand_contract <file> [<file> ...]
+
+Exits non-zero if any file has an unacknowledged contracting change.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+# Alembic op.* calls that remove or rename schema the old code may still read.
+# Dropping a CONSTRAINT is deliberately excluded: relaxing a unique/check/FK
+# constraint is backward-compatible for readers (the previous image keeps
+# working), and constraints are routinely dropped to be redefined. The danger
+# is losing a column/table the old code still selects.
+_CONTRACTING_OPS = frozenset({
+    "drop_column",
+    "drop_table",
+    "rename_column",
+    "rename_table",
+})
+
+# Raw-SQL contracting statements inside op.execute("...").
+_RAW_SQL_CONTRACTING = re.compile(
+    r"\b(drop\s+table|drop\s+column|alter\s+table\s+.+\bdrop\b|rename\s+to)\b",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_SAFETY_MARKER = re.compile(r"#\s*migration-safety:", re.IGNORECASE)
+
+
+def has_safety_marker(source: str) -> bool:
+    """True when the author acknowledged a contracting change."""
+    return bool(_SAFETY_MARKER.search(source))
+
+
+def _upgrade_function(tree: ast.AST) -> ast.FunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "upgrade":
+            return node
+    return None
+
+
+def contracting_ops_in_upgrade(source: str) -> list[str]:
+    """Contracting operations found in the migration's upgrade(), as
+    "op_name (line N)" strings. Empty when upgrade() is expand-only.
+
+    downgrade() is intentionally ignored — undoing a migration is expected to
+    drop things.
+    """
+    tree = ast.parse(source)
+    upgrade = _upgrade_function(tree)
+    if upgrade is None:
+        return []
+
+    found: list[str] = []
+    for node in ast.walk(upgrade):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in _CONTRACTING_OPS:
+                found.append(f"{node.func.attr} (line {node.func.lineno})")
+            elif node.func.attr == "execute":
+                for arg in node.args:
+                    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                        if _RAW_SQL_CONTRACTING.search(arg.value):
+                            found.append(f"raw SQL drop/rename (line {node.lineno})")
+    return found
+
+
+def check_file(path: Path) -> list[str]:
+    """Return a list of violation messages for one migration file."""
+    source = path.read_text(encoding="utf-8")
+    if has_safety_marker(source):
+        return []
+    return [f"{path.name}: {op}" for op in contracting_ops_in_upgrade(source)]
+
+
+def main(argv: list[str]) -> int:
+    files = [Path(a) for a in argv if a.endswith(".py")]
+    if not files:
+        print("No migration files to check.")
+        return 0
+
+    violations: list[str] = []
+    for path in files:
+        violations.extend(check_file(path))
+
+    if violations:
+        print("Unacknowledged contracting migration change(s) detected:\n")
+        for v in violations:
+            print(f"  - {v}")
+        print(
+            "\nThe deploy pipeline rolls code back but not the schema, so every\n"
+            "migration must be backward-compatible. If this drop/rename is\n"
+            "intentional and no live code reads the affected schema, add a\n"
+            "marker comment to the migration:\n\n"
+            "    # migration-safety: <why this is safe for the running code>\n"
+        )
+        return 1
+
+    print(f"Checked {len(files)} migration file(s): all expand-only or acknowledged.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/backend/tests/test_migration_expand_contract_guard.py
+++ b/backend/tests/test_migration_expand_contract_guard.py
@@ -1,0 +1,87 @@
+"""Unit tests for the expand/contract migration guard's detection logic."""
+
+from scripts.check_migration_expand_contract import (
+    contracting_ops_in_upgrade,
+    has_safety_marker,
+)
+
+_EXPAND_ONLY = '''
+def upgrade():
+    op.add_column("crashes", sa.Column("new_flag", sa.Boolean))
+    op.create_index("ix_new_flag", "crashes", ["new_flag"])
+
+def downgrade():
+    op.drop_index("ix_new_flag")
+    op.drop_column("crashes", "new_flag")
+'''
+
+_DROP_IN_UPGRADE = '''
+def upgrade():
+    op.drop_column("crashes", "legacy_col")
+
+def downgrade():
+    op.add_column("crashes", sa.Column("legacy_col", sa.String))
+'''
+
+_RAW_SQL_DROP = '''
+def upgrade():
+    op.execute("ALTER TABLE crashes DROP COLUMN legacy_col")
+'''
+
+_RENAME = '''
+def upgrade():
+    op.rename_column("crashes", "old", "new")
+'''
+
+
+def test_expand_only_upgrade_has_no_violations():
+    assert contracting_ops_in_upgrade(_EXPAND_ONLY) == []
+
+
+def test_drops_in_downgrade_are_ignored():
+    # _EXPAND_ONLY drops in downgrade() — must not be flagged.
+    ops = contracting_ops_in_upgrade(_EXPAND_ONLY)
+    assert not any("drop" in o for o in ops)
+
+
+def test_drop_column_in_upgrade_is_flagged():
+    ops = contracting_ops_in_upgrade(_DROP_IN_UPGRADE)
+    assert len(ops) == 1
+    assert "drop_column" in ops[0]
+
+
+def test_raw_sql_drop_is_flagged():
+    ops = contracting_ops_in_upgrade(_RAW_SQL_DROP)
+    assert len(ops) == 1
+    assert "raw SQL" in ops[0]
+
+
+def test_rename_in_upgrade_is_flagged():
+    ops = contracting_ops_in_upgrade(_RENAME)
+    assert "rename_column" in ops[0]
+
+
+def test_safety_marker_detected():
+    assert has_safety_marker("# migration-safety: intentional, no reader\n")
+    assert not has_safety_marker("# just a normal comment\n")
+
+
+def test_real_migrations_upgrade_paths_are_expand_only_or_marked():
+    """Every committed migration's upgrade() must be expand-only OR carry the
+    acknowledgment marker — the same rule CI enforces on new ones, applied to
+    the whole tree as a backstop."""
+    from pathlib import Path
+
+    versions = Path(__file__).resolve().parent.parent / "migrations" / "versions"
+    offenders = []
+    for path in versions.glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        if has_safety_marker(source):
+            continue
+        if contracting_ops_in_upgrade(source):
+            offenders.append(path.name)
+
+    assert not offenders, (
+        "migrations with an unacknowledged contracting upgrade(): "
+        f"{offenders}. Add a `# migration-safety:` comment if intentional."
+    )

--- a/docs/RESTORE_RUNBOOK.md
+++ b/docs/RESTORE_RUNBOOK.md
@@ -174,5 +174,3 @@ Write the elapsed `pg_restore` time here — it is your first real RTO number:
    backups. What survives a host loss: R2 dumps, the GitHub repo + Actions
    secrets, Cloudflare config, healthchecks.io. The real root of trust is
    **Jeff's Cloudflare and GitHub account access** — protect those above all.
-5. **`[LOW]` `docs/OPERATOR_SETUP.md` §3 is stale** — it claims nothing
-   uploads to R2. Offsite upload has been live since 2026-06-23.

--- a/docs/security/csp-style-unsafe-inline.md
+++ b/docs/security/csp-style-unsafe-inline.md
@@ -1,0 +1,37 @@
+# Why `style-src` keeps `'unsafe-inline'`
+
+The Content-Security-Policy in `frontend/public/_headers` allows
+`style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`. The
+`'unsafe-inline'` is a **deliberate, documented exception**, not an oversight
+(flagged as a LOW finding in the 2026-08-08 audit).
+
+## Why it can't simply be removed
+
+The app is a Leaflet map. Leaflet positions tiles, panes, markers, the heatmap
+canvas, and zoom transforms by writing to `element.style` on almost every
+interaction. Browsers govern inline **style attributes** (`el.style.foo = …`
+and `style="…"`) under `style-src-attr`, which falls back to `style-src`.
+Removing `'unsafe-inline'` there would break map rendering and panning.
+
+Unlike inline `<script>`, inline **styles** have no nonce/hash escape hatch
+that covers runtime `element.style` mutations — a nonce only authorizes
+`<style>` elements, not the style-attribute writes Leaflet relies on. So there
+is no way to keep the map working while dropping `'unsafe-inline'` from
+`style-src`.
+
+## Why the residual risk is low
+
+- `script-src` does **not** use `'unsafe-inline'` — it pins two hashes. Script
+  injection, the path to actual code execution and data exfiltration, is
+  closed.
+- `connect-src`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`,
+  and `frame-ancestors 'none'` remain tight, so even injected styles have no
+  exfiltration channel.
+- The worst realistic abuse of inline-style injection here is cosmetic
+  (restyling elements), not data theft or code execution.
+
+## If this is ever revisited
+
+Dropping `'unsafe-inline'` from `style-src` would require replacing Leaflet, or
+a browser mechanism for hashing/nonce-ing style-attribute writes. Neither is
+worth it for a cosmetic-only residual risk on a public open-data map.


### PR DESCRIPTION
The three low-severity remainder from the 2026-08-08 agent audit.

- **#16 Expand/contract migration guard.** The deploy rolls code back but never the schema, so every migration must be backward-compatible — nothing enforced it. `scripts/check_migration_expand_contract.py` flags `drop_column`/`drop_table`/`rename` in a migration's `upgrade()` (downgrade ignored; `drop_constraint` excluded as reader-safe). A genuinely-needed contracting change is acknowledged with `# migration-safety: <why>`. Enforcement is a **pytest backstop** scanning the whole `versions/` tree every CI run — no git-diff plumbing, passes clean today (the only two historical upgrade-drops are constraint redefinitions). Detection logic unit-tested.
- **#17 Stale runbook note.** `RESTORE_RUNBOOK.md` gap 5 flagged `OPERATOR_SETUP §3` as stale, but §3 was fixed in #391 — the note was itself stale. Removed.
- **#9 CSP `unsafe-inline` (documented won't-fix).** Leaflet writes `element.style` constantly, gated under `style-src-attr` with no nonce/hash escape hatch, so removing `'unsafe-inline'` breaks the map. `script-src` uses hashes (no unsafe-inline), so code-execution/exfil paths stay closed and the residual risk is cosmetic. Reasoning in `docs/security/csp-style-unsafe-inline.md`.

Closes the code-fixable remainder of the audit. Jeff-only items stay open (restore drill, R2 lifecycle rule, crontab-in-git).