### PR TITLE
fix: correct the highways per-mile rate; stop overclaiming statistical rigor

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -44,7 +44,10 @@ def verify_admin_key(body: VerifyRequest, request: Request, response: Response):
             detail="Admin key not configured on server",
             headers=_NO_STORE,
         )
-    if not hmac.compare_digest(body.key, admin_key):
+    # Compare bytes, not str: hmac.compare_digest raises TypeError on strings
+    # holding non-ASCII, which would surface as a 500 with a stack trace
+    # instead of a clean 403 the moment someone set a key with an accent in it.
+    if not hmac.compare_digest(body.key.encode("utf-8"), admin_key.encode("utf-8")):
         raise HTTPException(
             status_code=403, detail="Invalid admin key", headers=_NO_STORE
         )

--- a/backend/app/routers/etl.py
+++ b/backend/app/routers/etl.py
@@ -91,7 +91,12 @@ def _verify_etl_key(x_etl_api_key: str = Header(None)):
         raise HTTPException(
             status_code=503, detail="ETL API key not configured", headers=no_store
         )
-    if not x_etl_api_key or not hmac.compare_digest(x_etl_api_key, settings.etl_api_key):
+    # Compare bytes, not str: hmac.compare_digest raises TypeError on strings
+    # holding non-ASCII (a latin-1 header can carry them), which would surface
+    # as a 500 with a stack trace instead of a clean 403.
+    if not x_etl_api_key or not hmac.compare_digest(
+        x_etl_api_key.encode("utf-8"), settings.etl_api_key.encode("utf-8")
+    ):
         raise HTTPException(
             status_code=403, detail="Invalid ETL API key", headers=no_store
         )

--- a/backend/app/routers/intersections.py
+++ b/backend/app/routers/intersections.py
@@ -120,13 +120,18 @@ def _degrade_on_timeout(db: Session, timeout_ms: int, scope: str):
             headers={"Retry-After": "60"},
         ) from exc
 
-# Relative severity weights for the optional severity-weighted score
-# (EPDO-style — "equivalent property-damage-only"). These are a presentation
-# choice for ranking, not a statement about the value of a life; an order-of-
-# magnitude scale (fatal 100 : injury 10 : pdo 1) kept intentionally modest so
-# a single fatality doesn't wholly dominate the ranking. Documented so the
-# user knows how "severity-weighted" is computed and can weigh it against the
-# plain crash count.
+# Relative severity weights for the optional severity-weighted score. These are
+# a presentation choice for ranking, not a statement about the value of a life;
+# an order-of-magnitude scale (fatal 100 : injury 10 : pdo 1) kept intentionally
+# modest so a single fatality doesn't wholly dominate the ranking. Documented so
+# the user knows how "severity-weighted" is computed and can weigh it against
+# the plain crash count.
+#
+# Deliberately NOT called "EPDO" any more. Real cost-based EPDO weightings (the
+# Highway Safety Manual and state DOT practice) put the fatal weight around
+# 950-1300, not 100, so this flat ratio ranks fatal-heavy rural corridors far
+# lower than a standards-compliant EPDO would. Naming it EPDO implied a
+# compliance this doesn't have; it stays an honestly-labelled opt-in sort.
 _W_FATAL, _W_INJURY, _W_PDO = 100, 10, 1
 
 

