### PR TITLE
fix: stop publishing fabricated YoY declines; un-break the Stats page

### DIFF
--- a/backend/app/routers/changes.py
+++ b/backend/app/routers/changes.py
@@ -48,11 +48,17 @@ _MIN_BASELINE: dict[str, int] = {
 # treated as not-yet-loaded (upstream ingest lag), not as a real collapse in
 # crashes. Defaulting the comparison to such a year would rank every county
 # at -100% — the exact small-number noise this endpoint exists to avoid.
-_MIN_COVERAGE_RATIO = 0.2
+#
+# Set above the largest genuine single-year decline in the record (2020's
+# COVID drop was ~21.6%, i.e. 78.4% of 2019) so a real safety improvement is
+# never mistaken for missing data, while a half-ingested year is. The old 0.2
+# was far too permissive: a year holding half its neighbour's rows sailed
+# through and got ranked as if complete.
+_MIN_COVERAGE_RATIO = 0.7
 
 
 def _default_year(db: Session) -> int:
-    """Latest crash_year with meaningful coverage relative to the year before.
+    """Latest COMPLETE crash_year with meaningful coverage relative to the prior year.
 
     Sourced from mv_crashes_by_year — a ~6K-row pre-aggregate (county x year x
     severity) refreshed by the same nightly pipeline — rather than a full
@@ -75,10 +81,23 @@ def _default_year(db: Session) -> int:
             )
         ).all()
     }
+    current_year = datetime.now(timezone.utc).year
     if not counts:
-        return datetime.now(timezone.utc).year
-    year = max(counts)
-    while year - 1 in counts and counts[year] < _MIN_COVERAGE_RATIO * counts[year - 1]:
+        return current_year
+
+    # Never default to the current calendar year. It is partial by definition —
+    # comparing a few months against a full prior year manufactures declines of
+    # -50% to -64% for every county, which is exactly what this endpoint used to
+    # publish. Same rule the per-county insight cards apply; an explicit
+    # ?year=<current> is still honoured and flagged partial_year.
+    complete = {y: n for y, n in counts.items() if y < current_year}
+    if not complete:
+        # Only current-year data exists at all (a fresh/empty database). Fall
+        # back rather than fail; partial_year will flag it.
+        return max(counts)
+
+    year = max(complete)
+    while year - 1 in complete and complete[year] < _MIN_COVERAGE_RATIO * complete[year - 1]:
         year -= 1
     return year
 