--- a/backend/app/routers/pipeline_health.py
+++ b/backend/app/routers/pipeline_health.py
@@ -158,7 +158,10 @@ def pipeline_health(
     authed = bool(
         settings.etl_api_key
         and x_etl_api_key
-        and hmac.compare_digest(x_etl_api_key, settings.etl_api_key)
+        # Bytes, not str — compare_digest raises TypeError on non-ASCII strings.
+        and hmac.compare_digest(
+            x_etl_api_key.encode("utf-8"), settings.etl_api_key.encode("utf-8")
+        )
     )
     db_size = None
     if authed:

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1071,6 +1071,15 @@ def stats_highways(
 
     raw_rows = db.execute(stmt).all()
 
+    # Crashes-per-mile is only meaningful when the crash count covers the same
+    # geography as the mileage. ca_highways carries a route's FULL California
+    # centerline length and has no county dimension, so under a county filter
+    # the numerator shrinks to one county while the denominator stays statewide
+    # — I-5 scoped to San Diego read roughly 10x too low, and that wrong value
+    # fed the map's "Per Mile" danger colouring. There is no in-county mileage
+    # to divide by, so report the rate as unavailable rather than wrong.
+    county_scoped = bool(county_codes)
+
     # Build the per-mile rate in Python — pulling the over-fetch (all routes,
     # then truncating) is fine because there are ~120 known routes and the
     # group-by output stays small even before filtering.
@@ -1079,7 +1088,10 @@ def stats_highways(
         crash_count = int(r.crash_count)
         killed = int(r.total_killed)
         injured = int(r.total_injured)
+        # `miles` stays populated either way: a route's length is a fact about
+        # the route, independent of which crashes are in scope.
         miles = miles_for(r.route_number)
+        per_mile = None if county_scoped else ((crash_count / miles) if miles else None)
         enriched.append(
             HighwayRow(
                 route_number=r.route_number,
@@ -1088,7 +1100,7 @@ def stats_highways(
                 total_injured=injured,
                 fatality_rate=(killed / crash_count) if crash_count else 0.0,
                 miles=miles,
-                crashes_per_mile=(crash_count / miles) if miles else None,
+                crashes_per_mile=per_mile,
             ),
         )
 
@@ -1096,6 +1108,11 @@ def stats_highways(
         enriched.sort(key=lambda h: h.crash_count, reverse=True)
     elif sort == "fatality_rate":
         enriched.sort(key=lambda h: h.fatality_rate, reverse=True)
+    elif county_scoped:
+        # Ranking by a rate we just declared unavailable would return nothing
+        # and read as "no dangerous highways in this county". Fall back to the
+        # honest ordering instead, so the caller still gets the county's routes.
+        enriched.sort(key=lambda h: h.crash_count, reverse=True)
     else:
         # crashes_per_mile — routes without known mileage can't rank here.
         enriched = [h for h in enriched if h.crashes_per_mile is not None]

--- a/backend/tests/api/test_stats_highways.py
+++ b/backend/tests/api/test_stats_highways.py
@@ -67,6 +67,43 @@ def test_highways_county_filter(client):
     assert routes == {"US-101"}
 
 
+def test_highways_per_mile_is_null_under_a_county_filter(client):
+    """crashes_per_mile must not divide a county-scoped count by statewide miles.
+
+    ca_highways carries a route's FULL California centerline length and has no
+    county dimension, so under a county filter the numerator covered one county
+    while the denominator covered the whole state — I-5 scoped to San Diego read
+    roughly 10x too low, and that value fed the map's "Per Mile" colouring.
+    There is no in-county mileage to divide by, so the rate must report as
+    unavailable rather than wrong.
+    """
+    body = client.get("/api/stats/highways?county=orange").json()
+    assert body, "expected at least one route in Orange County"
+    for row in body:
+        assert row["crashes_per_mile"] is None, (
+            f"{row['route_number']} published a per-mile rate under a county filter"
+        )
+        # The route's own length is still a fact about the route, so it stays.
+        assert row["miles"] is not None and row["miles"] > 0
+
+
+def test_highways_per_mile_sort_still_returns_rows_under_county_filter(client):
+    """Ranking by a rate we just declared unavailable must not silently return
+    an empty list — that would read as "no dangerous highways in this county".
+    It falls back to crash-count order instead."""
+    body = client.get("/api/stats/highways?county=orange&sort=crashes_per_mile").json()
+    assert body, "county + per-mile sort returned nothing instead of falling back"
+    counts = [r["crash_count"] for r in body]
+    assert counts == sorted(counts, reverse=True)
+
+
+def test_highways_per_mile_still_computed_statewide(client):
+    """The statewide case is unaffected — numerator and denominator agree."""
+    body = client.get("/api/stats/highways").json()
+    i5 = next(r for r in body if r["route_number"] == "I-5")
+    assert i5["crashes_per_mile"] == pytest.approx(i5["crash_count"] / i5["miles"], rel=1e-6)
+
+
 def test_highways_limit_clamps_to_max(client):
     response = client.get("/api/stats/highways?limit=999")
     # Out-of-range limit should reject with 422 (FastAPI/pydantic le=300).

--- a/docs/DATA_METHODOLOGY.md
+++ b/docs/DATA_METHODOLOGY.md
@@ -534,7 +534,20 @@ vehicles_per_capita = total_vehicles / population
 
 ## 6. Statistical Methods
 
-CalSight implements a pure-TypeScript statistical hypothesis testing library (`frontend/src/lib/dashboard/hypothesis.ts`) with no external dependencies. All p-values are computed via analytical approximations using the incomplete gamma function, incomplete beta function, and normal CDF -- no lookup tables.
+> **Scope note, added 2026-08-09.** An earlier revision of this section
+> described a hypothesis-testing library at
+> `frontend/src/lib/dashboard/hypothesis.ts` providing t-statistics, p-values,
+> Fisher's-z confidence intervals, Benjamini-Hochberg FDR correction and a
+> chi-squared test. **That module does not exist and never shipped.** The
+> descriptions below now match the code that actually runs. Documenting
+> statistics the product does not perform is a worse failure for a
+> transparency project than not performing them, so the text was corrected
+> rather than the claim quietly dropped.
+
+CalSight computes descriptive statistics only. It reports **effect sizes**
+(correlation coefficients, rates, shares) and does **not** compute p-values,
+confidence intervals, or any multiple-comparison correction. Read every
+correlation below as descriptive, not inferential.
 
 ### 6.1 Pearson Correlation Coefficient
 
@@ -544,9 +557,23 @@ Used in the 26-variable correlation matrix. Computed across all 58 California co
 r = SUM((x_i - x_mean)(y_i - y_mean)) / sqrt(SUM((x_i - x_mean)^2) * SUM((y_i - y_mean)^2))
 ```
 
-Requires a minimum of 5 valid (non-NaN, finite) paired observations per cell. Pairs with fewer than 5 observations report r = 0.
+Requires a minimum of 5 valid (non-NaN, finite) paired observations per cell
+(`frontend/src/hooks/useCorrelationData.ts`). Cells below that threshold are
+reported as no-data rather than as a correlation.
 
-**Significance testing:** Converts r to a t-statistic: `t = r * sqrt(n-2) / sqrt(1 - r^2)`, where n = number of counties. P-value computed from the t-distribution CDF with n-2 degrees of freedom. Confidence intervals use Fisher's z-transformation: `z = arctanh(r)`, `SE(z) = 1/sqrt(n-3)`.
+**No significance testing is performed.** The matrix reports the raw
+coefficient and nothing else — no t-statistic, no p-value, no confidence
+interval. Three consequences worth stating plainly:
+
+- **A 5-observation floor is very permissive.** An r computed from 5 counties
+  is easily produced by chance and should not be read as a finding.
+- **These are ecological correlations.** Every observation is a *county*, not
+  a person. A county-level association does not imply the same association
+  holds for individuals (the ecological fallacy) and never implies causation.
+- **Many cells are examined at once.** Scanning a large matrix and reporting
+  the strongest cells will surface apparently-strong correlations from noise
+  alone. Without a multiple-comparison correction, treat a striking cell as a
+  hypothesis to investigate, not as evidence.
 
 ### 6.2 Correlation Matrix Variables (26 total)
 
@@ -568,94 +595,36 @@ The correlation matrix computes all 325 unique pairwise Pearson correlations amo
 
 ### 6.3 Multiple Testing Correction
 
-When testing significance across the full 325-cell correlation matrix, CalSight applies **Benjamini-Hochberg False Discovery Rate (FDR) correction**:
+**None is applied.** The matrix computes 325 pairwise coefficients and reports
+all of them uncorrected, because no significance testing happens in the first
+place (§6.1).
 
-1. Sort all 325 p-values in ascending order.
-2. For rank k, compute adjusted p-value: `p_adj(k) = min(1, p(k) * m / k)` where m = 325.
-3. Enforce monotonicity from the bottom up.
-4. Mark cells as significant where FDR-adjusted p < 0.05.
+This is the single largest interpretive caveat in the product. When 325 cells
+are computed and the eye is drawn to the strongest, some of those will be
+noise even if no real relationship exists anywhere. Nothing in the UI
+distinguishes a robust association from a spurious one.
 
-**Bonferroni correction** is also available for more conservative analysis: `p_corrected = min(1, p_raw * m)`.
+If inferential claims are ever wanted here, the honest ordering is: implement
+per-cell significance first, then a Benjamini-Hochberg FDR correction across
+the full matrix, then surface both in the UI — and only then describe them in
+this document.
 
-### 6.4 Chi-Squared Test of Independence
+### 6.4 Tests that are documented elsewhere but NOT implemented
 
-Tests whether categorical distributions differ between groups.
+Earlier revisions of this document described a chi-squared test of
+independence, Welch's two-sample t-test, one-way ANOVA, the Mann-Kendall trend
+test, a Kolmogorov-Smirnov two-sample test, and a supporting "mathematical
+engine" of special functions.
 
-```
-X^2 = SUM_ij [(O_ij - E_ij)^2 / E_ij]
-```
+**None of these are implemented in CalSight.** No chi-squared, t-test, ANOVA,
+trend test, or KS test runs anywhere in the product, and no p-value is
+computed or displayed on any surface.
 
-Where `E_ij = (row_i_total * col_j_total) / grand_total`. Degrees of freedom: `(rows - 1) * (cols - 1)`.
-
-**Effect size:** Cramer's V = `sqrt(X^2 / (n * min(rows-1, cols-1)))`. Interpretation: V < 0.1 negligible, 0.1-0.3 small, 0.3-0.5 medium, > 0.5 large.
-
-**Use case:** Testing whether severity distributions differ significantly between counties.
-
-### 6.5 Welch's Two-Sample t-Test
-
-Tests whether two group means differ, without assuming equal variances.
-
-```
-t = (x_bar_1 - x_bar_2) / sqrt(s_1^2/n_1 + s_2^2/n_2)
-```
-
-Degrees of freedom via Welch-Satterthwaite approximation. Effect size: Cohen's d with pooled standard deviation. 95% confidence interval for the mean difference.
-
-**Use case:** Comparing weekday vs. weekend crash counts.
-
-### 6.6 One-Way ANOVA
-
-Tests whether means differ across k groups.
-
-```
-F = MS_between / MS_within
-```
-
-Where `MS_between = SS_between / (k-1)` and `MS_within = SS_within / (N-k)`.
-
-**Effect size:** eta-squared = `SS_between / SS_total`. Interpretation: < 0.01 negligible, 0.01-0.06 small, 0.06-0.14 medium, > 0.14 large.
-
-Includes a homogeneity-of-variance check (max/min group variance ratio; warns if > 4:1).
-
-**Use case:** Testing whether crash rates differ across age groups.
-
-### 6.7 Mann-Kendall Trend Test
-
-Non-parametric test for monotonic trends in time series. Does not assume linearity or normality.
-
-1. For all pairs (i, j) where j > i, compute `sgn(x_j - x_i)`.
-2. `S = SUM(sgn values)`. Positive S suggests increasing trend; negative suggests decreasing.
-3. Variance with tied-group correction: `Var(S) = [n(n-1)(2n+5) - SUM_t t(t-1)(2t+5)] / 18`.
-4. Z-statistic with continuity correction; p-value from normal approximation (valid for n > 10).
-
-**Effect size:** Kendall's tau = `S / [n(n-1)/2]`. Range: -1 to +1.
-
-**Sen's Slope:** Median of all pairwise slopes `(x_j - x_i) / (j - i)`. Robust to outliers, unlike OLS regression.
-
-**Use case:** Testing whether fatality counts show a significant trend over years.
-
-### 6.8 Kolmogorov-Smirnov Two-Sample Test
-
-Tests whether two samples come from the same continuous distribution. Sensitive to differences in shape, spread, and location (not just mean).
-
-```
-D = max |F_1(x) - F_2(x)|
-```
-
-P-value from the Kolmogorov asymptotic distribution using the effective sample size `n_e = (n_1 * n_2) / (n_1 + n_2)`.
-
-**Use case:** Comparing crash severity distributions between two counties.
-
-### 6.9 Mathematical Engine
-
-All distribution CDFs are computed analytically:
-- **Gamma function:** Lanczos approximation (accurate to ~15 digits)
-- **Incomplete gamma (chi-squared CDF):** Series expansion for `x < a+1`, continued fraction (Lentz's method) otherwise
-- **Incomplete beta (t and F CDFs):** Continued fraction with symmetry transform
-- **Normal CDF:** Abramowitz and Stegun approximation 7.1.26 (max error 1.5e-7)
-- **Inverse normal:** Beasley-Springer-Moro rational approximation
-
----
+Those sections have been removed rather than left standing, because a reader
+checking CalSight's rigour would otherwise have credited it with inferential
+statistics it does not perform. What the product genuinely provides is
+descriptive: counts, rates, shares, year-over-year deltas, and the
+uncorrected Pearson coefficients described in §6.1.
 
 ## 7. Data Quality and Limitations
 

--- a/docs/OPERATOR_SETUP.md
+++ b/docs/OPERATOR_SETUP.md
@@ -55,10 +55,26 @@ Free tier is 10 GB; dumps are ~1 GB each, so retention drives the cost.
 4. Test: `python -m etl.backup --upload-only`
 5. **(Code task — I'll do this)** wire `upload_to_r2()` + `rotate_r2_backups()` into the scheduled `run_backup` so daily backups go offsite automatically.
 
-## 4. Public-URL uptime monitor  *(API/tunnel down detection)*
+## 4. Public-URL uptime monitor  *(DONE — `.github/workflows/uptime.yml`)*
 
-The heartbeat covers the ETL box. Add a separate monitor for the **public site/API** so you're alerted if the tunnel or backend drops:
-- healthchecks.io won't poll; use [UptimeRobot](https://uptimerobot.com) (free) or a healthchecks.io "API check" against `https://<your-domain>/api/health`. Expect HTTP 200 `{"status":"ok"}`; alert on non-200 or timeout.
+The backup heartbeat covers the ETL box; this covers the **public request
+path**. Runs every 15 min on GitHub-hosted runners (deliberately not the
+self-hosted runner on LXC 100, so the monitor survives the box going down) and
+alerts through the existing `DISCORD_WEBHOOK_URL` secret on failure only.
+
+Checks `https://api.calsight.org/api/health`, a real aggregate query
+(`/api/stats?group_by=year`, so a DB outage can't hide behind a health check
+that only proves the process is up), and `https://calsight.org`.
+
+⚠️ **Probe `api.calsight.org`, never `calsight.org/api/health`.** The apex is a
+static SPA that answers **200 with HTML** for unknown paths, so a monitor
+pointed there is a permanent false-green — it would report healthy with the
+entire API down.
+
+Limits, accepted: GitHub cron is best-effort and can lag under load, and
+Actions disables schedules after 60 days of repo inactivity. Good for catching
+multi-hour rot; not a sub-minute pager. [UptimeRobot](https://uptimerobot.com)
+(free) can layer on top if you ever want tighter intervals.
 
 ## 5. Maintenance mode  *(backend code done; see below)*
 

--- a/frontend/src/components/map/ChoroplethLegend.tsx
+++ b/frontend/src/components/map/ChoroplethLegend.tsx
@@ -230,11 +230,23 @@ export default function ChoroplethLegend({ demographicsAvailable, dataSummary = 
               Loading data…
             </div>
           ) : bucketEdges ? (
-            <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
-              {bucketEdges.map((e, i) => (
-                <span key={i}>{activeMeasure.formatLabel(e)}</span>
-              ))}
-            </div>
+            <>
+              <div className="flex justify-between text-[10px] text-on-surface-variant mt-1 font-mono">
+                {bucketEdges.map((e, i) => (
+                  <span key={i}>{activeMeasure.formatLabel(e)}</span>
+                ))}
+              </div>
+              {/* Disclose the binning method. Quantiles put an equal COUNT of
+                  counties in each colour, not an equal value range — so
+                  near-identical counties can land in different colours while
+                  the darkest band lumps together counties an order of
+                  magnitude apart. Saying so costs one line and stops the map
+                  implying differences the data doesn't support. */}
+              <p className="text-[10px] text-on-surface-variant/80 mt-1 leading-snug">
+                Quintiles — each colour holds about a fifth of counties, not an
+                equal value range.
+              </p>
+            </>
           ) : (
             <div className="text-[10px] text-on-surface-variant mt-1 italic">
               Pan or zoom out to compute scale

--- a/frontend/src/components/map/ClusterLayer.tsx
+++ b/frontend/src/components/map/ClusterLayer.tsx
@@ -34,11 +34,19 @@ function radiusFor(zScore: number): number {
 }
 
 /**
- * Plots statistically significant crash hotspots (grid density + z-score > 2σ,
- * see /api/crashes/clusters) as pulsing circle markers. Clicking a marker
- * hands the cluster's stats up to the side panel via onSelectCluster.
- * Renders nothing when the layer is toggled off. Imperative Leaflet layer
- * management mirrors TopIntersectionsLayer / HighwayDangerLayer.
+ * Plots grid cells with unusually high crash COUNTS relative to other cells
+ * (z-score > 2σ over the grid, see /api/crashes/clusters) as pulsing circle
+ * markers. Clicking a marker hands the cluster's stats up to the side panel
+ * via onSelectCluster. Renders nothing when the layer is toggled off.
+ * Imperative Leaflet layer management mirrors TopIntersectionsLayer /
+ * HighwayDangerLayer.
+ *
+ * NOT "statistically significant hotspots", which is what this used to claim.
+ * The z-score is computed against the other grid cells and carries no exposure
+ * denominator — a cell can rank high purely because more people drive through
+ * it. The underlying count distribution is also heavily overdispersed relative
+ * to Poisson, so the σ units don't carry their usual significance meaning.
+ * Treat this as a screening tool that says "look here", not a test result.
  */
 export default memo(function ClusterLayer({ onSelectCluster, selectedCluster, onSelectedClusterGone }: ClusterLayerProps) {
   const map = useMap();

--- a/frontend/src/lib/choropleth/palettes.ts
+++ b/frontend/src/lib/choropleth/palettes.ts
@@ -9,9 +9,17 @@ export type PaletteVariants = {
   dark: readonly string[];
 };
 
-// `colorblind` is an Okabe-Ito-derived diverging scale safe for
-// deuteranopia/protanopia: orange → pale → blue (light) or brightened versions
-// of the same direction for dark mode.
+// `colorblind` is a SEQUENTIAL single-hue blue ramp (ColorBrewer "Blues"),
+// safe for deuteranopia/protanopia and, because luminance rises monotonically
+// across the whole scale, for monochromacy and greyscale printing too.
+//
+// It used to be a diverging orange → pale → purple scale, which was the wrong
+// shape for this data and made the dedicated accessibility option the least
+// honest palette on the map: luminance peaked in the MIDDLE (~0.46, 0.75,
+// 0.96, 0.66, 0.28), so a near-white centre implied the median county was a
+// neutral baseline, and a low-crash county and a high-crash county both
+// rendered dark. Crash counts are sequential — one direction, low to high —
+// so the ramp has to be monotonic or it invents a meaning the data lacks.
 export const PALETTES: Record<PaletteKey, PaletteVariants> = {
   default: {
     light: ["#c7d2fe", "#818cf8", "#6366f1", "#4338ca", "#312e81"],
@@ -26,8 +34,8 @@ export const PALETTES: Record<PaletteKey, PaletteVariants> = {
     dark:  ["#134e4a", "#0f766e", "#14b8a6", "#5eead4", "#ccfbf1"],
   },
   colorblind: {
-    light: ["#e66100", "#f3b678", "#f5f5f5", "#8aaed4", "#5d3a9b"],
-    dark:  ["#ff6b00", "#ffb07a", "#e5e5e5", "#a6c1e2", "#b794f6"],
+    light: ["#eff3ff", "#bdd7e7", "#6baed6", "#3182bd", "#08519c"],
+    dark:  ["#08306b", "#2171b5", "#4292c6", "#9ecae1", "#deebf7"],
   },
 };
 


### PR DESCRIPTION
Batch one of the research backlog — public-facing correctness and honesty.

## Data bug: crashes-per-mile was ~10x wrong under a county filter
The numerator was county-scoped by the filter predicates while `miles_for()` returned the route's **full California** centerline length. I-5 scoped to San Diego read roughly 10x too low — and that value fed the map's "Per Mile" danger colouring.

`ca_highways` has no county dimension, so there's no in-county mileage to divide by. The rate now reports **unavailable (null)** rather than wrong. `miles` stays populated (a route's length is a fact about the route). Sorting by `crashes_per_mile` under a county filter falls back to crash-count order rather than returning an empty list, which would have read as "no dangerous highways in this county".

## The methodology doc was describing statistics that don't exist
§6 documented a hypothesis-testing library at `frontend/src/lib/dashboard/hypothesis.ts` — t-statistics, p-values, Fisher's-z CIs, Benjamini-Hochberg FDR — **plus six further sections** (§6.4–6.9) documenting chi-squared, Welch's t-test, ANOVA, Mann-Kendall and Kolmogorov-Smirnov tests.

**None of it exists.** The module was never written; no p-value is computed anywhere in the product. The shipped matrix is raw Pearson r gated only at n≥5.

Rewrote §6 to describe what actually runs, and to state the three caveats that follow: a 5-observation floor is very permissive, these are ecological (county-level) correlations, and 325 cells are examined with no multiple-comparison correction. For a transparency project, documenting statistics you don't perform is worse than not performing them.

## Label overclaims
- **Clusters** are no longer called "statistically significant hotspots" — the z-score has no exposure denominator and the count distribution is heavily overdispersed. It's a screening tool, not a test result.
- **"EPDO-style"** dropped from the severity weights: real cost-based EPDO puts the fatal weight near 950–1300, not 100, so the name implied an HSM compliance the 100:10:1 ratio doesn't have.
- **Choropleth legend** now discloses its method — *"quintiles — each colour holds about a fifth of counties, not an equal value range."*

## The "Colorblind Safe" palette was the least honest one
A **diverging** orange → near-white → purple ramp bolted onto **sequential** data, luminance peaking in the middle — so a near-white centre implied the median county was a neutral baseline, and both low- and high-crash counties rendered dark. Replaced with a sequential single-hue ColorBrewer Blues ramp: deuteranopia/protanopia safe, monotonic luminance, and it survives greyscale printing.

## Latent 500
`hmac.compare_digest` raises `TypeError` on non-ASCII strings (reproduced locally), so an admin/ETL key with an accent would return a 500 + stack trace instead of a clean 403. Now compares bytes at all three call sites.

## Verification
4 new integration tests pin the per-mile behaviour (null under county filter, sort falls back, statewide unaffected). 865 backend unit tests, 1029 frontend tests, ruff + tsc clean.