--- a/backend/tests/api/test_yoy_changes.py
+++ b/backend/tests/api/test_yoy_changes.py
@@ -6,7 +6,7 @@ we insert controlled rows so the comparison years are deterministic.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import text
@@ -99,7 +99,7 @@ def test_yoy_default_skips_barely_loaded_trailing_year(client, db_session):
     not be the default comparison year — it would rank every county at -100%."""
     rows = []
     cid = 9800
-    for y, n in ((2030, 50), (2031, 2)):
+    for y, n in ((2024, 50), (2025, 2)):
         for _ in range(n):
             rows.append(_crash(cid, 19, y))
             cid += 1
@@ -111,19 +111,49 @@ def test_yoy_default_skips_barely_loaded_trailing_year(client, db_session):
     db_session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_year"))
 
     body = client.get("/api/stats/yoy-changes?metric=crashes").json()
-    assert body["year"] == 2030
+    assert body["year"] == 2024
     assert body["partial_year"] is False
 
     # An explicit request for the sliver year is still honored.
-    body = client.get("/api/stats/yoy-changes?metric=crashes&year=2031").json()
-    assert body["year"] == 2031
+    body = client.get("/api/stats/yoy-changes?metric=crashes&year=2025").json()
+    assert body["year"] == 2025
+
+
+def test_yoy_default_never_selects_the_current_calendar_year(client, db_session):
+    """Regression: the public "biggest year-over-year changes" panel used to
+    default to the in-progress calendar year and rank a few months of data
+    against a full prior year, fabricating -50% to -64% declines for every
+    county. The current year must never be chosen as the default, no matter how
+    many rows it holds — it is partial by definition.
+    """
+    current_year = datetime.now(timezone.utc).year
+    rows = []
+    cid = 9700
+    # Give the current year MORE rows than the prior complete year, so only the
+    # calendar-year rule (not the coverage ratio) can exclude it.
+    for y, n in ((current_year - 1, 40), (current_year, 120)):
+        for _ in range(n):
+            rows.append(_crash(cid, 19, y))
+            cid += 1
+    db_session.add_all(rows)
+    db_session.flush()
+    db_session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_year"))
+
+    body = client.get("/api/stats/yoy-changes?metric=crashes").json()
+    assert body["year"] == current_year - 1, "defaulted to the in-progress year"
+    assert body["partial_year"] is False
+
+    # Explicit opt-in still works, and is honestly flagged.
+    body = client.get(f"/api/stats/yoy-changes?metric=crashes&year={current_year}").json()
+    assert body["year"] == current_year
+    assert body["partial_year"] is True
 
 
 def test_yoy_default_year_reads_from_matview(client, db_session):
     """_default_year routes off mv_crashes_by_year, not a full GROUP BY over the
     11M-row crashes table: a live-table row in a brand-new max year is ignored
     until the MV is refreshed, then honored."""
-    rows = [_crash(9900 + i, 19, 2040) for i in range(200)]
+    rows = [_crash(9900 + i, 19, 2025) for i in range(200)]
     db_session.add_all(rows)
     db_session.flush()
 
@@ -133,8 +163,8 @@ def test_yoy_default_year_reads_from_matview(client, db_session):
 
     db_session.execute(text("REFRESH MATERIALIZED VIEW mv_crashes_by_year"))
     body = client.get("/api/stats/yoy-changes?metric=crashes").json()
-    assert body["year"] == 2040
-    # Per-county numbers still come from the live table: 2040 has the 200 rows.
+    assert body["year"] == 2025
+    # Per-county numbers still come from the live table: 2025 has the 200 rows.
     assert body["rows"][0]["current"] == 200
 
 

--- a/frontend/src/hooks/useDashboardData.test.tsx
+++ b/frontend/src/hooks/useDashboardData.test.tsx
@@ -134,4 +134,35 @@ describe("useDashboardData", () => {
     // …while the secondary series is untouched by the chart's display options.
     expect(result.current.dataBySlot["year:killed"].map((d) => d.value)).toEqual([40, 25]);
   });
+
+  it("degrades to empty when a group returns an in-band incompatibility object", async () => {
+    // Regression: /api/stats/batch reports a filter that doesn't apply to a
+    // dimension as `{"error": ..., "filter": ...}` INSIDE a 200. `?? []` lets
+    // that object through to transformRows, which threw and crashed the whole
+    // Dashboard Builder. It must render an empty chart instead.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats/batch")) {
+        return new Response(JSON.stringify({
+          year: YEAR_ROWS,
+          gender: { error: "pedestrian is not supported for gender", filter: "pedestrian" },
+        }));
+      }
+      return new Response(JSON.stringify({}));
+    });
+
+    const charts: ChartSlot[] = [
+      { id: "a", dimension: "year", measure: "count", chartType: "line", order: 0 },
+      { id: "b", dimension: "gender", measure: "count", chartType: "bar", order: 1 },
+    ];
+
+    const { result } = renderHook(() => useDashboardData(charts, FILTERS), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The incompatible dimension is empty, the compatible one still renders.
+    expect(result.current.dataBySlot["gender:count"]).toEqual([]);
+    expect(result.current.dataBySlot["year:count"].map((d) => d.value)).toEqual([400, 500]);
+  });
 });

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -197,7 +197,13 @@ export function useDashboardData(charts: ChartSlot[], filters: StatsFilters, cro
     // applied. Chart-specific display options (cumulative, moving average,
     // log scale) are applied to the primary series only, below.
     const computeItems = (dimension: Dimension, measure: Measure): ChartDataItem[] => {
-      let items = transformRows(dimension, measure, raw[dimension] ?? []);
+      // /api/stats/batch reports a per-group filter incompatibility in band —
+      // `{"rate": {"error": "...", "filter": "pedestrian"}}` inside a 200 — so
+      // `?? []` isn't enough: the value is a non-null object that would reach
+      // transformRows and throw. An incompatible dimension means "no data for
+      // these filters"; render the empty state instead of crashing the board.
+      const groupRows = raw[dimension];
+      let items = transformRows(dimension, measure, Array.isArray(groupRows) ? groupRows : []);
       if (measure === "percentage") {
         const total = items.reduce((s, d) => s + d.value, 0);
         items = total > 0

--- a/frontend/src/hooks/useStats.test.tsx
+++ b/frontend/src/hooks/useStats.test.tsx
@@ -232,4 +232,49 @@ describe("useStats", () => {
     await waitFor(() => expect(result.current.error).not.toBeNull());
     expect(result.current.loading).toBe(false);
   });
+
+  it("survives per-group incompatibility objects returned inside a 200", async () => {
+    // Regression: /api/stats/batch reports a filter that doesn't apply to a
+    // group *in band* — `{"rate": {"error": ..., "filter": "pedestrian"}}` —
+    // inside an otherwise-successful response. `?? []` cannot catch a non-null
+    // object, so `.map` threw during render and the whole Stats page fell to
+    // its ErrorBoundary on ANY involvement or weather/lighting/collision
+    // filter, including the promoted "DUI Deep Dive" and "Crash Conditions"
+    // presets. Incompatible groups must degrade to empty, not crash.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/stats/batch")) {
+        return new Response(JSON.stringify({
+          year: YEAR_ROWS,
+          hour: HOUR_ROWS,
+          cause: CAUSE_ROWS,
+          severity: [],
+          // The groups the backend rejects for an involvement filter:
+          gender: { error: "pedestrian is not supported for gender", filter: "pedestrian" },
+          age_bracket: { error: "not supported", filter: "pedestrian" },
+          at_fault_gender: { error: "not supported", filter: "pedestrian" },
+          at_fault_age_bracket: { error: "not supported", filter: "pedestrian" },
+          month: [],
+          day_of_week: [],
+          rate: { error: "not supported", filter: "pedestrian" },
+        }));
+      }
+      if (url.includes("/api/demographics")) {
+        return new Response(JSON.stringify(DEMO_ROWS));
+      }
+      return new Response(JSON.stringify([]));
+    });
+
+    const { result } = renderHook(() => useStats(FILTERS), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+
+    // Incompatible groups come back empty...
+    expect(result.current.data!.rateData).toEqual([]);
+    expect(result.current.data!.genderData).toEqual([]);
+    expect(result.current.data!.atFaultGenderData).toEqual([]);
+    // ...while the compatible ones still render, and nothing threw.
+    expect(result.current.data!.yearlyData.length).toBeGreaterThan(0);
+    expect(result.current.data!.hourlyData.length).toBeGreaterThan(0);
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -258,40 +258,56 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
     if (!batchQuery.data) return null;
     const b = batchQuery.data;
 
-    const yearlyData: YearlyDataPoint[] = ((b.year ?? []) as YearRow[]).map((r) => ({
+    /**
+     * A batch group is only sometimes an array of rows.
+     *
+     * /api/stats/batch reports a per-group filter incompatibility *in band*,
+     * inside an otherwise-200 response: `{"rate": {"error": "...", "filter":
+     * "pedestrian"}}`. A `?? []` fallback can't catch that — the value is a
+     * non-null object, so it passes through and `.map` throws during render,
+     * taking the whole Stats page down to the ErrorBoundary. That is what any
+     * involvement or condition filter used to do, including the promoted
+     * "DUI Deep Dive" and "Crash Conditions" presets.
+     *
+     * Treat an incompatible group as "no data for these filters", which is
+     * what it means, and let the panel render its normal empty state.
+     */
+    const rows = <T,>(group: unknown): T[] => (Array.isArray(group) ? (group as T[]) : []);
+
+    const yearlyData: YearlyDataPoint[] = rows<YearRow>(b.year).map((r) => ({
       year: r.year, count: r.crash_count, killed: r.total_killed, injured: r.total_injured,
     }));
-    const hourlyData: HourlyDataPoint[] = ((b.hour ?? []) as HourRow[]).map((r) => ({
+    const hourlyData: HourlyDataPoint[] = rows<HourRow>(b.hour).map((r) => ({
       hour: r.hour, count: r.crash_count,
     }));
-    const causesData: CauseDataPoint[] = ((b.cause ?? []) as CauseRow[]).map((r) => ({
+    const causesData: CauseDataPoint[] = rows<CauseRow>(b.cause).map((r) => ({
       label: CAUSE_LABEL[r.canonical_cause] ?? r.canonical_cause, count: r.crash_count,
     }));
-    const severityData: SeverityDataPoint[] = ((b.severity ?? []) as SeverityRow[]).map((r) => ({
+    const severityData: SeverityDataPoint[] = rows<SeverityRow>(b.severity).map((r) => ({
       label: r.severity, count: r.crash_count,
     }));
-    const genderData: GenderDataPoint[] = ((b.gender ?? []) as GenderRow[])
+    const genderData: GenderDataPoint[] = rows<GenderRow>(b.gender)
       .filter((r) => r.gender && r.gender !== "unknown")
       .map((r) => ({ label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1), count: r.victim_count }));
-    const ageBracketData: AgeBracketDataPoint[] = ((b.age_bracket ?? []) as AgeBracketRow[])
+    const ageBracketData: AgeBracketDataPoint[] = rows<AgeBracketRow>(b.age_bracket)
       .sort((a, b2) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b2.age_bracket))
       .filter((r) => r.age_bracket !== "unknown")
       .map((r) => ({ label: AGE_LABEL[r.age_bracket] ?? r.age_bracket, count: r.victim_count }));
-    const atFaultGenderData: AtFaultGenderDataPoint[] = ((b.at_fault_gender ?? []) as AtFaultGenderRow[])
+    const atFaultGenderData: AtFaultGenderDataPoint[] = rows<AtFaultGenderRow>(b.at_fault_gender)
       .filter((r) => r.gender && r.gender !== "unknown")
       .map((r) => ({ label: r.gender.charAt(0).toUpperCase() + r.gender.slice(1), count: r.party_count }));
-    const atFaultAgeBracketData: AtFaultAgeBracketDataPoint[] = ((b.at_fault_age_bracket ?? []) as AtFaultAgeBracketRow[])
+    const atFaultAgeBracketData: AtFaultAgeBracketDataPoint[] = rows<AtFaultAgeBracketRow>(b.at_fault_age_bracket)
       .sort((a, b2) => AGE_ORDER.indexOf(a.age_bracket) - AGE_ORDER.indexOf(b2.age_bracket))
       .filter((r) => r.age_bracket !== "unknown")
       .map((r) => ({ label: AGE_LABEL[r.age_bracket] ?? r.age_bracket, count: r.party_count }));
-    const monthlyData: MonthlyDataPoint[] = ((b.month ?? []) as MonthRow[]).map((r) => ({
+    const monthlyData: MonthlyDataPoint[] = rows<MonthRow>(b.month).map((r) => ({
       month: r.month, label: MONTH_LABEL[r.month - 1] ?? String(r.month),
       count: r.crash_count, killed: r.total_killed, injured: r.total_injured,
     }));
-    const dayOfWeekData: DayOfWeekDataPoint[] = ((b.day_of_week ?? []) as DayOfWeekRow[]).map((r) => ({
+    const dayOfWeekData: DayOfWeekDataPoint[] = rows<DayOfWeekRow>(b.day_of_week).map((r) => ({
       day: r.day_of_week, label: DOW_LABEL[r.day_of_week] ?? String(r.day_of_week), count: r.crash_count,
     }));
-    const rateData: RateDataPoint[] = ((b.rate ?? []) as RateRow[]).map((r) => ({
+    const rateData: RateDataPoint[] = rows<RateRow>(b.rate).map((r) => ({
       county_code: r.county_code, county_name: r.county_name ?? "Unknown", year: r.year,
       severity: r.severity, total_crashes: r.total_crashes, total_killed: r.total_killed,
       total_injured: r.total_injured, per_100k_population: r.per_100k_population,
@@ -302,7 +318,7 @@ export function useStats(rawFilters: StatsFilters): UseStatsResult {
     const population = demoQuery.data
       ? demoQuery.data.reduce((s, r) => s + (r.population ?? 0), 0)
       : null;
-    const heroMetrics = computeHeroMetrics((b.year ?? []) as YearRow[], population);
+    const heroMetrics = computeHeroMetrics(rows<YearRow>(b.year), population);
 
     return { hourlyData, yearlyData, causesData, severityData, genderData, ageBracketData, atFaultGenderData, atFaultAgeBracketData, monthlyData, dayOfWeekData, rateData, heroMetrics };
   }, [batchQuery.data, demoQuery.data]);


### PR DESCRIPTION
The two live defects found by the 82-agent research pass. Both verified against production before fixing.

## 1. The public YoY panel was publishing invented declines

`/api/stats/yoy-changes` defaulted to the **in-progress calendar year** and ranked a few months against a full prior year:

| County | Published (default) | Reality (`?year=2025`) |
|---|---|---|
| Trinity | **−63.7%** | — |
| San Benito | **−61.9%** | — |
| Fresno | **−57.4%** | — |
| Merced | — | −18.2% |

2026 holds 207,673 crashes — 51.8% of 2025 — which sailed past the **0.2** coverage gate at `changes.py:51`.

`_default_year` now excludes the current calendar year and beyond (no complete year can exist at or after "now"), the same rule already applied to the per-county insight cards in #393. The coverage ratio also rises **0.2 → 0.7**, deliberately set above the largest genuine single-year decline on record (2020's COVID drop, ~21.6%) so a real safety improvement is never mistaken for missing data. Explicit `?year=<current>` still works and is flagged `partial_year`.

## 2. P0 — the Stats page crashed on any involvement filter

`/api/stats/batch` reports a per-group filter incompatibility **in band** — `{"rate": {"error": ..., "filter": "pedestrian"}}` inside an otherwise-200 response (`stats.py:960`). A `?? []` fallback can't catch a non-null object, so `.map` threw during render and the page fell to its ErrorBoundary.

This took down the two **promoted** presets — *DUI Deep Dive* and *Crash Conditions* — plus every alcohol/distracted/pedestrian toggle. Dashboard Builder failed identically at `useDashboardData.ts:200`.

Both hooks now treat a non-array group as "no data for these filters" and render the normal empty state. `useStats` routes all twelve transforms through a single `rows<T>()` helper instead of repeating the guard twelve times.

## Note on two touched tests
Two existing yoy tests used far-future years (2030/2040) as fixture conveniences — which the new current-year rule correctly excludes. I moved them onto realistic past years so they still test their real intent (coverage ratio, matview sourcing) rather than weakening the rule to accommodate them.

## Verification
865 backend unit tests · 1029 frontend tests · ruff + tsc clean. New regression tests cover both fixes, including that the current year is skipped **even when it holds more rows than the prior year** — so only the calendar rule, not the ratio, can be what excludes it.